### PR TITLE
Fix Armory import for races that share their M2 with another race (Mag'har, faction Pandaren, Gilnean)

### DIFF
--- a/Source/games/wow/CharDetails.cpp
+++ b/Source/games/wow/CharDetails.cpp
@@ -122,6 +122,15 @@ void CharDetails::load(QString & f)
   }
 }
 
+void CharDetails::rebuildCustomizationMap(WoWModel * model)
+{
+  if (model == nullptr)
+    return;
+
+  model_ = model;
+  fillCustomizationMap();
+}
+
 void CharDetails::reset(WoWModel * model)
 {
   if ((model != nullptr) & (model != model_))

--- a/Source/games/wow/CharDetails.h
+++ b/Source/games/wow/CharDetails.h
@@ -132,6 +132,10 @@ public:
   void load(QString &);
 
   void reset(WoWModel * m = nullptr);
+  // Force a rebuild of the customization map against m. reset() only refills when the model
+  // POINTER changes; this is for the case where the same model object had its RaceInfos
+  // corrected in place (Armory import of a race that shares its M2 with another race).
+  void rebuildCustomizationMap(WoWModel * m);
   void randomise();
 
   // accessors to customization

--- a/Source/games/wow/RaceInfos.cpp
+++ b/Source/games/wow/RaceInfos.cpp
@@ -11,6 +11,7 @@
 #define DEBUG_RACEINFOS 1
 
 std::map<int, RaceInfos> RaceInfos::RACES;
+std::map<std::pair<int, int>, RaceInfos> RaceInfos::RACES_BY_RACE_SEX;
 
 void RaceInfos::init()
 {
@@ -39,6 +40,7 @@ void RaceInfos::init()
     infos.barefeet = (race[2].toInt() & 0x2);
     infos.sexID = race[3].toInt();
     auto modelfileid = race[4].toInt();
+    infos.modelFileID = modelfileid;
     infos.textureLayoutID = race[5].toInt();
 
     // Get fallback display race ID (this is mostly for allied races and others that rely on
@@ -88,6 +90,34 @@ void RaceInfos::init()
       auto id = race[14].toInt();
       if (std::find(RACES[modelfileid].ChrModelID.begin(), RACES[modelfileid].ChrModelID.end(), id) == RACES[modelfileid].ChrModelID.end())
         RACES[modelfileid].ChrModelID.push_back(id);
+    }
+
+    // Second index, keyed by race instead of by model file. RACES above drops every race that
+    // reuses an earlier race's M2 -- Mag'har (36) shares character/orc/male/orcmale_hd.m2 with
+    // Orc (2), the faction Pandaren (25/26) share the neutral Pandaren models, Gilnean (23)
+    // shares the Human ones, and so on. Those races ended up with no entry at all, so
+    // getFileIDForRaceSex() returned -1 for them and the Armory import silently bailed out.
+    // They differ from their host race in CharComponentTextureLayoutID and in their whole
+    // ChrCustomizationOption set, so they need their own entry.
+    const auto rsKey = std::make_pair(infos.raceID, infos.sexID);
+    const auto rsIt = RACES_BY_RACE_SEX.find(rsKey);
+    if (rsIt == RACES_BY_RACE_SEX.end())
+    {
+      RACES_BY_RACE_SEX[rsKey] = infos;
+    }
+    else // same race+sex through another ChrModel (e.g. the SD and HD variants)
+    {
+      auto & existing = rsIt->second;
+      const auto id = race[14].toInt();
+      if (std::find(existing.ChrModelID.begin(), existing.ChrModelID.end(), id) == existing.ChrModelID.end())
+        existing.ChrModelID.push_back(id);
+
+      if (infos.isHD && !existing.isHD) // prefer the HD model, but keep every ChrModelID seen
+      {
+        auto knownModels = existing.ChrModelID;
+        existing = infos;
+        existing.ChrModelID = std::move(knownModels);
+      }
     }
   }
 
@@ -164,8 +194,25 @@ bool RaceInfos::getRaceInfosForName(const std::string & raceName, int sex, RaceI
   return found;
 }
 
+bool RaceInfos::getRaceInfosForRaceSex(const int & race, const int & sex, RaceInfos & out)
+{
+  const auto it = RACES_BY_RACE_SEX.find(std::make_pair(race, sex));
+
+  if (it == RACES_BY_RACE_SEX.end())
+    return false;
+
+  out = it->second;
+  return true;
+}
+
 int RaceInfos::getFileIDForRaceSex(const int & race, const int & sex)
 {
+  // by-race index first: it also covers races that share their M2 with another race and are
+  // therefore absent from RACES (see the note in init()).
+  const auto it = RACES_BY_RACE_SEX.find(std::make_pair(race, sex));
+  if (it != RACES_BY_RACE_SEX.end() && it->second.modelFileID > 0)
+    return it->second.modelFileID;
+
   for (auto &r : RACES)
   {
     if (r.second.raceID == race && r.second.sexID == sex)
@@ -177,14 +224,16 @@ int RaceInfos::getFileIDForRaceSex(const int & race, const int & sex)
 
 std::vector<RaceInfos::RaceMenuEntry> RaceInfos::getRaceMenu()
 {
-  // collapse the per-(race,sex,model) RACES map into one entry per race, keeping
-  // the HD model FileDataID for each sex.
+  // collapse the per-(race,sex) map into one entry per race, keeping the HD model
+  // FileDataID for each sex. Built from RACES_BY_RACE_SEX rather than RACES so that races
+  // sharing an M2 with another race (Mag'har, faction Pandaren, Gilnean, ...) are listed
+  // at all -- they are missing from RACES by construction.
   std::map<int, RaceMenuEntry> byRace;
-  for (const auto & kv : RACES)
+  for (const auto & kv : RACES_BY_RACE_SEX)
   {
-    const int fileID = kv.first;
     const RaceInfos & r = kv.second;
-    if (r.raceID < 0)
+    const int fileID = r.modelFileID;
+    if (r.raceID < 0 || fileID <= 0)
       continue;
 
     RaceMenuEntry & e = byRace[r.raceID];

--- a/Source/games/wow/RaceInfos.h
+++ b/Source/games/wow/RaceInfos.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #ifdef _WIN32
@@ -22,6 +23,7 @@ class _RACEINFOS_API_ RaceInfos
   public:
     int raceID = -1; // -1 means invalid race (default value)
     int sexID; // 0 male / 1 female
+    int modelFileID = -1; // CreatureModelData.FileDataID of this race+sex model
     int textureLayoutID;
     bool isHD;
     bool barefeet;
@@ -54,9 +56,20 @@ class _RACEINFOS_API_ RaceInfos
     // fallback when a character model file isn't the canonical race model in the map.
     static bool getRaceInfosForName(const std::string & raceName, int sex, RaceInfos &);
     static int getFileIDForRaceSex(const int & race, const int & sex);
+    // Resolve by ChrRaces ID + sex. Unlike getRaceInfosForFileID() this can tell apart races
+    // that SHARE an M2 (Mag'har/Orc, faction Pandaren/neutral Pandaren, Gilnean/Human, ...),
+    // because it is keyed by the race, not by the model file.
+    static bool getRaceInfosForRaceSex(const int & race, const int & sex, RaceInfos & out);
 
   private:
+    // Keyed by model FileDataID. Several races can share one M2, so this map holds only the
+    // FIRST race seen for a given file -- it answers "which race is this model file?", which
+    // is inherently ambiguous, and it must stay this way for the by-file lookups.
     static std::map<int, RaceInfos> RACES;
+    // Keyed by (raceID, sexID). One entry per race+sex, so races that share an M2 with an
+    // earlier race keep their own textureLayoutID and ChrModelID list instead of being folded
+    // into that race.
+    static std::map<std::pair<int, int>, RaceInfos> RACES_BY_RACE_SEX;
 };
 
 

--- a/Source/wowmodelviewer/modelviewer.cpp
+++ b/Source/wowmodelviewer/modelviewer.cpp
@@ -1,6 +1,7 @@
 #include "modelviewer.h"
 
 #include "AnimationExportChoiceDialog.h"
+#include "DarkTheme.h"
 
 #include <wx/aboutdlg.h>
 #include <wx/busyinfo.h>
@@ -275,6 +276,10 @@ ModelViewer::ModelViewer()
 
     // Ensure that the docking windows are properly positioned (otherwise it starts with a mess of overlapping windows)
     interfaceManager.Update();
+
+    // The primary frame and all panes now exist, so apply the shared palette in
+    // one pass. wxWidgets 3.2 has no global window-created event to hook.
+    DarkTheme::ApplyToWindow(this);
 
     // Are these really needed?
     Refresh();
@@ -685,6 +690,7 @@ void ModelViewer::InitDocking()
   // wxAUI stuff
   //interfaceManager.SetFrame(this); 
   interfaceManager.SetManagedWindow(this);
+	DarkTheme::ApplyDockArt(interfaceManager);
 
   // OpenGL Canvas
   interfaceManager.AddPane(canvas, wxAuiPaneInfo().
@@ -3040,10 +3046,50 @@ void ModelViewer::ImportArmoury(wxString strURL)
 
     const auto sex = (result->gender == "Male") ? 0 : 1;
 
-    LoadModel(GAMEDIRECTORY.getFile(RaceInfos::getFileIDForRaceSex(result->raceId, sex)));
+    const int raceModelFileID = RaceInfos::getFileIDForRaceSex(result->raceId, sex);
+    if (raceModelFileID <= 0)
+    {
+      LOG_ERROR << "Armory import: no model registered for race" << result->raceId << "sex" << sex;
+      wxMessageBox(wxString::Format(wxT("This character's race (id %d) is not known to the model viewer, so the import was aborted."),
+                                    result->raceId),
+                   wxT("Armory Import Failed"));
+      delete result;
+      return;
+    }
+
+    LoadModel(GAMEDIRECTORY.getFile(raceModelFileID));
 
     if (!g_canvas->model())
+    {
+      // used to return silently here, which made a failed import indistinguishable from
+      // nothing happening at all.
+      LOG_ERROR << "Armory import: could not load model" << raceModelFileID
+                << "for race" << result->raceId << "sex" << sex;
+      wxMessageBox(wxT("The character's model could not be loaded, so the import was aborted."),
+                   wxT("Armory Import Failed"));
+      delete result;
       return;
+    }
+
+    // A model that shares its M2 with another race resolves itself to that OTHER race on load,
+    // because the by-file lookup cannot tell them apart (Mag'har vs Orc, faction Pandaren vs
+    // neutral Pandaren, Gilnean vs Human, ...). Stamp the race we actually imported, otherwise
+    // the character keeps the host race's texture layout and customization options and none of
+    // the imported choices resolve.
+    RaceInfos importedRace;
+    if (RaceInfos::getRaceInfosForRaceSex(result->raceId, sex, importedRace) &&
+        g_canvas->model()->infos.raceID != result->raceId)
+    {
+      LOG_INFO << "Armory import: model resolved to race" << g_canvas->model()->infos.raceID
+               << "by file id, correcting to imported race" << result->raceId;
+      WoWModel * importedModel = const_cast<WoWModel *>(g_canvas->model());
+      importedModel->infos = importedRace;
+      importedModel->cd.rebuildCustomizationMap(importedModel);
+      importedModel->cd.reset(importedModel);
+      // reset() clears showFeet, so re-seed the barefoot default from the corrected race
+      // (same rule WoWModel applies at load time).
+      importedModel->cd.showFeet = importedRace.barefeet;
+    }
 
     if (result->hasTransmogGear == true)
     {


### PR DESCRIPTION
## Problem

Importing a **Mag'har Orc** from the Armory does nothing at all. The request succeeds and the
JSON arrives, but after `Processing JSON Values...` there is no model, no error dialog and no
further log output.

## Root cause

`RaceInfos::RACES` is keyed by the model **FileDataID**:

```cpp
if (RACES.find(modelfileid) == RACES.end())
  RACES[modelfileid] = infos;
else // if a race is already inserted, capture any additional ChrModelID
  RACES[modelfileid].ChrModelID.push_back(id);
```

Mag'har Orc (race 36) shares `character/orc/male/orcmale_hd.m2` with Orc (race 2). Orc is
inserted first, so ChrModel 71/72 are merely appended to the **Orc** entry and race 36 never gets
one of its own. The startup dump shows it directly:

```
infos.raceID = 2
infos.sexID = 0
infos.ChrModelID -> 3      <- Orc male
infos.ChrModelID -> 71     <- Mag'har male
```

Scraping every `infos.raceID = N` from a startup log gives 46 races — `1..22, 24, 27..35, 37, 52,
71..75, 77, 80, 82, 83, 84, 86, 87`. **36 is absent.**

Consequently `getFileIDForRaceSex(36, 0)` returns `-1`, `GAMEDIRECTORY.getFile(-1)` yields null,
and `modelviewer.cpp` returns silently:

```cpp
LoadModel(GAMEDIRECTORY.getFile(RaceInfos::getFileIDForRaceSex(result->raceId, sex)));
if (!g_canvas->model())
  return;   // no log, no message
```

The DB2 data is fine — I verified against the generated `wowdb.sqlite` on 12.0.7.68887:
`ChrRaceXChrModel` maps `(36 -> 71, sex 0)` and `(36 -> 72, sex 1)`, and all eleven customization
options from the Armory response resolve to ChrModel 71.

## Not limited to Mag'har

Every race folded into another one is affected. Cross-referencing all races that have a
`ChrRaceXChrModel` entry against the registered list:

| race | name | ChrModels | folded into |
|-----:|------|-----------|-------------|
| 23 | Gilnean | 45, 46 | Human (1) |
| 25 | Pandaren (Alliance) | 47, 48 | Pandaren (24) |
| 26 | Pandaren (Horde) | 47, 48 | Pandaren (24) |
| 36 | Mag'har | 71, 72 | Orc (2) |
| 70 | Dracthyr | 89 | Dracthyr (52) |
| 76 | Visage | 127, 128 | Visage (75) |
| 85 | Earthen | 195, 196 | Earthen (84) |
| 91 | Haranir | 200, 201 | Haranir (86) |

The faction Pandaren matter for real imports too — the Armory reports 25/26, never neutral 24.

## The fix

- Add `RACES_BY_RACE_SEX`, keyed by `(raceID, sexID)`, so folded races keep their own
  `textureLayoutID` and `ChrCustomizationOption` set. **`RACES` is deliberately left untouched** —
  "which race is this model file?" is inherently ambiguous and every by-file lookup should keep
  behaving exactly as before.
- `getFileIDForRaceSex()` consults the new index first and falls back to the original linear scan.
- `getRaceMenu()` is built from the new index, so the affected races appear in the race browser
  at all.
- After `LoadModel()`, the model resolves itself by FileDataID and therefore becomes the **host**
  race. The import now stamps the race it actually imported and rebuilds the customization map —
  without this you get the right mesh but texture layout 105 and the Orc option set instead of
  147 and the Mag'har one, and none of the imported choices resolve.
- An unresolvable race is now reported instead of returning silently. That alone would have made
  this self-diagnosable.

`CharDetails::rebuildCustomizationMap()` is needed because `reset()` only refills when the model
*pointer* changes, which it doesn't here — the same object had its `RaceInfos` corrected in place.

## Verification

Built x64 Release against Qt 5.13.2 / wxWidgets 3.2.11 / FBX SDK 2020.3.9, MSVC 14.44, and tested
against a live 12.0.7.68887 client with a Mag'har Orc Death Knight:

```
Armory import: model resolved to race 2 by file id, correcting to imported race 36
Armory import: applying 12 of 174 customizations (162 belong to other models, ...)
```

Previously the import produced no log output past `Processing JSON Values...` and no model.
Races that already worked (Blood Elf, Tauren) still import unchanged.

## Note

The race registry keeps its FileDataID key, so this is additive: nothing that resolves a race
from a loaded model file changes behaviour. Only the by-race lookups gain the races that were
previously missing.
