### PR TITLE
Add embedded Unity renderer foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Embedded Unity renderer viewport — View → Unity Renderer (first step of the new renderer).**
+  The viewer can now host a separately built Unity standalone player inside a dockable pane.
+  This is the foundation of WMV's **new rendering pipeline**: long term the Unity viewport
+  becomes the primary viewport and future rendering features (characters, equipment, maps, fog,
+  OBS scenes, stream features) target it first, while the classic OpenGL viewport is kept as the
+  legacy/fallback renderer during the migration. Unity renders directly from WoW data -- it
+  requests raw assets/metadata from the app over IPC (no OBJ/FBX/GLB export step); the app
+  remains responsible for the UI, the active client/profile, CASC/MPQ access,
+  databases/metadata and runtime commands. The player is launched embedded (parent-window mode),
+  resizes with its pane and is shut down with the app. **For now it is optional:** nothing in the
+  normal build depends on Unity, and if no player build is found (default location
+  `tools\unity-renderer\UnityRenderer.exe` next to the exe, or the `Tools/UnityRendererPath`
+  setting) a clear message is shown and the app carries on with the OpenGL viewport. The player
+  project sources and a Unity-free test stub live in `Tools/UnityRendererProject/`; the direction
+  and migration roadmap are in `docs/unity-renderer/`.
 - **Legacy WotLK creatures and items now show their real, database-driven textures.** For a loaded
   WotLK 3.3.5 (MPQ) client, the viewer now reads the classic `.dbc` databases
   (`CreatureModelData`, `CreatureDisplayInfo`, `ItemDisplayInfo`) to resolve the skins and item

--- a/Source/wowmodelviewer/CMakeLists.txt
+++ b/Source/wowmodelviewer/CMakeLists.txt
@@ -44,6 +44,7 @@ set(src  AnimationExportChoiceDialog.cpp
          Quantize.cpp
          SettingsControl.cpp
          shaders.cpp
+         UnityRendererHost.cpp
          UserSkins.cpp
          util.cpp)
 
@@ -85,6 +86,7 @@ set(headers AnimationExportChoiceDialog.h
             resource1.h
             SettingsControl.h
             shaders.h
+            UnityRendererHost.h
             UserSkins.h
             util.h)
 

--- a/Source/wowmodelviewer/UnityRendererHost.cpp
+++ b/Source/wowmodelviewer/UnityRendererHost.cpp
@@ -1,0 +1,248 @@
+/*
+ * UnityRendererHost.cpp
+ */
+
+#include "UnityRendererHost.h"
+
+#include <wx/filename.h>
+#include <wx/stdpaths.h>
+
+#include "enums.h"
+#include "util.h"
+
+#include "logger/Logger.h"
+
+IMPLEMENT_CLASS(UnityRendererHost, wxPanel)
+
+BEGIN_EVENT_TABLE(UnityRendererHost, wxPanel)
+  EVT_SIZE(UnityRendererHost::OnSize)
+  EVT_SET_FOCUS(UnityRendererHost::OnSetFocus)
+END_EVENT_TABLE()
+
+UnityRendererHost::UnityRendererHost(wxWindow * parent, wxWindowID id)
+{
+  // A plain panel: the player reparents its own window into this one and paints it
+  // entirely, so no wx-side drawing is needed. Black background = unobtrusive while
+  // the player is still starting up (or after it exited).
+  Create(parent, id, wxDefaultPosition, wxSize(640, 480), wxNO_BORDER | wxCLIP_CHILDREN, wxT("UnityRendererHost"));
+  SetBackgroundColour(*wxBLACK);
+}
+
+UnityRendererHost::~UnityRendererHost()
+{
+  shutdown();
+}
+
+wxString UnityRendererHost::resolveUnityExePath()
+{
+  if (!unityRendererPath.IsEmpty())
+    return unityRendererPath;
+
+  // Default: tools\unity-renderer\UnityRenderer.exe next to the WMV executable.
+  wxFileName exeFn(wxStandardPaths::Get().GetExecutablePath());
+  return exeFn.GetPath(wxPATH_GET_VOLUME) + SLASH + wxT("tools") + SLASH +
+         wxT("unity-renderer") + SLASH + wxT("UnityRenderer.exe");
+}
+
+#ifdef _WINDOWS
+
+namespace
+{
+  struct FindChildData
+  {
+    DWORD processId;
+    HWND found;
+  };
+
+  BOOL CALLBACK findChildByProcessId(HWND child, LPARAM lparam)
+  {
+    FindChildData * data = reinterpret_cast<FindChildData *>(lparam);
+    DWORD pid = 0;
+    GetWindowThreadProcessId(child, &pid);
+    if (pid == data->processId)
+    {
+      data->found = child;
+      return FALSE; // stop enumerating
+    }
+    return TRUE;
+  }
+}
+
+bool UnityRendererHost::launch()
+{
+  if (isRunning())
+    return true;
+
+  const wxString exePath = resolveUnityExePath();
+  if (!wxFileName::FileExists(exePath))
+  {
+    LOG_ERROR << "Unity renderer player not found:" << QString::fromWCharArray(exePath.c_str());
+    wxMessageBox(wxString::Format(
+                   _("No Unity renderer build was found at:\n\n%s\n\n"
+                     "The Unity viewport is optional -- the rest of the application is unaffected.\n\n"
+                     "To use it, build the player from Tools\\UnityRendererProject to that location, "
+                     "or point \"Tools/UnityRendererPath\" in userSettings\\Config.ini at your build."),
+                   exePath.c_str()),
+                 _("Unity Renderer not found"), wxOK | wxICON_INFORMATION, this);
+    return false;
+  }
+
+  // The player's documented embedding contract: "-parentHWND <hwnd> delayed" makes it
+  // create its window as a child of ours. The HWND is passed in decimal. A log file in
+  // userSettings keeps player output next to WMV's own log.
+  wxFileName exeFn(wxStandardPaths::Get().GetExecutablePath());
+  const wxString logPath = exeFn.GetPath(wxPATH_GET_VOLUME) + SLASH + wxT("userSettings") + SLASH + wxT("unityRenderer.log");
+  wxString cmdLine = wxString::Format(wxT("\"%s\" -parentHWND %llu delayed -logFile \"%s\""),
+                                      exePath.c_str(),
+                                      (unsigned long long)(uintptr_t)GetHandle(),
+                                      logPath.c_str());
+
+  STARTUPINFOW si;
+  ZeroMemory(&si, sizeof(si));
+  si.cb = sizeof(si);
+  PROCESS_INFORMATION pi;
+  ZeroMemory(&pi, sizeof(pi));
+
+  // CreateProcess may modify the command-line buffer -> writable copy.
+  std::wstring cmdBuf(cmdLine.c_str());
+  const std::wstring workDir(wxFileName(exePath).GetPath(wxPATH_GET_VOLUME).c_str());
+
+  if (!CreateProcessW(nullptr, &cmdBuf[0], nullptr, nullptr, FALSE, 0, nullptr,
+                      workDir.empty() ? nullptr : workDir.c_str(), &si, &pi))
+  {
+    const DWORD err = GetLastError();
+    LOG_ERROR << "Failed to start Unity renderer player (error" << (int)err << "):"
+              << QString::fromWCharArray(exePath.c_str());
+    wxMessageBox(wxString::Format(_("Failed to start the Unity renderer player (error %lu):\n\n%s"),
+                                  (unsigned long)err, exePath.c_str()),
+                 _("Unity Renderer"), wxOK | wxICON_ERROR, this);
+    return false;
+  }
+
+  CloseHandle(pi.hThread);
+  m_process = pi.hProcess;
+  m_processId = pi.dwProcessId;
+  m_embeddedWnd = nullptr;
+
+  LOG_INFO << "Unity renderer player started (pid" << (int)m_processId << "):"
+           << QString::fromWCharArray(exePath.c_str());
+  return true;
+}
+
+bool UnityRendererHost::isRunning()
+{
+  if (!m_process)
+    return false;
+  if (WaitForSingleObject(m_process, 0) == WAIT_TIMEOUT)
+    return true;
+
+  // Player exited on its own (or crashed): reap the handle so launch() can start a new one.
+  LOG_INFO << "Unity renderer player (pid" << (int)m_processId << ") has exited.";
+  CloseHandle(m_process);
+  m_process = nullptr;
+  m_processId = 0;
+  m_embeddedWnd = nullptr;
+  return false;
+}
+
+void UnityRendererHost::shutdown()
+{
+  if (!m_process)
+    return;
+
+  // Polite first: the embedding contract is to send the player's window WM_CLOSE.
+  if (HWND wnd = findEmbeddedWindow())
+    PostMessage(wnd, WM_CLOSE, 0, 0);
+
+  // Wait for the exit while STILL PUMPING messages: destroying a window that is parented
+  // into our panel makes the player's process send this thread messages synchronously
+  // (WM_PARENTNOTIFY etc.); a plain blocking wait would stall the player's DestroyWindow
+  // until the timeout fired and needlessly hard-terminate it every time.
+  const DWORD start = GetTickCount();
+  bool exited = false;
+  for (;;)
+  {
+    const DWORD elapsed = GetTickCount() - start;
+    if (elapsed >= 3000)
+      break;
+    const DWORD wait = MsgWaitForMultipleObjects(1, &m_process, FALSE, 3000 - elapsed, QS_ALLINPUT);
+    if (wait == WAIT_OBJECT_0) { exited = true; break; }
+    if (wait != WAIT_OBJECT_0 + 1)
+      break; // timeout/failure
+    MSG msg;
+    while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
+    {
+      TranslateMessage(&msg);
+      DispatchMessage(&msg);
+    }
+  }
+
+  if (!exited)
+  {
+    LOG_INFO << "Unity renderer player did not close in time -- terminating (pid" << (int)m_processId << ")";
+    TerminateProcess(m_process, 0);
+    WaitForSingleObject(m_process, 1000);
+  }
+
+  CloseHandle(m_process);
+  m_process = nullptr;
+  m_processId = 0;
+  m_embeddedWnd = nullptr;
+}
+
+HWND UnityRendererHost::findEmbeddedWindow()
+{
+  if (m_embeddedWnd && IsWindow(m_embeddedWnd))
+    return m_embeddedWnd;
+  m_embeddedWnd = nullptr;
+
+  if (!m_process)
+    return nullptr;
+
+  FindChildData data = { m_processId, nullptr };
+  EnumChildWindows((HWND)GetHandle(), findChildByProcessId, reinterpret_cast<LPARAM>(&data));
+  m_embeddedWnd = data.found;
+  return m_embeddedWnd;
+}
+
+void UnityRendererHost::resizeEmbeddedWindow()
+{
+  if (!isRunning())
+    return;
+  if (HWND wnd = findEmbeddedWindow())
+  {
+    const wxSize size = GetClientSize();
+    MoveWindow(wnd, 0, 0, size.GetWidth(), size.GetHeight(), TRUE);
+  }
+}
+
+void UnityRendererHost::OnSetFocus(wxFocusEvent & event)
+{
+  // Hand keyboard focus straight to the embedded player so its input works when the
+  // pane is clicked/activated.
+  if (HWND wnd = findEmbeddedWindow())
+    ::SetFocus(wnd);
+  event.Skip();
+}
+
+#else // !_WINDOWS
+
+bool UnityRendererHost::launch()
+{
+  wxMessageBox(_("The embedded Unity renderer is only supported on Windows."),
+               _("Unity Renderer"), wxOK | wxICON_INFORMATION, this);
+  return false;
+}
+
+bool UnityRendererHost::isRunning() { return false; }
+void UnityRendererHost::shutdown() {}
+void UnityRendererHost::resizeEmbeddedWindow() {}
+void UnityRendererHost::OnSetFocus(wxFocusEvent & event) { event.Skip(); }
+
+#endif // _WINDOWS
+
+void UnityRendererHost::OnSize(wxSizeEvent & event)
+{
+  resizeEmbeddedWindow();
+  event.Skip();
+}

--- a/Source/wowmodelviewer/UnityRendererHost.h
+++ b/Source/wowmodelviewer/UnityRendererHost.h
@@ -1,0 +1,86 @@
+/*
+ * UnityRendererHost.h
+ *
+ * Embedded Unity renderer viewport -- the NEW RENDERER FOUNDATION for WMV. Direction: the
+ * embedded Unity player is to become the baseline / primary rendering viewport; the existing
+ * OpenGL ModelCanvas is kept as the LEGACY / FALLBACK renderer during the migration and gets
+ * maintenance only. Future rendering work (characters, equipment, maps, fog, OBS scenes,
+ * stream features) targets Unity first. Unity renders DIRECTLY FROM WOW DATA: it requests raw
+ * assets and metadata from WMV over IPC (asset-access / runtime APIs) -- there is no
+ * OBJ/FBX/GLB export step. WMV provides the app UI, the active client/profile, CASC/MPQ
+ * access, DB/metadata and the runtime commands; Unity provides the modern rendering
+ * pipeline. See docs/unity-renderer/README.md.
+ *
+ * Mechanics: hosts a SEPARATELY BUILT Unity standalone player inside a plain wxPanel by
+ * launching it with the player's documented embedding arguments ("-parentHWND <hwnd>
+ * delayed"): the player reparents itself into this panel's native window and renders there
+ * with its own graphics device, in its own process. Because it is out-of-process and draws
+ * into ITS OWN child window, the legacy OpenGL viewport is untouched -- the app's single WGL
+ * context stays bound to the ModelCanvas HWND and nothing here calls into GL at all.
+ *
+ * Current migration stage (V0): the player build is OPTIONAL at build and run time and never
+ * part of the WMV build -- if the exe is absent, launch() shows a clear message and the app
+ * (and the legacy viewport) continue normally. The exe location is the
+ * "Tools/UnityRendererPath" setting when set, else tools\unity-renderer\UnityRenderer.exe
+ * next to the WMV executable. See Tools/UnityRendererProject/ for the player project.
+ */
+
+#ifndef UNITYRENDERERHOST_H
+#define UNITYRENDERERHOST_H
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+    #include <wx/wx.h>
+#endif
+
+#ifdef _WINDOWS
+#include <windows.h>
+#include <wx/msw/winundef.h>
+#endif
+
+class UnityRendererHost : public wxPanel
+{
+    DECLARE_CLASS(UnityRendererHost)
+    DECLARE_EVENT_TABLE()
+
+public:
+  UnityRendererHost(wxWindow * parent, wxWindowID id);
+  ~UnityRendererHost();
+
+  // Full path to the player exe: the user's Tools/UnityRendererPath override when set,
+  // else <WMV exe dir>\tools\unity-renderer\UnityRenderer.exe. Existence is not checked.
+  static wxString resolveUnityExePath();
+
+  // Launch the player embedded in this panel. Safe to call repeatedly (no-op while the
+  // player is already running). Returns false after showing a non-fatal error message
+  // when the exe is missing or the process cannot be started.
+  bool launch();
+
+  // True while the embedded player process is alive (reaps the handle when it has exited,
+  // so a crashed/closed player can simply be relaunched).
+  bool isRunning();
+
+  // Close the embedded player: polite WM_CLOSE to its window first, hard-terminate as a
+  // fallback. Called from the host frame's OnClose and from the destructor.
+  void shutdown();
+
+private:
+  void OnSize(wxSizeEvent & event);
+  void OnSetFocus(wxFocusEvent & event);
+
+  // The player does not follow the parent's size on its own; the host must resize the
+  // embedded child window whenever the panel resizes (it fills the whole client area).
+  void resizeEmbeddedWindow();
+
+#ifdef _WINDOWS
+  // The player's top-level-turned-child window inside this panel (found lazily: the
+  // player creates it asynchronously after process start).
+  HWND findEmbeddedWindow();
+
+  HANDLE m_process = nullptr; // owned; nullptr when no player has been launched
+  DWORD  m_processId = 0;
+  HWND   m_embeddedWnd = nullptr;
+#endif
+};
+
+#endif // UNITYRENDERERHOST_H

--- a/Source/wowmodelviewer/app.cpp
+++ b/Source/wowmodelviewer/app.cpp
@@ -853,6 +853,11 @@ void WowModelViewApp::LoadSettings()
   ssCounter = config.value("Settings/SSCounter", 100).toInt();
   imgFormat = config.value("Settings/DefaultFormat", 1).toInt();
 
+  // Optional override for the embedded Unity renderer player exe. Empty (the default) ->
+  // resolved at use-time as tools\unity-renderer\UnityRenderer.exe next to the WMV
+  // executable, so a moved install keeps finding its bundled player.
+  unityRendererPath = config.value("Tools/UnityRendererPath", "").toString().toStdWString();
+
   // Optional override for the armory importer's proxy URL (the proxy holds the
   // Blizzard credentials server-side). Pushed into the core singleton so the Qt
   // importer plugin can read it; empty -> the plugin uses its built-in default.
@@ -877,6 +882,8 @@ void WowModelViewApp::SaveSettings()
   config.setValue("Settings/displayItemAndNPCId", displayItemAndNPCId);
   config.setValue("Settings/SSCounter", ssCounter);
   config.setValue("Settings/DefaultFormat", imgFormat);
+
+  config.setValue("Tools/UnityRendererPath", QString::fromWCharArray(unityRendererPath.c_str()));
 
   config.setValue("Armory/ProxyURL", QString::fromStdString(GLOBALSETTINGS.armoryProxyURL()));
   config.sync();

--- a/Source/wowmodelviewer/enums.h
+++ b/Source/wowmodelviewer/enums.h
@@ -50,6 +50,7 @@ enum ObjectID {
 
   ID_VIEW_NPC,
   ID_VIEW_ITEM,
+  ID_VIEW_UNITY_RENDERER,
 
   ID_LOAD_WOW,
   ID_LOAD_MPQ,
@@ -204,6 +205,7 @@ enum ObjectID {
   // ----------------------------------------
   // Model Control Frame
   ID_MODEL_FRAME,
+  ID_UNITY_FRAME,
   ID_MODEL_NAME,
   ID_MODEL_LOD,
   ID_MODEL_ALPHA,

--- a/Source/wowmodelviewer/modelviewer.cpp
+++ b/Source/wowmodelviewer/modelviewer.cpp
@@ -37,6 +37,7 @@
 #include "PluginManager.h"
 #include "RaceInfos.h"
 #include "SettingsControl.h"
+#include "UnityRendererHost.h"
 #include "UserSkins.h"
 #include "util.h"
 #include "WoWDatabase.h"
@@ -95,6 +96,7 @@ EVT_MENU(ID_SHOW_ANIM, ModelViewer::OnToggleDock)
 EVT_MENU(ID_SHOW_CHAR, ModelViewer::OnToggleDock)
 EVT_MENU(ID_SHOW_LIGHT, ModelViewer::OnToggleDock)
 EVT_MENU(ID_SHOW_MODEL, ModelViewer::OnToggleDock)
+EVT_MENU(ID_VIEW_UNITY_RENDERER, ModelViewer::OnUnityRenderer)
 // --
 //EVT_MENU(ID_SHOW_WIREFRAME, ModelViewer::OnToggleCommand)
 //EVT_MENU(ID_SHOW_BONES, ModelViewer::OnToggleCommand)
@@ -221,6 +223,7 @@ ModelViewer::ModelViewer()
   modelControl = NULL;
   imageControl = NULL;
   settingsControl = NULL;
+  unityRendererHost = NULL;
   animExporter = NULL;
   fileControl = NULL;
 
@@ -372,6 +375,8 @@ void ModelViewer::InitMenu()
   viewMenu->Append(ID_SHOW_ANIM, _("Show animation control"));
   viewMenu->Append(ID_SHOW_CHAR, _("Show character control"));
   viewMenu->Append(ID_SHOW_MODEL, _("Show model control"));
+  viewMenu->AppendSeparator();
+  viewMenu->Append(ID_VIEW_UNITY_RENDERER, _("Unity Renderer"));
   if (canvas) {
     viewMenu->Append(ID_BG_COLOR, _("Background Color..."));
     viewMenu->AppendCheckItem(ID_BACKGROUND, _("Load Background\tCTRL+L"));
@@ -726,9 +731,14 @@ void ModelViewer::InitDocking()
   //interfaceManager.Update();
 }
 
+// forward decl (defined next to OnUnityRenderer): shared Unity pane settings
+static wxAuiPaneInfo buildUnityRendererPaneInfo();
+
 void ModelViewer::ResetLayout()
 {
   interfaceManager.DetachPane(fileControl);
+  if (unityRendererHost)
+    interfaceManager.DetachPane(unityRendererHost);
   interfaceManager.DetachPane(animControl);
   interfaceManager.DetachPane(charControl);
   interfaceManager.DetachPane(lightControl);
@@ -768,6 +778,11 @@ void ModelViewer::ResetLayout()
                            Name(wxT("Settings")).Caption(wxT("Settings")).
                            FloatingSize(wxSize(400, 550)).Float().TopDockable(false).LeftDockable(false).
                            RightDockable(false).BottomDockable(false).Show(false));
+
+  // Unity viewport pane (only exists once View > Unity Renderer has been used)
+  if (unityRendererHost)
+    interfaceManager.AddPane(unityRendererHost,
+                             buildUnityRendererPaneInfo().Show(unityRendererHost->isRunning()));
 
   // tell the manager to "commit" all the changes just made
   interfaceManager.Update();
@@ -1420,6 +1435,12 @@ ModelViewer::~ModelViewer()
   if (!batchMode)
     SaveLayout();
 
+  // Shut the embedded Unity player down (if one was ever opened) BEFORE the AUI teardown
+  // destroys its host panel, so the child process never outlives -- or paints into -- a
+  // dead window.
+  if (unityRendererHost)
+    unityRendererHost->shutdown();
+
   // wxAUI stuff (teardown, always run)
   interfaceManager.UnInit();
 
@@ -1467,6 +1488,11 @@ ModelViewer::~ModelViewer()
     modelControl = NULL;
   }
 
+  if (unityRendererHost) {
+    unityRendererHost->Destroy();
+    unityRendererHost = NULL;
+  }
+
   if (enchants) {
     enchants->Destroy();
     enchants = NULL;
@@ -1500,6 +1526,48 @@ void ModelViewer::OnToggleDock(wxCommandEvent &event)
     settingsControl->Open();
   }
   interfaceManager.Update();
+}
+
+// The Unity viewport's docking setup, shared by the lazy creation below and ResetLayout so
+// both register the pane identically (an initially-hidden, dockable/floatable side pane).
+// For now the OpenGL canvas stays the one CenterPane; as the Unity renderer becomes the
+// primary viewport this pane is expected to take over that position, with the OpenGL
+// canvas retained as the legacy/fallback viewport.
+static wxAuiPaneInfo buildUnityRendererPaneInfo()
+{
+  return wxAuiPaneInfo().
+         Name(wxT("unityRenderer")).Caption(wxT("Unity Renderer")).
+         BestSize(wxSize(640, 480)).FloatingSize(wxSize(800, 600)).
+         Right().Layer(2).Show(false).DestroyOnClose(false);
+}
+
+// View > Unity Renderer: the embedded Unity viewport -- the new renderer foundation for WMV
+// (the OpenGL canvas is the legacy/fallback viewport during the migration; see
+// docs/unity-renderer/README.md). At this stage it is still OPTIONAL: the host panel and its
+// pane are created lazily on FIRST use (same pattern as the Screenshot pane) so normal
+// startup and headless/batch runs never construct them, and the player itself is an external
+// exe launched by UnityRendererHost -- nothing in the WMV build depends on Unity being
+// installed.
+void ModelViewer::OnUnityRenderer(wxCommandEvent &event)
+{
+  if (!unityRendererHost)
+  {
+    unityRendererHost = new UnityRendererHost(this, ID_UNITY_FRAME);
+    interfaceManager.AddPane(unityRendererHost, buildUnityRendererPaneInfo());
+  }
+
+  // Show the pane first so the panel is realized at its docked size, then embed the player
+  // into it (the player parents itself to the panel's HWND).
+  interfaceManager.GetPane(unityRendererHost).Show(true);
+  interfaceManager.Update();
+
+  if (!unityRendererHost->isRunning() && !unityRendererHost->launch())
+  {
+    // Launch failed (missing/broken player build): the host already told the user; hide the
+    // empty pane again and carry on -- the rest of the app is unaffected.
+    interfaceManager.GetPane(unityRendererHost).Show(false);
+    interfaceManager.Update();
+  }
 }
 
 // Menu button press events

--- a/Source/wowmodelviewer/modelviewer.h
+++ b/Source/wowmodelviewer/modelviewer.h
@@ -34,6 +34,7 @@
 class SettingsControl;
 class ExportJobManager;
 class ImageSequenceExporter;
+class UnityRendererHost;
 
 namespace core { class GameConfig; }
 
@@ -65,6 +66,11 @@ public:
   ImageControl *imageControl;
   //SoundControl *soundControl;
   SettingsControl *settingsControl;
+  // Embedded Unity viewport pane -- the new renderer foundation (the OpenGL canvas is the
+  // legacy/fallback viewport during the migration). Currently optional: created lazily on
+  // first View > Unity Renderer use (nullptr until then, and forever in headless runs).
+  // See UnityRendererHost.h and docs/unity-renderer/README.md.
+  UnityRendererHost *unityRendererHost;
 
   CAnimationExporter *animExporter;
 
@@ -152,6 +158,10 @@ public:
   void OnSetEquipment(wxCommandEvent &event);
   void OnCharToggle(wxCommandEvent &event);
   void OnImportNPCFromURL(wxCommandEvent &event);  // direct "Import NPC from URL" menu entry
+
+  // View > Unity Renderer: show the embedded Unity viewport -- the new renderer foundation,
+  // optional at this migration stage (lazy pane + player launch). See UnityRendererHost.h.
+  void OnUnityRenderer(wxCommandEvent &event);
 
   void OnMount(wxCommandEvent &event);
   void OnSave(wxCommandEvent &event);

--- a/Source/wowmodelviewer/util.cpp
+++ b/Source/wowmodelviewer/util.cpp
@@ -16,6 +16,7 @@ wxString cfgPath;
 wxString bgImagePath;
 wxString armoryPath;
 wxString customDirectoryPath;
+wxString unityRendererPath;
 int customFilesConflictPolicy = 0;
 int displayItemAndNPCId = 0;
 

--- a/Source/wowmodelviewer/util.h
+++ b/Source/wowmodelviewer/util.h
@@ -27,6 +27,9 @@ extern wxString cfgPath;
 extern wxString bgImagePath;
 extern wxString armoryPath;
 extern wxString customDirectoryPath;
+// Optional override for the embedded Unity renderer player exe; empty -> resolved at
+// use-time as tools\unity-renderer\UnityRenderer.exe next to the WMV executable.
+extern wxString unityRendererPath;
 extern int customFilesConflictPolicy;
 extern int displayItemAndNPCId;
 

--- a/Tools/UnityRendererProject/.gitignore
+++ b/Tools/UnityRendererProject/.gitignore
@@ -1,0 +1,11 @@
+# Never commit player or stub build output -- the Unity player is built locally
+# by each user (see README.md) and stays out of the repository.
+*.exe
+*.obj
+*.pdb
+*.ilk
+Library/
+Temp/
+Logs/
+Build/
+UserSettings/

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvIpcServer.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvIpcServer.cs
@@ -1,0 +1,208 @@
+// WmvIpcServer.cs
+//
+// IPC endpoint of the WMV Unity viewport player: a localhost TCP server speaking
+// newline-delimited JSON (one object per line). Default port 9500, overridable with
+// "-wmvPort <n>" on the player command line.
+//
+// The player is WMV's new renderer foundation and renders directly from WoW data: it asks
+// WMV -- which owns the app UI, the active client/profile, CASC/MPQ access, DB/metadata and
+// the runtime commands -- for raw assets and metadata over this channel. The player never
+// reads game archives itself and no exported mesh/texture files are involved.
+//
+// V0 skeleton (future-facing vocabulary only):
+//
+//   WMV -> player (runtime commands)
+//     clearScene
+//     loadWoWModel { sourcePath, fileDataID }       V0: acknowledged "not implemented yet"
+//     setCamera    { position[3], rotation[3] }
+//
+//   player -> WMV (state)
+//     unityReady | loaded | error { message }
+//
+//   player -> WMV (asset / metadata requests; WMV serves them from CASC/MPQ + DB in V1)
+//     getAsset             { path }
+//     getAssetByFileDataID { fileDataID }
+//
+//   WMV -> player (asset replies, V1; payload framing to be finalised with V1)
+//     asset { path | fileDataID, size }             V0: logged, not handled
+//
+// The listener/read loop runs on a background thread; handlers run on the main thread
+// (Unity API is main-thread-only) via a queue drained in Update().
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using UnityEngine;
+
+public class WmvIpcServer : MonoBehaviour
+{
+    public Action OnClearScene;
+    public Action<string, int> OnLoadWoWModel;     // (sourcePath, fileDataID)
+    public Action<Vector3, Vector3> OnSetCamera;   // (position, rotationEuler)
+
+    [Serializable] class Msg
+    {
+        public string type;
+        public string sourcePath;
+        public int fileDataID;
+        public string path;
+        public int size;
+        public string message;
+        public float[] position;
+        public float[] rotation;
+    }
+
+    TcpListener listener;
+    Thread thread;
+    volatile bool stopping;
+    NetworkStream clientStream;              // most recent client (the WMV host)
+    readonly object streamLock = new object();
+    readonly Queue<Msg> inbox = new Queue<Msg>();
+
+    void Start()
+    {
+        int port = 9500;
+        var args = Environment.GetCommandLineArgs();
+        for (int i = 0; i < args.Length - 1; i++)
+            if (args[i] == "-wmvPort" && int.TryParse(args[i + 1], out var p))
+                port = p;
+
+        listener = new TcpListener(IPAddress.Loopback, port);
+        listener.Start();
+        thread = new Thread(AcceptLoop) { IsBackground = true };
+        thread.Start();
+        Debug.Log("WMV IPC listening on 127.0.0.1:" + port);
+    }
+
+    void AcceptLoop()
+    {
+        try
+        {
+            while (!stopping)
+            {
+                var client = listener.AcceptTcpClient();
+                var stream = client.GetStream();
+                lock (streamLock) clientStream = stream;
+                Send("{\"type\":\"unityReady\"}");
+
+                try
+                {
+                    using (var reader = new StreamReader(stream, Encoding.UTF8))
+                    {
+                        string line;
+                        while (!stopping && (line = reader.ReadLine()) != null)
+                        {
+                            if (line.Trim().Length == 0) continue;
+                            var msg = JsonUtility.FromJson<Msg>(line);
+                            if (msg != null)
+                                lock (inbox) inbox.Enqueue(msg);
+                        }
+                    }
+                }
+                catch (IOException) { /* host disconnected; wait for the next one */ }
+                lock (streamLock) clientStream = null;
+            }
+        }
+        catch (SocketException) { /* listener stopped */ }
+    }
+
+    void Update()
+    {
+        while (true)
+        {
+            Msg msg;
+            lock (inbox)
+            {
+                if (inbox.Count == 0) return;
+                msg = inbox.Dequeue();
+            }
+
+            try
+            {
+                switch (msg.type)
+                {
+                    case "clearScene":
+                        OnClearScene?.Invoke();
+                        break;
+                    case "loadWoWModel":
+                        OnLoadWoWModel?.Invoke(msg.sourcePath ?? "", msg.fileDataID);
+                        break;
+                    case "setCamera":
+                        if (msg.position != null && msg.position.Length == 3 &&
+                            msg.rotation != null && msg.rotation.Length == 3)
+                            OnSetCamera?.Invoke(
+                                new Vector3(msg.position[0], msg.position[1], msg.position[2]),
+                                new Vector3(msg.rotation[0], msg.rotation[1], msg.rotation[2]));
+                        break;
+                    case "asset":
+                        // Reply to getAsset / getAssetByFileDataID. Payload handling lands with the
+                        // V1 loaders; for now just show that the round trip works.
+                        Debug.Log("asset reply for " + (msg.path ?? ("fileDataID " + msg.fileDataID)) +
+                                  " (" + msg.size + " bytes) -- asset replies are not handled yet");
+                        break;
+                    default:
+                        SendError("Unknown message type: " + msg.type);
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                SendError(e.Message);
+            }
+        }
+    }
+
+    // ---- state -> WMV ----
+
+    public void SendLoaded() { Send("{\"type\":\"loaded\"}"); }
+
+    public void SendError(string message)
+    {
+        Debug.LogWarning("WMV IPC error: " + message);
+        Send("{\"type\":\"error\",\"message\":\"" + Escape(message) + "\"}");
+    }
+
+    // ---- asset / metadata requests -> WMV (the V1 asset channel) ----
+    // The player never reads CASC/MPQ itself: everything it renders is requested from WMV.
+
+    public void RequestAsset(string path)
+    {
+        Send("{\"type\":\"getAsset\",\"path\":\"" + Escape(path) + "\"}");
+    }
+
+    public void RequestAssetByFileDataID(int fileDataID)
+    {
+        Send("{\"type\":\"getAssetByFileDataID\",\"fileDataID\":" + fileDataID + "}");
+    }
+
+    // Cheap JSON string escape for the two characters that matter here.
+    static string Escape(string s)
+    {
+        return (s ?? "").Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+
+    void Send(string json)
+    {
+        lock (streamLock)
+        {
+            if (clientStream == null) return;
+            try
+            {
+                var bytes = Encoding.UTF8.GetBytes(json + "\n");
+                clientStream.Write(bytes, 0, bytes.Length);
+                clientStream.Flush();
+            }
+            catch (IOException) { clientStream = null; }
+        }
+    }
+
+    void OnDestroy()
+    {
+        stopping = true;
+        try { listener?.Stop(); } catch { }
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -1,0 +1,91 @@
+// WmvMain.cs
+//
+// Bootstrap for the WMV Unity viewport player -- WMV's new renderer foundation and intended
+// primary viewport (the OpenGL canvas is the legacy/fallback viewport during the migration;
+// see docs/unity-renderer/README.md). Add this component to one empty GameObject in an
+// otherwise-empty scene; at runtime it builds everything else: camera rig + orbit controls,
+// a directional light, the V0 test cube, and the IPC server WMV talks to.
+//
+// V0 scope: embedding proof (test cube) + IPC skeleton. loadWoWModel is acknowledged with
+// "not implemented yet"; the V1 loaders will build the scene from raw WoW data requested from
+// WMV over IPC (WmvIpcServer.RequestAsset / RequestAssetByFileDataID).
+
+using UnityEngine;
+
+public class WmvMain : MonoBehaviour
+{
+    WmvIpcServer ipc;
+    GameObject testCube;
+
+    void Awake()
+    {
+        // The player is embedded in a host app whose window normally has focus;
+        // without this the player would pause immediately. (Also set Run In
+        // Background in Player Settings -- this is a belt-and-braces override.)
+        Application.runInBackground = true;
+
+        // Camera rig
+        var cam = Camera.main;
+        if (cam == null)
+        {
+            var camGo = new GameObject("Main Camera");
+            cam = camGo.AddComponent<Camera>();
+            camGo.tag = "MainCamera";
+        }
+        cam.transform.position = new Vector3(0f, 1.2f, -4f);
+        cam.transform.LookAt(Vector3.zero);
+        cam.clearFlags = CameraClearFlags.SolidColor;
+        cam.backgroundColor = new Color(0.10f, 0.10f, 0.12f);
+        cam.gameObject.AddComponent<WmvOrbitCamera>();
+
+        // Light
+        var lightGo = new GameObject("Directional Light");
+        var light = lightGo.AddComponent<Light>();
+        light.type = LightType.Directional;
+        light.intensity = 1.1f;
+        lightGo.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
+
+        // V0 proof-of-life: a visible spinning cube until real WoW models arrive (V1).
+        testCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        testCube.name = "WMV Test Cube";
+        testCube.AddComponent<WmvSpin>();
+
+        // IPC
+        ipc = gameObject.AddComponent<WmvIpcServer>();
+        ipc.OnClearScene = HandleClearScene;
+        ipc.OnLoadWoWModel = HandleLoadWoWModel;
+        ipc.OnSetCamera = HandleSetCamera;
+    }
+
+    // V1: request the model's M2 / skin / textures from WMV (ipc.RequestAsset /
+    // RequestAssetByFileDataID) and build the scene from that data. V0 only acknowledges.
+    void HandleLoadWoWModel(string sourcePath, int fileDataID)
+    {
+        var what = string.IsNullOrEmpty(sourcePath) ? ("fileDataID " + fileDataID) : sourcePath;
+        Debug.Log("loadWoWModel " + what + ": not implemented yet");
+        ipc.SendError("loadWoWModel not implemented yet (" + what + ")");
+    }
+
+    void HandleClearScene()
+    {
+        // Nothing to clear in V0 beyond making sure the test scene is visible.
+        if (testCube != null) testCube.SetActive(true);
+    }
+
+    void HandleSetCamera(Vector3 position, Vector3 rotationEuler)
+    {
+        var cam = Camera.main;
+        if (cam == null) return;
+        cam.transform.position = position;
+        cam.transform.rotation = Quaternion.Euler(rotationEuler);
+    }
+}
+
+// Slow idle spin so the V0 test scene is visibly "live".
+public class WmvSpin : MonoBehaviour
+{
+    void Update()
+    {
+        transform.Rotate(0f, 40f * Time.deltaTime, 0f);
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvOrbitCamera.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvOrbitCamera.cs
@@ -1,0 +1,70 @@
+// WmvOrbitCamera.cs
+//
+// Simple orbit/zoom/pan controls for the embedded viewport:
+//   left-drag  = orbit around the pivot
+//   right-drag = pan the pivot
+//   wheel      = zoom
+// Attached to the main camera by WmvMain.
+
+using UnityEngine;
+
+public class WmvOrbitCamera : MonoBehaviour
+{
+    public Vector3 pivot = Vector3.zero;
+    public float distance = 4f;
+    public float yaw = 0f;
+    public float pitch = 20f;
+
+    const float OrbitSpeed = 0.25f;   // degrees per pixel
+    const float PanSpeed = 0.0025f;   // world units per pixel per distance
+    const float ZoomSpeed = 0.12f;
+    const float MinDistance = 0.2f;
+    const float MaxDistance = 200f;
+
+    Vector3 lastMouse;
+
+    void Start()
+    {
+        Apply();
+    }
+
+    void Update()
+    {
+        var mouse = Input.mousePosition;
+        var delta = mouse - lastMouse;
+        lastMouse = mouse;
+
+        bool changed = false;
+
+        if (Input.GetMouseButton(0) && !Input.GetMouseButtonDown(0))
+        {
+            yaw += delta.x * OrbitSpeed;
+            pitch = Mathf.Clamp(pitch - delta.y * OrbitSpeed, -89f, 89f);
+            changed = true;
+        }
+        else if (Input.GetMouseButton(1) && !Input.GetMouseButtonDown(1))
+        {
+            var t = transform;
+            pivot -= t.right * (delta.x * PanSpeed * distance);
+            pivot -= t.up * (delta.y * PanSpeed * distance);
+            changed = true;
+        }
+
+        var scroll = Input.GetAxis("Mouse ScrollWheel");
+        if (Mathf.Abs(scroll) > 0.0001f)
+        {
+            distance = Mathf.Clamp(distance * (1f - scroll * ZoomSpeed * 10f), MinDistance, MaxDistance);
+            changed = true;
+        }
+
+        if (changed)
+            Apply();
+    }
+
+    void Apply()
+    {
+        var rot = Quaternion.Euler(pitch, yaw, 0f);
+        transform.position = pivot - rot * Vector3.forward * distance;
+        transform.rotation = rot;
+    }
+}

--- a/Tools/UnityRendererProject/README.md
+++ b/Tools/UnityRendererProject/README.md
@@ -1,0 +1,75 @@
+# UnityRendererProject — the WMV Unity viewport player
+
+This folder holds the **source-only** pieces of the Unity standalone player that WMV embeds
+via `View → Unity Renderer`. The repo contains no Unity project boilerplate and no build
+output — you create the project locally with your own Unity install and drop these
+scripts in.
+
+**Direction:** this player is WMV's **new renderer foundation and intended primary
+viewport**; the OpenGL canvas remains the legacy/fallback viewport during the migration.
+It renders **directly from WoW data**: it requests raw assets and metadata from WMV over
+IPC (no OBJ/FBX/GLB export workflow). WMV provides the app UI, the active client/profile,
+CASC/MPQ access, DB/metadata and the runtime commands; the player provides the modern
+rendering pipeline. See `docs/unity-renderer/README.md`. For now the player is optional at
+build and run time.
+
+## Build steps
+
+1. Install a Unity LTS (2021.3 or newer; any recent LTS works — the scripts use only
+   core UnityEngine + .NET `TcpListener`).
+2. Create a new **3D (Built-in Render Pipeline)** project named e.g. `WmvUnityRenderer`.
+3. Copy the `Assets/Scripts/` folder from here into the project's `Assets/`.
+4. Create an empty GameObject in the default scene and add the **WmvMain** component to
+   it. (It builds the camera rig, light, test cube and starts the IPC server at runtime —
+   no other scene setup needed.)
+5. **Player Settings** (Edit → Project Settings → Player):
+   - **Resolution and Presentation → Run In Background: ON** (required — otherwise the
+     player pauses whenever the WMV window has focus, which is always).
+   - Fullscreen Mode: *Windowed*.
+6. **File → Build Settings → Windows x86_64 → Build**, and build **into**
+   `tools\unity-renderer\` next to `wowmodelviewer.exe`, with the executable named
+   `UnityRenderer.exe`.
+   (Alternatively build anywhere and set `Tools/UnityRendererPath` in
+   `userSettings\Config.ini` to the exe's full path.)
+
+Do **not** commit the build output (exe, `UnityRenderer_Data/`, `UnityPlayer.dll`, …) to
+this repository.
+
+## Scripts
+
+| File | Role |
+|---|---|
+| `WmvMain.cs` | Bootstrap: camera rig, light, V0 test cube, wires the IPC handlers. `loadWoWModel` is acknowledged with "not implemented yet" until the V1 loaders land. |
+| `WmvIpcServer.cs` | IPC skeleton: runtime commands from WMV (`clearScene`, `loadWoWModel`, `setCamera`), state to WMV (`unityReady`, `loaded`, `error`), and the asset-channel requests to WMV (`getAsset`, `getAssetByFileDataID`). |
+| `WmvOrbitCamera.cs` | Orbit / pan / zoom controls for the viewport. |
+
+## How embedding works
+
+WMV launches the player with the standard standalone-player embedding arguments:
+
+```
+UnityRenderer.exe -parentHWND <decimal hwnd> delayed -logFile <...>\userSettings\unityRenderer.log
+```
+
+The player creates its window as a child of the given WMV panel; WMV resizes that child
+window whenever the pane resizes and sends it `WM_CLOSE` on shutdown.
+
+## IPC
+
+`WmvIpcServer` listens on `127.0.0.1:9500` (override with `-wmvPort <n>` on the player
+command line) and speaks newline-delimited JSON — see `docs/unity-renderer/README.md` for
+the full vocabulary. In V0 the player starts the listener and sends `unityReady` to
+whoever connects; the WMV-side client and the asset serving land with V1.
+
+## TestStub
+
+`TestStub/` contains a ~150-line Win32 program that honours the same `-parentHWND`
+contract (child window, fills the parent, exits on `WM_CLOSE`). Build it with any MSVC
+prompt:
+
+```
+cl fake_unity_renderer.c user32.lib gdi32.lib shell32.lib /Fe:UnityRenderer.exe
+```
+
+Drop the result at `tools\unity-renderer\UnityRenderer.exe` to test the WMV-side
+embedding (launch, docking, resize, shutdown) without installing Unity.

--- a/Tools/UnityRendererProject/TestStub/fake_unity_renderer.c
+++ b/Tools/UnityRendererProject/TestStub/fake_unity_renderer.c
@@ -1,0 +1,142 @@
+/*
+ * fake_unity_renderer.c
+ *
+ * Tiny stand-in for the Unity standalone player, honouring the same embedding
+ * contract the WMV UnityRendererHost relies on:
+ *
+ *   UnityRenderer.exe -parentHWND <decimal hwnd> [delayed] [-logFile <path>]
+ *
+ *   - creates its window as a WS_CHILD of the given parent HWND
+ *   - does NOT resize itself; the host resizes it (MoveWindow) on pane resize
+ *   - exits its message loop when it receives WM_CLOSE (the host's polite shutdown)
+ *
+ * Purpose: verify the WMV-side embedding (launch / dock / resize / shutdown /
+ * process lifetime) without a Unity install. It paints a gradient + label so an
+ * embedded, live-resizing child is visually obvious.
+ *
+ * Build (any MSVC x64/x86 developer prompt):
+ *   cl fake_unity_renderer.c user32.lib gdi32.lib shell32.lib /Fe:UnityRenderer.exe
+ *
+ * Then place UnityRenderer.exe at tools\unity-renderer\ next to wowmodelviewer.exe.
+ * Never commit the built exe.
+ */
+
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+  switch (msg)
+  {
+    case WM_PAINT:
+    {
+      PAINTSTRUCT ps;
+      HDC dc = BeginPaint(hwnd, &ps);
+      RECT rc;
+      GetClientRect(hwnd, &rc);
+
+      /* vertical blue->dark gradient so resizes are visually obvious */
+      int h = rc.bottom > 0 ? rc.bottom : 1;
+      for (int y = 0; y < rc.bottom; y++)
+      {
+        int shade = 40 + (150 * (h - y)) / h;
+        HBRUSH brush = CreateSolidBrush(RGB(20, 30, shade));
+        RECT line = { 0, y, rc.right, y + 1 };
+        FillRect(dc, &line, brush);
+        DeleteObject(brush);
+      }
+
+      char text[128];
+      _snprintf(text, sizeof(text), "UnityRenderer stub  %ldx%ld", rc.right, rc.bottom);
+      SetBkMode(dc, TRANSPARENT);
+      SetTextColor(dc, RGB(230, 230, 240));
+      DrawTextA(dc, text, -1, &rc, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+
+      EndPaint(hwnd, &ps);
+      return 0;
+    }
+    case WM_SIZE:
+      InvalidateRect(hwnd, NULL, TRUE);
+      return 0;
+    case WM_CLOSE:      /* the host's polite shutdown path */
+      DestroyWindow(hwnd);
+      return 0;
+    case WM_DESTROY:
+      PostQuitMessage(0);
+      return 0;
+  }
+  return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdLine, int show)
+{
+  HWND parent = NULL;
+  FILE * log = NULL;
+
+  int argc = 0;
+  LPWSTR * argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+  for (int i = 1; i < argc - 1; i++)
+  {
+    if (wcscmp(argv[i], L"-parentHWND") == 0)
+      parent = (HWND)(UINT_PTR)_wcstoui64(argv[i + 1], NULL, 10);
+    else if (wcscmp(argv[i], L"-logFile") == 0)
+      log = _wfopen(argv[i + 1], L"w");
+  }
+  LocalFree(argv);
+
+  if (log)
+  {
+    fprintf(log, "fake_unity_renderer: parentHWND=%p\n", (void *)parent);
+    fflush(log);
+  }
+
+  WNDCLASSA wc;
+  ZeroMemory(&wc, sizeof(wc));
+  wc.lpfnWndProc = WndProc;
+  wc.hInstance = inst;
+  wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+  wc.lpszClassName = "FakeUnityRenderer";
+  RegisterClassA(&wc);
+
+  DWORD style;
+  int w = 640, h = 480;
+  if (parent && IsWindow(parent))
+  {
+    style = WS_CHILD | WS_VISIBLE;
+    RECT rc;
+    if (GetClientRect(parent, &rc))
+    {
+      w = rc.right > 0 ? rc.right : w;
+      h = rc.bottom > 0 ? rc.bottom : h;
+    }
+  }
+  else
+  {
+    style = WS_OVERLAPPEDWINDOW | WS_VISIBLE;  /* standalone fallback for manual runs */
+    parent = NULL;
+  }
+
+  HWND hwnd = CreateWindowA("FakeUnityRenderer", "UnityRenderer stub", style,
+                            0, 0, w, h, parent, NULL, inst, NULL);
+  if (!hwnd)
+  {
+    if (log) { fprintf(log, "CreateWindow failed (%lu)\n", GetLastError()); fclose(log); }
+    return 1;
+  }
+
+  MSG msg;
+  while (GetMessage(&msg, NULL, 0, 0) > 0)
+  {
+    TranslateMessage(&msg);
+    DispatchMessage(&msg);
+  }
+
+  if (log)
+  {
+    fprintf(log, "fake_unity_renderer: clean exit\n");
+    fclose(log);
+  }
+  return 0;
+}

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -1,0 +1,155 @@
+# Embedded Unity Renderer
+
+## Direction (read this first)
+
+The embedded Unity viewport is the **new renderer foundation for WMV** and its **intended
+primary viewport**. The existing OpenGL viewport (`ModelCanvas`) remains the **legacy /
+fallback renderer during the migration** and is not where new rendering work goes.
+
+Concretely:
+
+- **Unity first.** Future rendering features — characters, equipment, maps, fog, OBS
+  scenes and stream features — target the Unity viewport first. The OpenGL path receives
+  maintenance only.
+- **Unity renders directly from WoW data.** There is **no OBJ / FBX / GLB export workflow**
+  between WMV and Unity. Unity requests the raw WoW assets (M2, skins, BLP textures, …) and
+  metadata it needs from WMV over IPC and builds the scene from them. (WMV's export plugins
+  remain a separate, user-facing feature; they are not part of the render path.)
+- **Responsibility split** (detailed below): **WMV provides the application UI, the active
+  client/profile, CASC/MPQ access, DB/metadata and the runtime commands; Unity provides the
+  modern rendering pipeline and asks WMV for assets/metadata.**
+- **Optional for now.** While the migration is in progress the Unity viewport is optional at
+  build and run time: nothing in the normal WMV build depends on Unity (no SDK, no binaries
+  in the repo, no new link dependencies), and a missing player build produces a clear
+  message while the app — and the legacy OpenGL viewport — carry on unchanged. "Optional"
+  describes the current migration stage, not the destination.
+
+## Responsibility split
+
+| WMV (wxWidgets application) | Unity (embedded player) |
+|---|---|
+| Application UI (menus, panes, dialogs, settings) | Modern rendering pipeline (materials, lighting, post, HDR/PBR) |
+| Active client / profile (retail, PTR, classic, legacy MPQ) | Scene graph: models, attachments, equipment, maps, fog |
+| CASC / MPQ access — the only component that reads game archives | Cameras, orbit/controls, capture-friendly output (OBS, transparent/solid backgrounds, stream features) |
+| Databases / metadata (DB2, DBC, listfiles, customization, display info) | Animation playback / skinning on the GPU |
+| Runtime commands: what to show, customization/equipment, camera, capture | Requests raw assets / metadata from WMV; reports state back (unityReady / loaded / error) |
+| Legacy OpenGL viewport (fallback during migration) | — |
+
+Unity never parses CASC/MPQ itself and never depends on files WMV writes to disk: it
+**asks WMV** for what it needs (raw file bytes by path or FileDataID, resolved metadata)
+over the IPC channel, and WMV serves it from its existing file providers and database.
+
+## Architecture
+
+```
++----------------------------- WMV (wxWidgets) ------------------------------+
+|  ModelCanvas (OpenGL)              |  UnityRendererHost (wxPanel)          |
+|  LEGACY / FALLBACK during the      |  NEW RENDERER FOUNDATION              |
+|  migration; maintenance only       |  - launches UnityRenderer.exe with    |
+|  - app's single WGL context bound  |    "-parentHWND <hwnd> delayed"       |
+|    to this canvas' own HWND        |    (player reparents itself INTO      |
+|                                    |    this panel, own process + device)  |
+|                                    |  - resizes the embedded child window  |
+|                                    |  - WM_CLOSE (+terminate fallback)     |
+|                                    |    on app shutdown                    |
++----------------------------------------------------------------------------+
+        ^ state                               | runtime commands      ^ asset/metadata
+        | (unityReady, loaded,                v (clearScene,          | requests
+        |  error)                               loadWoWModel,         | (getAsset,
+        |                                       setCamera)            |  getAssetByFileDataID)
+   +----+---------------------------------------+----------------------+-----------+
+   |         WMV asset-access / runtime API over local IPC (TCP, JSON lines)       |
+   |     served by WMV from its CASC/MPQ file providers + GAMEDATABASE             |
+   +-------------------------------------------------------------------------------+
+                                   |
+                                   v
+   UnityRenderer.exe (separate process, own graphics device)
+   - V0: blank scene + test cube (embedding proof) + IPC skeleton
+   - V1+: M2 / skin / BLP / DB-driven loaders that build the scene straight from the
+     bytes and metadata WMV serves -- no intermediate files
+```
+
+Why this is safe for the legacy viewport today: on Windows the OpenGL context is a single
+process-global WGL context bound to the ModelCanvas's own HWND/HDC. The player runs
+**out of process** and renders into **its own** child window with its own device, so the
+two never share a device, context or pixel format. The Unity panel is a *sibling* of the
+canvas in the wxAUI layout (the canvas stays the CenterPane for now; as the migration
+progresses the Unity pane is expected to take over the primary viewport position, with
+the OpenGL canvas retained as a fallback).
+
+## Locating the player (current, optional stage)
+
+1. `Tools/UnityRendererPath` in `userSettings\Config.ini` (when non-empty), else
+2. `tools\unity-renderer\UnityRenderer.exe` next to the WMV executable.
+
+Player logs go to `userSettings\unityRenderer.log` (next to WMV's own log). The player is
+built locally from `Tools/UnityRendererProject/` — the repository contains **no** Unity
+build output.
+
+## IPC
+
+Transport: **localhost TCP** (default port `9500`, player argument `-wmvPort <n>` to
+override), newline-delimited JSON. The player hosts the listener; WMV connects (the
+WMV-side client lands with V1 — in V0 the player only starts the listener and announces
+itself to whoever connects). Vocabulary is future-facing from V0 on:
+
+**Runtime commands — WMV → player**
+
+```json
+{ "type": "clearScene" }
+{ "type": "loadWoWModel", "sourcePath": "creature/chicken/chicken.m2", "fileDataID": 123456 }
+{ "type": "setCamera", "position": [x, y, z], "rotation": [rx, ry, rz] }
+```
+
+V0 answers `loadWoWModel` with an `error` reading *"loadWoWModel not implemented yet"*;
+V1 implements it by requesting the model's assets (below) and building the scene.
+
+**State — player → WMV**
+
+```json
+{ "type": "unityReady" }
+{ "type": "loaded" }
+{ "type": "error", "message": "..." }
+```
+
+**Asset / metadata requests — player → WMV** (served by WMV from CASC/MPQ + database)
+
+```json
+{ "type": "getAsset", "path": "creature/chicken/chicken.m2" }
+{ "type": "getAssetByFileDataID", "fileDataID": 123457 }
+```
+
+**Asset replies — WMV → player** (V1; payload framing — e.g. a JSON header followed by a
+length-prefixed binary frame — to be finalised with V1)
+
+```json
+{ "type": "asset", "path": "creature/chicken/chicken.m2", "size": 183204 }   // + raw bytes
+```
+
+Metadata requests (resolved skins / display info / customization lookups) will be added to
+the same channel as the loaders need them. The important property is that **the player only
+ever sees what WMV serves at runtime** — the same data the legacy viewport renders from.
+
+## Migration roadmap
+
+- **V0 (this branch):** `View → Unity Renderer` opens a dockable pane, launches the player
+  embedded in it, resize/shutdown work, missing player handled gracefully; player shows a
+  test scene and hosts the IPC skeleton. Unity optional at build and run time.
+- **V1:** WMV-side IPC client + asset-access/runtime API (`getAsset`,
+  `getAssetByFileDataID`, metadata); Unity-side M2 + skin + BLP loaders render
+  `creature/chicken/chicken.m2` **directly from WoW data served by WMV**.
+- **V2+ (Unity first):** characters + customization, equipment/attachments, animation,
+  maps/terrain/fog, OBS-friendly backgrounds and scene/stream features — each built on the
+  Unity pipeline, with the legacy OpenGL viewport kept as fallback until parity.
+- **Cut-over:** once Unity covers the baseline feature set, it becomes the default /
+  primary viewport; the OpenGL canvas remains available as legacy/fallback.
+
+Explicitly deferred until V0/V1 are solid: full maps/ADT terrain, WMO placement,
+volumetric fog, armory donations, equipment.
+
+## The player project
+
+Source-only player pieces live in `Tools/UnityRendererProject/` (see its README for build
+steps). `Tools/UnityRendererProject/TestStub/` contains a tiny Win32 stand-in that honours
+the same `-parentHWND` embedding contract, so the WMV-side host can be exercised without
+any Unity install.


### PR DESCRIPTION
View > Unity Renderer opens a dockable pane hosting a separately built Unity standalone player, embedded via the player's parent-window mode (-parentHWND <hwnd> delayed). This is the foundation of WMV's new rendering pipeline: the Unity viewport is the intended primary viewport, with the existing OpenGL ModelCanvas kept as the legacy/fallback renderer during the migration. Unity renders directly from WoW data -- it requests raw assets and metadata from WMV over IPC; there is no OBJ/FBX/GLB export workflow. WMV provides the app UI, the active client/profile, CASC/MPQ access, DB/metadata and the runtime commands; Unity provides the modern rendering pipeline.

For now the Unity viewport is optional at build and run time: no Unity SDK or binaries in the repo, no new link dependencies, and the pane + host are created lazily on first menu use (headless/batch runs never construct them). If no player build exists at
tools\unity-renderer\UnityRenderer.exe next to the exe (or at the Tools/UnityRendererPath setting), a clear message is shown and the app continues with the OpenGL viewport.

UnityRendererHost (new) owns launch, embedded-child resize, focus forwarding and shutdown. Shutdown posts WM_CLOSE and waits with a message-pumping MsgWaitForMultipleObjects loop -- the player's DestroyWindow sends our thread WM_PARENTNOTIFY synchronously, so a blocking wait would stall it into the terminate fallback every time.

The player runs out of process and draws into its own child window with its own graphics device, so the app's single WGL context (bound to the ModelCanvas HWND) is untouched.

Tools/UnityRendererProject/ carries the source-only player pieces: bootstrap with a V0 test cube, orbit camera, and the IPC skeleton using the future-facing vocabulary (clearScene / loadWoWModel / setCamera from WMV; unityReady / loaded / error to WMV; getAsset / getAssetByFileDataID asset requests to WMV -- loadWoWModel is acknowledged "not implemented yet" until the V1 loaders land). A tiny Win32 TestStub honours the same -parentHWND contract so the host can be exercised without a Unity install. Direction, responsibility split, IPC vocabulary and migration roadmap are in docs/unity-renderer/README.md.