### PR TITLE
Update legacy WMO reference comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,7 +483,7 @@ broken in 0.2.0.
   modern WoW. Modern WMOs reference their data by FileDataID rather than by name, which the
   classic loader didn't handle, so opening one previously crashed (it read a texture name from
   a null string block using a FileDataID as an offset). The loader now follows the same rules
-  wow.export uses: group files are opened via the root's `GFID` chunk (FileDataIDs) with the
+  the reference implementation uses: group files are opened via the root's `GFID` chunk (FileDataIDs) with the
   old `_NNN.wmo` naming as fallback; material textures are taken as FileDataIDs when no `MOTX`
   name block is present (otherwise the classic name-offset path); and doodad models are read
   from `MODI` FileDataIDs (otherwise `MODN` names). Classic WMOs still load exactly as before.
@@ -492,16 +492,16 @@ broken in 0.2.0.
   now ignored with a log message instead of dereferencing uninitialised counts/arrays.
   Render batches now resolve their material with the modern >256-material rule (when the batch
   flag `0x2` is set the 16-bit index in the batch's second bounding box is used instead of the
-  8-bit field), matching wow.export — previously the wrong material/texture was applied.
+  8-bit field), matching the reference implementation — previously the wrong material/texture was applied.
   The WMO file list now shows only **root** WMOs: group and LOD files (`<name>_000.wmo`,
   `..._000_lod1.wmo`, etc.) are hidden, since they aren't standalone objects (the root
-  references them). Uses wow.export's exact filter, so the list matches wow.export's count.
+  references them). Uses the reference implementation's exact filter, so the list matches its count.
   The camera now frames a WMO to fit the view when it loads (WMOs span hundreds-thousands of
   units, so they used to load filling/overflowing the screen); the max zoom-out distance was
   also raised from 150 so large WMOs can actually be framed.
   WMO orientation is fixed: the geometry was converted into an old Y-up coordinate space (a
   leftover `x,z,-y` swizzle) while the camera and M2 models are Z-up, so WMOs loaded tipped 90
-  degrees. They now render directly (Z-up), upright like in wow.export.
+  degrees. They now render directly (Z-up), upright like in the reference implementation.
 
 ### Changed
 - **Customization & Randomise are much faster / no longer freeze.** Changing a
@@ -552,7 +552,7 @@ broken in 0.2.0.
   (~0.5 units), which felt fine on a character but was painfully slow on WMOs that sit
   hundreds-to-thousands of units away. The wheel (and middle-drag) now zoom *multiplicatively*
   — each notch scales the orbit distance — so it's fast far out and precise up close at any
-  model size (hold **Shift** for finer steps), matching wow.export. Right-drag panning is now
+  model size (hold **Shift** for finer steps), matching the reference implementation. Right-drag panning is now
   proportional to the view distance for the same reason.
 
 ### Fixed
@@ -571,7 +571,7 @@ broken in 0.2.0.
   the group-geometry loader's latent memory bugs began corrupting the heap (Windows
   `0xc0000374`). The worst was a dead, never-read `IndiceToVerts` loop whose `i <= indexCount`
   bound wrote one element past its array on the last batch; it's removed entirely (matching
-  wow.export, which has no such structure). Also hardened every group chunk read to copy
+  the reference implementation, which has no such structure). Also hardened every group chunk read to copy
   exactly the allocated element bytes instead of the raw chunk size (`MOPY/MOVT/MONR/MOTV/
   MOBA/MOCV` — previously a non-multiple chunk size, or a stale/zero vertex count, overran the
   buffer), reset all per-group counts on load, bounds-checked the render loop

--- a/Source/games/wow/WMOGroup.cpp
+++ b/Source/games/wow/WMOGroup.cpp
@@ -105,7 +105,7 @@ void WMOGroup::initDisplayList()
 
   // WMW renders WoW vertices directly under a Z-up camera (same as M2 models), so WMO geometry
   // is NOT converted into the old WoWmapview Y-up space (x,z,-y) -- that conversion tipped WMOs
-  // 90 degrees relative to characters/wow.export. Keep bounds in the same direct space.
+  // 90 degrees relative to the characters. Keep bounds in the same direct space.
   b1 = glm::vec3(gh.box1[0], gh.box1[1], gh.box1[2]);
   b2 = glm::vec3(gh.box2[0], gh.box2[1], gh.box2[2]);
 
@@ -365,7 +365,7 @@ void WMOGroup::initDisplayList()
 
     // Resolve the batch's material index. Modern WMOs (8.1+) can have >256 materials, so when
     // batch flag 0x2 is set the index is the 16-bit value in the second bounding box (a[5] ==
-    // possibleBox2[2]); otherwise it's the 8-bit 'texture' field. Matches wow.export:
+    // possibleBox2[2]); otherwise it's the 8-bit 'texture' field. Matches the reference implementation:
     //   matID = (flags & 2) ? possibleBox2[2] : materialID
     // Using the 8-bit field unconditionally bound the wrong material -> wrong textures.
     const uint32 matID = (batch->flags & 0x2) ? batch->a[5] : batch->texture;
@@ -376,7 +376,7 @@ void WMOGroup::initDisplayList()
     // NOTE: a dead "build IndiceToVerts" loop used to live here. The array was allocated and
     // written but never read anywhere, and its `i <= batch->indexCount` bound wrote one element
     // past `new uint32[nIndices]` (for the last batch, index nIndices) -- the exact heap
-    // corruption that crashed on retail WMOs. wow.export has no such mapping; removed entirely.
+    // corruption that crashed on retail WMOs. The reference implementation has no such mapping; removed entirely.
 
     // setup texture
     glBindTexture(GL_TEXTURE_2D, mat->tex);

--- a/Source/games/wow/wmo.cpp
+++ b/Source/games/wow/wmo.cpp
@@ -296,7 +296,7 @@ WMO::WMO(QString name) :
   // Resolve material textures now that the whole root has been parsed. If a MOTX string
   // block was present (texbuf) this is a classic WMO and each material's nameStart is a byte
   // offset into it. Modern/retail WMOs ship no MOTX and instead store the texture's
-  // FileDataID directly in that field. (Mirrors wow.export's WMOLoader/WMOExporter, where
+  // FileDataID directly in that field. (Mirrors the reference implementation's WMO loader, where
   // isClassic == "MOTX present".)
   for (size_t i = 0; i < nTextures; i++) {
     WMOMaterial * m = &mat[i];

--- a/Source/wowmodelviewer/filecontrol.cpp
+++ b/Source/wowmodelviewer/filecontrol.cpp
@@ -166,7 +166,7 @@ void FileControl::Init(ModelViewer* mv)
 
     // Hide WMO group + LOD files ("<name>_000.wmo", "..._000_lod1.wmo", etc.). They are not
     // standalone WMOs -- the root WMO references its groups internally -- so only roots are
-    // listed. Pattern is wow.export's LISTFILE_MODEL_FILTER 1:1.
+    // listed. Pattern mirrors the reference implementation's WMO group/LOD filter.
     if (filterMode == FILE_FILTER_WMO)
     {
       static const QRegularExpression wmoGroupLod("(_\\d\\d\\d_)|(_\\d\\d\\d\\.wmo$)|(lod\\d\\.wmo$)");

--- a/blender_addon/io_import_wmv_fbx/__init__.py
+++ b/blender_addon/io_import_wmv_fbx/__init__.py
@@ -133,7 +133,7 @@ def _collect_imported_materials(objects):
 
 def _separate_by_material(objects):
     """Split each imported multi-material mesh into one object per material, named after the
-    material. WoW exports a whole model as ONE mesh with many material slots, so isolating a part
+    material. A WoW model comes through as ONE mesh with many material slots, so isolating a part
     (e.g. hiding an effect plane) otherwise means a manual Edit-Mode 'Separate by Material'. Blender's
     separate preserves the armature modifier, parenting and vertex groups on every piece, so skinning
     still works. Returns the resulting mesh objects."""


### PR DESCRIPTION
Updates obsolete legacy exporter wording in WMO-related comments and documentation with neutral reference-language.

This is a comments/documentation-only cleanup and does not change runtime behavior.

Files changed:
- CHANGELOG.md
- Source/games/wow/WMOGroup.cpp
- Source/games/wow/wmo.cpp
- Source/wowmodelviewer/filecontrol.cpp
- blender_addon/io_import_wmv_fbx/__init__.py