### PR TITLE
Add initial Unity static M2 rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Embedded Unity renderer: static WoW models now render (M2 + BLP at runtime).** The Unity
+  viewport no longer just fetches bytes -- it turns them into a visible model. On `loadWoWModel`
+  the player fetches the `.m2`, parses it, fetches the `.skin` profile the model names, resolves
+  and fetches its texture(s), decodes the BLP in memory and builds a Unity mesh with one submesh
+  per WoW draw batch, correct WoW->Unity axes and winding, a basic material (opaque / alpha-key /
+  alpha, two-sided when asked) and bounds-driven camera framing. Solidity is treated as a
+  correctness requirement rather than a default: BLP rows are flipped once on upload (they are
+  top-down, Unity's raw texture data is bottom-up), transparency follows the WoW blend mode and
+  never the texture's alpha channel -- a creature skin has one regardless, and on an opaque
+  material it is discarded at upload -- and the shader is screened so it can actually be drawn
+  opaque, since always-included fallbacks such as `Sprites/Default` bake alpha blending, no depth
+  write and no back-face culling into the pass and silently swallow every attempt to change it.
+  `Assets/Resources/WmvOpaque.shader` ships with the renderer as the shader a player build cannot
+  strip. Each load logs the material state it actually produced, and `-wmvFlipV`,
+  `-wmvForceOpaque`, `-wmvForceSolid` and `-wmvMatColors` isolate a visual fault without a rebuild.
+  Draw batches now also honour the two things an M2 uses to say what a material really is: a batch
+  loads as many textures as it declares (unit *k* is `textureComboIndex + k`, not just the first
+  entry), and its shader id names the combiner and the per-unit UV routing -- chicken2's
+  `Combiners_Opaque_Mod2xNA_Alpha` / `Diffuse_T1_Env` makes unit 1 an environment sphere map and the
+  base texture's alpha the reflection mask rather than transparency. And a batch the model hides at
+  rest by keying its colour track to zero is skipped, exactly as the OpenGL viewport does: chicken2
+  ships an 18-triangle eye overlay keyed to alpha 0 whose only visible effect, if drawn, is to cover
+  the eye painted into the skin underneath.
+  Verified end to end against retail data in a real Unity 6 URP player build:
+  `creature/chicken2/chicken2.m2` renders as 1632 vertices, 778 triangles from the one batch the
+  model wants drawn, with its 256x256 DXT5 skin resolved from the creature database and its 64x64
+  environment unit bound, opaque with depth write and back-face culling on. Textures a model does not name
+  itself (replaceable creature skins) are resolved by the app from the client database and handed
+  over as FileDataIDs; the rare legacy model that no creature display references any more falls
+  back to its conventional sibling skin, explicitly labelled as such. Still runtime-only:
+  nothing is exported or written to disk, and there is no OBJ/FBX/GLB step. Animation, the full
+  material system, particles and the character/equipment pipeline are not part of this step.
 - **Embedded Unity renderer: runtime asset access (V1).** The Unity viewport now talks to the app at
   runtime: the app hosts a localhost IPC server (started before the player launches, port passed
   on the player command line), the player connects back and announces itself, the app tells it

--- a/Source/wowmodelviewer/UnityAssetAccess.cpp
+++ b/Source/wowmodelviewer/UnityAssetAccess.cpp
@@ -9,6 +9,7 @@
 #include "GameFile.h"
 #include "GameFolder.h"
 #include "HardDriveFile.h"
+#include "GameDatabase.h"   // sqlResult / GAMEDATABASE query surface
 #include "WoWFolder.h"
 #include "logger/Logger.h"
 
@@ -201,6 +202,89 @@ UnityAssetAccess::Result UnityAssetAccess::readByPath(const QString & path)
 
   r.ok = readGameFile(file, casc, r);
   return r;
+}
+
+bool UnityAssetAccess::resolveModelTextures(int m2FileDataID, std::vector<ModelTexture> & out, QString & error)
+{
+  out.clear();
+  if (m2FileDataID <= 0)
+  {
+    error = "invalid model fileDataID";
+    return false;
+  }
+  if (!hasActiveClient())
+  {
+    error = g_clientLoadDepth > 0 ? "game client is still loading" : "no game client loaded";
+    return false;
+  }
+
+  // 1) Authoritative: the creature's skins live on CreatureDisplayInfo, keyed to the model
+  //    through CreatureModelData.FileDataID -- the same relation the viewer's own skin list
+  //    uses (AnimControl::UpdateModel). Take the first display: the viewer's default skin.
+  //    Column count differs across client generations, so try the widest form first.
+  const char * queries[] = {
+    "SELECT TextureVariationFileDataID1, TextureVariationFileDataID2, TextureVariationFileDataID3, "
+    "TextureVariationFileDataID4 FROM CreatureDisplayInfo "
+    "LEFT JOIN CreatureModelData ON CreatureDisplayInfo.ModelID = CreatureModelData.ID "
+    "WHERE CreatureModelData.FileDataID = %1",
+    "SELECT TextureVariationFileDataID1, TextureVariationFileDataID2, TextureVariationFileDataID3 "
+    "FROM CreatureDisplayInfo "
+    "LEFT JOIN CreatureModelData ON CreatureDisplayInfo.ModelID = CreatureModelData.ID "
+    "WHERE CreatureModelData.FileDataID = %1",
+  };
+
+  for (const char * q : queries)
+  {
+    const sqlResult r = GAMEDATABASE.sqlQuery(QString(q).arg(m2FileDataID));
+    if (!r.valid || r.values.empty())
+      continue;
+    const std::vector<QString> & row = r.values[0];
+    for (size_t i = 0; i < row.size(); i++)
+    {
+      const int id = row[i].toInt();
+      if (id > 0)
+      {
+        ModelTexture t;
+        t.index = (int)i;
+        t.fileDataID = id;
+        t.fromDatabase = true;
+        out.push_back(t);
+      }
+    }
+    if (!out.empty())
+      return true;
+  }
+
+  // 2) Fallback for models no creature display references any more (legacy assets that are
+  //    still shipped, e.g. creature/chicken/chicken.m2): look for the conventional sibling
+  //    skin next to the model in the listfile. Existence is authoritative (the listfile knows
+  //    the file is really there); the ASSOCIATION is a naming convention, so it is reported as
+  //    such (fromDatabase = false) and logged, never presented as database truth.
+  wow::WoWFolder & folder = static_cast<wow::WoWFolder &>(GAMEDIRECTORY);
+  const QString modelPath = normalizePath(folder.fileName(m2FileDataID));
+  if (!modelPath.isEmpty() && modelPath.endsWith(".m2"))
+  {
+    const QString base = modelPath.left(modelPath.size() - 3); // drop ".m2"
+    const QString candidates[] = { base + "skin.blp", base + ".blp" };
+    for (const QString & cand : candidates)
+    {
+      const int id = folder.fileID(cand);
+      if (id > 0)
+      {
+        ModelTexture t;
+        t.index = 0;
+        t.fileDataID = id;
+        t.fromDatabase = false;
+        out.push_back(t);
+        LOG_INFO << "[unityipc] no creature display for model" << m2FileDataID
+                 << "-- using the conventional sibling skin" << cand << "(fileDataID" << id << ")";
+        return true;
+      }
+    }
+  }
+
+  error = "no texture could be resolved for this model (no creature display, no conventional skin)";
+  return false;
 }
 
 UnityAssetAccess::Result UnityAssetAccess::readByFileDataID(int fileDataID)

--- a/Source/wowmodelviewer/UnityAssetAccess.h
+++ b/Source/wowmodelviewer/UnityAssetAccess.h
@@ -18,6 +18,7 @@
 
 #include <QByteArray>
 #include <QString>
+#include <vector>
 
 class UnityAssetAccess
 {
@@ -42,6 +43,25 @@ public:
   // Read raw bytes by FileDataID. Only CASC-addressed clients support this; legacy MPQ
   // clients (name lookup only) get a clear "not supported" error.
   static Result readByFileDataID(int fileDataID);
+
+  // One texture the renderer needs for a model. Modern M2s leave "replaceable" textures
+  // (creature skins, TextureType != 0) out of the file itself: the M2's TXID entry is 0 and
+  // the texture array carries no filename, because the actual skin comes from the client
+  // database. Only WMV can answer that -- it owns the DB -- so the renderer asks for it.
+  struct ModelTexture
+  {
+    int index = 0;         // slot in the model's texture array / variation index
+    int fileDataID = 0;    // resolved texture FileDataID (fetch it with readByFileDataID)
+    bool fromDatabase = true; // true: CreatureDisplayInfo (authoritative). false: the model is
+                              // not referenced by any creature display any more (legacy asset)
+                              // and this is the conventional sibling skin found in the listfile.
+  };
+
+  // Resolve the texture(s) of a model that the M2 itself does not name, using the same
+  // CreatureDisplayInfo -> CreatureModelData relation the viewer uses for its own skin list.
+  // Returns the FIRST display's variations (the viewer's own default skin). False with a
+  // reason when there is no client, no database or no matching creature display.
+  static bool resolveModelTextures(int m2FileDataID, std::vector<ModelTexture> & out, QString & error);
 
   // Name of the active client's storage backend ("CASC"/"MPQ"/"Unknown") -- for logging.
   static QString activeProviderName();

--- a/Source/wowmodelviewer/UnityIpcServer.cpp
+++ b/Source/wowmodelviewer/UnityIpcServer.cpp
@@ -15,6 +15,7 @@
 #include "UnityIpcServer.h"
 
 #include <QCryptographicHash>
+#include <QJsonArray>
 #include <QJsonDocument>
 
 #include "UnityAssetAccess.h"
@@ -317,6 +318,10 @@ void UnityIpcServer::handleLine(const std::string & line)
   {
     handleGetAsset(msg, true);
   }
+  else if (type == "getModelTextures")
+  {
+    handleGetModelTextures(msg);
+  }
   else
   {
     LOG_ERROR << "[unityipc] unknown message type from player:" << type;
@@ -330,6 +335,48 @@ void UnityIpcServer::handleLine(const std::string & line)
       queueJson(resp);
     }
   }
+}
+
+void UnityIpcServer::handleGetModelTextures(const QJsonObject & msg)
+{
+  const QString requestId = msg.value("requestId").toString();
+  const int fdid = msg.value("fileDataID").toInt(0);
+  m_stats.requests++;
+  m_stats.lastRequest = QString("modelTextures %1").arg(fdid);
+  LOG_INFO << "[unityipc] <- getModelTextures" << requestId << "fileDataID=" << fdid;
+
+  std::vector<UnityAssetAccess::ModelTexture> textures;
+  QString error;
+  const bool ok = UnityAssetAccess::resolveModelTextures(fdid, textures, error);
+
+  QJsonObject resp;
+  resp["type"] = "modelTextures";
+  resp["requestId"] = requestId;
+  resp["ok"] = ok;
+  resp["fileDataID"] = fdid;
+  if (ok)
+  {
+    QJsonArray arr;
+    for (const UnityAssetAccess::ModelTexture & t : textures)
+    {
+      QJsonObject o;
+      o["index"] = t.index;
+      o["fileDataID"] = t.fileDataID;
+      o["source"] = t.fromDatabase ? "database" : "convention";
+      arr.append(o);
+    }
+    resp["textures"] = arr;
+    m_stats.responsesOk++;
+    LOG_INFO << "[unityipc] -> modelTextures" << requestId << "resolved" << (int)textures.size() << "texture(s)";
+  }
+  else
+  {
+    resp["error"] = error;
+    m_stats.responsesError++;
+    m_stats.lastError = error;
+    LOG_ERROR << "[unityipc] -> modelTextures" << requestId << "error:" << error;
+  }
+  queueJson(resp);
 }
 
 void UnityIpcServer::handleGetAsset(const QJsonObject & msg, bool byFileDataID)

--- a/Source/wowmodelviewer/UnityIpcServer.h
+++ b/Source/wowmodelviewer/UnityIpcServer.h
@@ -18,11 +18,19 @@
  *     { "type":"unityReady", "protocolVersion":1 }
  *     { "type":"getAsset",             "requestId":"abc123", "path":"creature/chicken/chicken.m2" }
  *     { "type":"getAssetByFileDataID", "requestId":"abc124", "fileDataID":123456 }
+ *     { "type":"getModelTextures",     "requestId":"abc125", "fileDataID":123200 }
  *   WMV -> player
  *     { "type":"loadWoWModel", "path":"creature/chicken/chicken.m2", "fileDataID":0, "client":"active" }
  *     { "type":"assetResponse", "requestId":"abc123", "ok":true, "path":"...", "fileDataID":n,
  *       "byteLength":123456, "sha1":"...", "encoding":"base64", "data":"..." }
  *     { "type":"assetResponse", "requestId":"abc123", "ok":false, "error":"not found" }
+ *     { "type":"modelTextures", "requestId":"abc125", "ok":true, "fileDataID":123200,
+ *       "textures":[ { "index":0, "fileDataID":123199 } ] }
+ *
+ * getModelTextures exists because modern M2s do NOT name their replaceable textures (a
+ * creature skin's TXID entry is 0 and the texture array carries no filename) -- the skin comes
+ * from the client database, which only WMV can read. It returns metadata only; the renderer
+ * still fetches the bytes with getAssetByFileDataID.
  *
  * Implementation: plain Winsock2, non-blocking, polled from the GUI thread by a wxTimer (the
  * app has no Qt event loop, so QTcpServer signals would never fire; and GAMEDIRECTORY must be
@@ -96,6 +104,7 @@ private:
   void pollSend();
   void handleLine(const std::string & line);
   void handleGetAsset(const QJsonObject & msg, bool byFileDataID);
+  void handleGetModelTextures(const QJsonObject & msg);
   void queueJson(const QJsonObject & obj);
   void dropClient(const char * why);
 

--- a/Source/wowmodelviewer/app.cpp
+++ b/Source/wowmodelviewer/app.cpp
@@ -285,6 +285,21 @@ static void doHeadlessUnityIpcTest(ModelViewer * frame)
       const UnityAssetAccess::Result byId = UnityAssetAccess::readByFileDataID(fdid > 0 ? fdid : 0);
       LOG_INFO << "[unityipc-test] by-FileDataID check: fileDataID=" << fdid << "ok=" << (byId.ok ? 1 : 0)
                << "bytes=" << byId.data.size() << "path=" << byId.path << "error=" << byId.error;
+
+      // Replaceable-texture metadata: modern M2s do not name creature skins, so the renderer
+      // asks WMV to resolve them from the client database (getModelTextures over IPC).
+      std::vector<UnityAssetAccess::ModelTexture> modelTextures;
+      QString texError;
+      const bool texOk = UnityAssetAccess::resolveModelTextures(fdid, modelTextures, texError);
+      LOG_INFO << "[unityipc-test] model-textures check: ok=" << (texOk ? 1 : 0)
+               << "count=" << (int)modelTextures.size() << "error=" << texError;
+      for (size_t ti = 0; ti < modelTextures.size(); ti++)
+      {
+        const UnityAssetAccess::Result tex = UnityAssetAccess::readByFileDataID(modelTextures[ti].fileDataID);
+        LOG_INFO << "[unityipc-test]   texture[" << (int)modelTextures[ti].index << "] fileDataID="
+                 << modelTextures[ti].fileDataID << "ok=" << (tex.ok ? 1 : 0)
+                 << "bytes=" << tex.data.size() << "path=" << tex.path;
+      }
     }
   }
 

--- a/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
@@ -1,0 +1,139 @@
+// The renderer's guaranteed fallback material, and the only one that can run an M2 combiner.
+//
+// A player build strips every shader no asset references, and a material built at runtime
+// references nothing at build time -- so Shader.Find("Standard"), the URP/HDRP Lit names and even
+// the default material a primitive is created with can ALL come back missing or as the magenta
+// error shader. What is left is whatever Unity always includes, and those (Sprites/Default, the
+// UI shaders) bake alpha blending, ZWrite Off and Cull Off into the pass. Those are not material
+// properties, so nothing can turn them off, and an opaque WoW material renders as a stack of
+// translucent shells.
+//
+// Anything under a Resources folder is always included in the build, so this file is the one
+// shader the player can count on. It is deliberately plain: single pass, single variant, no
+// pipeline-specific includes, and no lighting data from the engine (URP and HDRP do not feed the
+// built-in light uniforms). The key light below is fixed in world space so the model shades the
+// same way in every pipeline.
+//
+// The render state is exposed as properties, which is the point: WmvModelBuilder sets _SrcBlend,
+// _DstBlend, _ZWrite, _Cull and _Cutoff explicitly, and here those calls actually take effect.
+//
+// SECOND TEXTURE UNIT. An M2 material can combine several textures, and which arithmetic it uses
+// is selected by the material's shader id rather than described in the file. _CombinerMode carries
+// the resolved combiner id (the same numbering the legacy OpenGL viewport's GLSL combiner uses);
+// 0 means "single texture", which is the default and the behaviour of every material this shader
+// does not have a case for. It is a plain float uniform, not a shader keyword, so no extra shader
+// variants exist for a player build to strip.
+
+Shader "WMV/Opaque Textured"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+        _SecondTex ("Second texture (M2 unit 1)", 2D) = "black" {}
+        _CombinerMode ("Combiner id (0 = single texture)", Float) = 0
+        _Color ("Tint", Color) = (1,1,1,1)
+        _Cutoff ("Alpha cutoff", Range(0,1)) = 0.5
+        [Enum(UnityEngine.Rendering.CullMode)] _Cull ("Cull", Float) = 2      // Back
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend ("Src blend", Float) = 1  // One
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend ("Dst blend", Float) = 0  // Zero
+        [Toggle] _ZWrite ("ZWrite", Float) = 1
+    }
+
+    SubShader
+    {
+        // No LightMode tag: the built-in pipeline draws this as a normal opaque pass, and URP
+        // draws it through SRPDefaultUnlit, so one SubShader covers both.
+        Tags { "RenderType" = "Opaque" "Queue" = "Geometry" "IgnoreProjector" = "True" }
+
+        Cull [_Cull]
+        Blend [_SrcBlend] [_DstBlend]
+        ZWrite [_ZWrite]
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_local _ _ALPHATEST_ON
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float2 uv     : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 pos    : SV_POSITION;
+                float2 uv     : TEXCOORD0;
+                float3 normal : TEXCOORD1;
+                float2 env    : TEXCOORD2;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            sampler2D _SecondTex;
+            float _CombinerMode;
+            fixed4 _Color;
+            fixed _Cutoff;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                o.normal = UnityObjectToWorldNormal(v.normal);
+
+                // ENVIRONMENT UNIT. The M2 vertex shader for a combiner material names where each
+                // texture unit takes its coordinates from, and "Env" means the unit is fed by a
+                // sphere map generated from the view-space normal -- not by any UV set stored in
+                // the mesh. This reproduces fixed-function GL_SPHERE_MAP, which is what the legacy
+                // viewport uses for the same unit.
+                float3 viewPos = UnityObjectToViewPos(v.vertex);
+                float3 viewNrm = normalize(mul((float3x3)UNITY_MATRIX_IT_MV, v.normal));
+                float3 r = reflect(normalize(viewPos), viewNrm);
+                float m = max(2.0 * sqrt(r.x * r.x + r.y * r.y + (r.z + 1.0) * (r.z + 1.0)), 1e-4);
+                // V is inverted relative to the GL formula: a BLP's rows are uploaded flipped so
+                // that ordinary Unity UVs work, which puts this generated coordinate the other way
+                // up from the OpenGL viewport's. Without the flip the sheen sits on the wrong side.
+                o.env = float2(r.x / m + 0.5, 0.5 - r.y / m);
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                fixed4 t1 = tex2D(_MainTex, i.uv);
+                fixed4 c = t1 * _Color;
+                #ifdef _ALPHATEST_ON
+                    clip(c.a - _Cutoff);
+                #endif
+
+                // Combiner 12, "Combiners_Opaque_Mod2xNA_Alpha". The BASE texture's alpha is the
+                // mask that decides where the second unit is folded in at 2x -- it is not
+                // transparency. On a creature skin that mask is white almost everywhere and dark
+                // only on small features (chicken2 uses it for the eye pupil), so the second unit
+                // shows up exactly where the model wants a reflective highlight.
+                if (_CombinerMode > 11.5 && _CombinerMode < 12.5)
+                {
+                    fixed3 t2 = tex2D(_SecondTex, i.env).rgb;
+                    c.rgb = lerp(t1.rgb * t2 * 2.0, t1.rgb, t1.a) * _Color.rgb;
+                }
+
+                // Fixed key light + ambient. Engine light data is unavailable across pipelines,
+                // so this is a viewer light, not the scene's -- it only has to read as shape.
+                half3 n = normalize(i.normal);
+                half ndl = saturate(dot(n, normalize(half3(0.35, 0.80, -0.50))));
+                c.rgb *= 0.45h + 0.75h * ndl;
+
+                // Opaque output: the alpha channel of a WoW skin is not transparency.
+                c.a = 1.0h;
+                return c;
+            }
+            ENDCG
+        }
+    }
+
+    Fallback Off
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
@@ -15,11 +15,17 @@
 //   unityReady           { protocolVersion }
 //   getAsset             { requestId, path }
 //   getAssetByFileDataID { requestId, fileDataID }
+//   getModelTextures     { requestId, fileDataID }
 //
 // WMV -> player
 //   loadWoWModel  { path, fileDataID, client }
 //   assetResponse { requestId, ok, path, fileDataID, byteLength, sha1, encoding:"base64", data }
 //   assetResponse { requestId, ok:false, error }
+//   modelTextures { requestId, ok, fileDataID, textures:[{ index, fileDataID, source }] }
+//
+// getModelTextures exists because a modern M2 does not name its replaceable textures (a
+// creature skin's TXID entry is 0 and its texture array carries no filename) -- the skin comes
+// from the client database, which only WMV can read.
 //
 // V1 carries asset bytes as base64 inside the JSON line (simple, debuggable). A binary
 // frame (JSON header + length-prefixed payload) can replace it later without changing
@@ -44,6 +50,7 @@ public class WmvIpcClient : MonoBehaviour
     // Raised on the main thread.
     public Action<string, int, string> OnLoadWoWModel;        // (path, fileDataID, client)
     public Action<AssetResponse> OnAssetResponse;
+    public Action<ModelTexturesResponse> OnModelTextures;
     public Action<string> OnStatus;                            // human-readable connection/state text
 
     public bool Connected { get { return connected; } }
@@ -63,8 +70,32 @@ public class WmvIpcClient : MonoBehaviour
         public bool hashMatches { get { return ok && data != null && localSha1 == (sha1 ?? "").ToLowerInvariant(); } }
     }
 
+    public class ModelTextureRef
+    {
+        public int index;
+        public int fileDataID;
+        public string source = "";   // "database" (authoritative) or "convention" (legacy fallback)
+    }
+
+    public class ModelTexturesResponse
+    {
+        public string requestId;
+        public bool ok;
+        public int fileDataID;
+        public string error;
+        public ModelTextureRef[] textures = new ModelTextureRef[0];
+    }
+
+    [Serializable] class MsgTexture
+    {
+        public int index;
+        public int fileDataID;
+        public string source;
+    }
+
     [Serializable] class Msg
     {
+        public MsgTexture[] textures;
         public string type;
         public string requestId;
         public string path;
@@ -181,6 +212,27 @@ public class WmvIpcClient : MonoBehaviour
                 OnLoadWoWModel?.Invoke(msg.path ?? "", msg.fileDataID, msg.client ?? "active");
                 break;
 
+            case "modelTextures":
+            {
+                var r = new ModelTexturesResponse
+                {
+                    requestId = msg.requestId, ok = msg.ok, fileDataID = msg.fileDataID, error = msg.error,
+                };
+                if (msg.textures != null)
+                {
+                    r.textures = new ModelTextureRef[msg.textures.Length];
+                    for (int i = 0; i < msg.textures.Length; i++)
+                        r.textures[i] = new ModelTextureRef
+                        {
+                            index = msg.textures[i].index,
+                            fileDataID = msg.textures[i].fileDataID,
+                            source = msg.textures[i].source ?? "",
+                        };
+                }
+                OnModelTextures?.Invoke(r);
+                break;
+            }
+
             case "assetResponse":
             {
                 var r = new AssetResponse
@@ -238,6 +290,14 @@ public class WmvIpcClient : MonoBehaviour
     {
         var id = NewRequestId();
         Send("{\"type\":\"getAssetByFileDataID\",\"requestId\":\"" + id + "\",\"fileDataID\":" + fileDataID + "}");
+        return id;
+    }
+
+    /// <summary>Ask WMV which textures a model needs (it resolves them from the client DB).</summary>
+    public string RequestModelTextures(int fileDataID)
+    {
+        var id = NewRequestId();
+        Send("{\"type\":\"getModelTextures\",\"requestId\":\"" + id + "\",\"fileDataID\":" + fileDataID + "}");
         return id;
     }
 

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -1,36 +1,67 @@
 // WmvMain.cs
 //
-// Bootstrap for the WMV Unity viewport player -- WMV's new renderer foundation and intended
-// primary viewport (the OpenGL canvas is the legacy/fallback viewport during the migration;
-// see docs/unity-renderer/README.md). Add this component to one empty GameObject in an
-// otherwise-empty scene; at runtime it builds everything else: camera rig + orbit controls,
-// a directional light, the test cube, the on-screen status text, and the IPC client that
-// connects back to WMV.
+// Bootstrap and load orchestration for the WMV Unity viewport player -- WMV's new renderer
+// foundation and intended primary viewport (the OpenGL canvas is the legacy/fallback viewport
+// during the migration; see docs/unity-renderer/README.md).
 //
-// V1 scope: runtime asset access. On loadWoWModel the player requests the model's raw
-// bytes from WMV (getAsset / getAssetByFileDataID), verifies the assetResponse (byte
-// length + SHA-1) and reports it on screen. No M2 parsing and no mesh rendering yet --
-// that is the next step, built on top of these bytes.
+// Add this component to one empty GameObject in an otherwise-empty scene; at runtime it builds
+// the camera rig, a light, the status overlay and the IPC client that connects back to WMV.
+//
+// LOAD PIPELINE (all bytes arrive over IPC; nothing is read from or written to disk):
+//
+//   loadWoWModel(path, fileDataID)
+//     -> getAsset(path)                     the .m2 itself
+//     -> M2Parser                           header, vertices, textures, materials, SFID/TXID
+//     -> getAssetByFileDataID(SFID[0])      the .skin profile (LOD 0)
+//     -> M2SkinParser                       lookup, triangles, submeshes, batches
+//     -> textures: TXID entry when the M2 names one, otherwise getModelTextures so WMV can
+//        resolve the replaceable creature skin from the client database
+//     -> getAssetByFileDataID(texture)      the .blp
+//     -> BlpDecoder                         RGBA32 in memory
+//     -> WmvModelBuilder                    Mesh + Materials + Texture2D + GameObject
+//     -> frame the camera on the mesh bounds
+//
+// This milestone renders a STATIC model: bone data is parsed and preserved but no animation,
+// no skinning, no attachments, no particles.
 
+using System.Collections.Generic;
 using UnityEngine;
+using Wmv.Wow;
 
 public class WmvMain : MonoBehaviour
 {
     WmvIpcClient ipc;
-    GameObject testCube;
+    GameObject placeholder;
     WmvStatusOverlay status;
+    WmvOrbitCamera orbit;
 
-    string pendingRequestId;
-    string pendingWhat;
+    WmvRuntimeModel current;          // the model on screen (disposed when replaced)
+    LoadJob job;                      // in-flight load, if any
+
+    /// <summary>State for one in-flight model load.</summary>
+    class LoadJob
+    {
+        public string Path;
+        public int FileDataID;
+        public System.Diagnostics.Stopwatch Clock = System.Diagnostics.Stopwatch.StartNew();
+        public long M2Ms, SkinMs, TextureMs, ParseMs, BuildMs;
+
+        public byte[] M2Bytes;
+        public M2ParsedModel Model;
+        public M2ParsedSkin Skin;
+        public readonly Dictionary<int, BlpImage> Textures = new Dictionary<int, BlpImage>();
+
+        public string PendingM2, PendingSkin, PendingTextureList;
+        public readonly Dictionary<string, int> PendingTextures = new Dictionary<string, int>(); // requestId -> slot
+        public int TexturesExpected;
+    }
 
     void Awake()
     {
-        // The player is embedded in a host app whose window normally has focus;
-        // without this the player would pause immediately. (Also set Run In
-        // Background in Player Settings -- this is a belt-and-braces override.)
+        // The player is embedded in a host app whose window normally has focus; without this it
+        // would pause immediately. (Also set Run In Background in Player Settings.)
         Application.runInBackground = true;
 
-        // Camera rig
         var cam = Camera.main;
         if (cam == null)
         {
@@ -38,90 +69,249 @@ public class WmvMain : MonoBehaviour
             cam = camGo.AddComponent<Camera>();
             camGo.tag = "MainCamera";
         }
-        cam.transform.position = new Vector3(0f, 1.2f, -4f);
-        cam.transform.LookAt(Vector3.zero);
         cam.clearFlags = CameraClearFlags.SolidColor;
         cam.backgroundColor = new Color(0.10f, 0.10f, 0.12f);
-        cam.gameObject.AddComponent<WmvOrbitCamera>();
+        cam.nearClipPlane = 0.01f;
+        orbit = cam.gameObject.GetComponent<WmvOrbitCamera>() ?? cam.gameObject.AddComponent<WmvOrbitCamera>();
 
-        // Light
         var lightGo = new GameObject("Directional Light");
         var light = lightGo.AddComponent<Light>();
         light.type = LightType.Directional;
         light.intensity = 1.1f;
         lightGo.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
+        RenderSettings.ambientLight = new Color(0.35f, 0.35f, 0.4f);
 
-        // Proof-of-life: a visible spinning cube until real WoW models arrive.
-        testCube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-        testCube.name = "WMV Test Cube";
-        testCube.AddComponent<WmvSpin>();
+        // Proof-of-life until a real model arrives. Its default material comes from the
+        // built-in resources, which a player build may have stripped (that is what makes an
+        // untouched primitive render magenta), so give it the same shader the model builder
+        // resolved rather than leaving a confusing magenta cube on screen.
+        placeholder = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        placeholder.name = "WMV Placeholder";
+        placeholder.AddComponent<WmvSpin>();
+        var placeholderShader = WmvModelBuilder.ResolveShader(s => Debug.Log("WMV: " + s));
+        if (placeholderShader != null)
+            placeholder.GetComponent<MeshRenderer>().material = new Material(placeholderShader);
 
-        // Status text in the viewport
         status = gameObject.AddComponent<WmvStatusOverlay>();
         status.Set("Starting ...");
 
-        // IPC client (connects back to the WMV server given by -wmvPort)
         ipc = gameObject.AddComponent<WmvIpcClient>();
         ipc.OnStatus = s => status.Set(s);
         ipc.OnLoadWoWModel = HandleLoadWoWModel;
         ipc.OnAssetResponse = HandleAssetResponse;
+        ipc.OnModelTextures = HandleModelTextures;
     }
 
-    // WMV tells us which model is active. V1: fetch its raw bytes and report; V2+: parse
-    // the M2 and its skin/textures (also fetched through getAsset) and build the scene.
+    // ---------------------------------------------------------------- load pipeline
+
     void HandleLoadWoWModel(string path, int fileDataID, string client)
     {
         status.Set("Active client received (" + client + ")");
-        if (!string.IsNullOrEmpty(path))
-        {
-            pendingWhat = path;
-            pendingRequestId = ipc.RequestAsset(path);
-        }
-        else if (fileDataID > 0)
-        {
-            pendingWhat = "fileDataID " + fileDataID;
-            pendingRequestId = ipc.RequestAssetByFileDataID(fileDataID);
-        }
-        else
+        if (string.IsNullOrEmpty(path) && fileDataID <= 0)
         {
             status.Set("loadWoWModel without path or fileDataID -- ignored");
             return;
         }
-        status.Set("Requested " + pendingWhat + " ...");
-        Debug.Log("WMV IPC: requested " + pendingWhat + " (requestId " + pendingRequestId + ")");
+
+        job = new LoadJob { Path = path, FileDataID = fileDataID };
+        status.Set("Requested " + (string.IsNullOrEmpty(path) ? ("fileDataID " + fileDataID) : path));
+        job.PendingM2 = string.IsNullOrEmpty(path)
+            ? ipc.RequestAssetByFileDataID(fileDataID)
+            : ipc.RequestAsset(path);
     }
 
     void HandleAssetResponse(WmvIpcClient.AssetResponse r)
     {
-        var what = !string.IsNullOrEmpty(r.path) ? r.path : ("fileDataID " + r.fileDataID);
+        if (job == null)
+            return;
+
         if (!r.ok)
         {
-            status.Set("Error for " + what + ": " + r.error);
-            Debug.LogWarning("WMV IPC: assetResponse error for " + what + ": " + r.error);
+            // Attribute the failure to the stage that asked for it.
+            if (r.requestId == job.PendingM2) Fail("M2 request failed: " + r.error);
+            else if (r.requestId == job.PendingSkin) Fail("skin request failed: " + r.error);
+            else if (job.PendingTextures.ContainsKey(r.requestId)) TextureFailed(r.requestId, r.error);
+            else Debug.LogWarning("WMV: unexpected failed response " + r.requestId + ": " + r.error);
             return;
         }
-        var verdict = r.hashMatches ? "sha1 OK" : "sha1 MISMATCH (reported " + r.sha1 + ", local " + r.localSha1 + ")";
-        status.Set("Received " + r.byteLength + " bytes for " + what + " (" + verdict + ")");
-        Debug.Log("WMV IPC: received " + what + ": byteLength=" + r.byteLength +
-                  " decoded=" + (r.data != null ? r.data.Length : 0) + " sha1=" + r.sha1 + " " + verdict);
-        // Next step (not V1): parse r.data as M2 and request its skins/textures the same way.
+
+        if (r.requestId == job.PendingM2) OnM2Bytes(r);
+        else if (r.requestId == job.PendingSkin) OnSkinBytes(r);
+        else if (job.PendingTextures.ContainsKey(r.requestId)) OnTextureBytes(r);
+    }
+
+    void OnM2Bytes(WmvIpcClient.AssetResponse r)
+    {
+        job.M2Ms = job.Clock.ElapsedMilliseconds;
+        status.Set("Received " + r.byteLength + " bytes for " + job.Path);
+        try
+        {
+            long t0 = job.Clock.ElapsedMilliseconds;
+            job.M2Bytes = r.data;
+            job.Model = M2Parser.Parse(r.data);
+            job.ParseMs += job.Clock.ElapsedMilliseconds - t0;
+            if (job.FileDataID <= 0) job.FileDataID = r.fileDataID;
+        }
+        catch (WowParseException e) { Fail("M2 parse failed: " + e.Message); return; }
+
+        if (job.Model.SkinFileDataIDs.Length == 0)
+        {
+            Fail("model has no skin profile (SFID chunk missing) -- nothing to render");
+            return;
+        }
+        // SFID[0] is the highest-detail profile.
+        job.PendingSkin = ipc.RequestAssetByFileDataID(job.Model.SkinFileDataIDs[0]);
+    }
+
+    void OnSkinBytes(WmvIpcClient.AssetResponse r)
+    {
+        job.SkinMs = job.Clock.ElapsedMilliseconds - job.M2Ms;
+        try
+        {
+            long t0 = job.Clock.ElapsedMilliseconds;
+            job.Skin = M2SkinParser.Parse(r.data);
+            job.ParseMs += job.Clock.ElapsedMilliseconds - t0;
+        }
+        catch (WowParseException e) { Fail("skin parse failed: " + e.Message); return; }
+
+        RequestTextures();
+    }
+
+    /// <summary>
+    /// Textures the M2 names itself (TXID) are fetched directly; replaceable ones (creature
+    /// skins) have no id in the file, so WMV resolves them from the client database.
+    /// </summary>
+    void RequestTextures()
+    {
+        var direct = new List<KeyValuePair<int, int>>();   // slot -> fileDataID
+        bool needsHost = false;
+        for (int i = 0; i < job.Model.Textures.Length; i++)
+        {
+            var t = job.Model.Textures[i];
+            if (t.FileDataID > 0) direct.Add(new KeyValuePair<int, int>(i, t.FileDataID));
+            else if (t.IsReplaceable) needsHost = true;
+        }
+
+        job.TexturesExpected = direct.Count;
+        foreach (var d in direct)
+            job.PendingTextures[ipc.RequestAssetByFileDataID(d.Value)] = d.Key;
+
+        if (needsHost)
+            job.PendingTextureList = ipc.RequestModelTextures(job.FileDataID);
+        else if (direct.Count == 0)
+            BuildIfReady();
+    }
+
+    void HandleModelTextures(WmvIpcClient.ModelTexturesResponse r)
+    {
+        if (job == null || r.requestId != job.PendingTextureList)
+            return;
+        job.PendingTextureList = null;
+
+        if (!r.ok || r.textures.Length == 0)
+        {
+            // Not fatal: the mesh still renders, untextured, and the reason is visible.
+            status.Set("No texture resolved (" + (r.error ?? "none") + ") -- rendering untextured");
+            BuildIfReady();
+            return;
+        }
+
+        foreach (var t in r.textures)
+        {
+            if (t.fileDataID <= 0) continue;
+            job.TexturesExpected++;
+            job.PendingTextures[ipc.RequestAssetByFileDataID(t.fileDataID)] = t.index;
+            Debug.Log("WMV: texture slot " + t.index + " -> fileDataID " + t.fileDataID + " (" + t.source + ")");
+        }
+        if (job.TexturesExpected == 0)
+            BuildIfReady();
+    }
+
+    void OnTextureBytes(WmvIpcClient.AssetResponse r)
+    {
+        int slot = job.PendingTextures[r.requestId];
+        job.PendingTextures.Remove(r.requestId);
+        long t0 = job.Clock.ElapsedMilliseconds;
+        try
+        {
+            BlpImage img = BlpDecoder.Decode(r.data);
+            job.Textures[slot] = img;
+            Debug.Log("WMV: decoded texture slot " + slot + ": " + img.Width + "x" + img.Height +
+                      " " + img.Encoding + " (" + img.Rgba.Length + " bytes RGBA)");
+        }
+        catch (WowParseException e)
+        {
+            status.Set("Texture decode failed: " + e.Message);   // keep going: mesh without texture
+        }
+        job.TextureMs += job.Clock.ElapsedMilliseconds - t0;
+        BuildIfReady();
+    }
+
+    void TextureFailed(string requestId, string error)
+    {
+        job.PendingTextures.Remove(requestId);
+        status.Set("Texture request failed: " + error);
+        BuildIfReady();
+    }
+
+    void BuildIfReady()
+    {
+        if (job == null || job.Model == null || job.Skin == null) return;
+        if (job.PendingTextureList != null || job.PendingTextures.Count > 0) return;
+
+        try
+        {
+            long t0 = job.Clock.ElapsedMilliseconds;
+            var built = WmvModelBuilder.Build(job.Model, job.Skin, job.Textures,
+                                              string.IsNullOrEmpty(job.Model.Name) ? "WoWModel" : job.Model.Name,
+                                              s => Debug.LogWarning("WMV: " + s));
+            job.BuildMs = job.Clock.ElapsedMilliseconds - t0;
+
+            if (current != null) current.Dispose();      // never leak the previous model
+            current = built;
+            if (placeholder != null) placeholder.SetActive(false);
+
+            orbit.Frame(built.Bounds);
+
+            status.Set("Loaded " + job.Path);
+            status.Set(string.Format("Vertices {0}  Triangles {1}  Submeshes {2}  Textures {3}",
+                                     built.VertexCount, built.TriangleCount, built.SubmeshCount, job.Textures.Count));
+            status.Set(string.Format("Bounds {0} size {1}", built.Bounds.center, built.Bounds.size));
+            status.Set(string.Format("Load {0} ms (m2 {1}, skin {2}, tex {3}, parse {4}, build {5})",
+                                     job.Clock.ElapsedMilliseconds, job.M2Ms, job.SkinMs, job.TextureMs,
+                                     job.ParseMs, job.BuildMs));
+            Debug.Log(string.Format(
+                "WMV: loaded {0} -- {1} vertices, {2} triangles, {3} submeshes, {4} texture(s), bounds {5}, {6} ms",
+                job.Path, built.VertexCount, built.TriangleCount, built.SubmeshCount, job.Textures.Count,
+                built.Bounds, job.Clock.ElapsedMilliseconds));
+        }
+        catch (WowParseException e) { Fail("mesh creation failed: " + e.Message); }
+        finally { job = null; }
+    }
+
+    void Fail(string reason)
+    {
+        status.Set("FAILED: " + reason);
+        Debug.LogError("WMV: " + reason);
+        job = null;
+    }
+
+    void OnDestroy()
+    {
+        if (current != null) current.Dispose();
     }
 }
 
-// Slow idle spin so the test scene is visibly "live".
+// Slow idle spin so the placeholder scene is visibly "live".
 public class WmvSpin : MonoBehaviour
 {
-    void Update()
-    {
-        transform.Rotate(0f, 40f * Time.deltaTime, 0f);
-    }
+    void Update() { transform.Rotate(0f, 40f * Time.deltaTime, 0f); }
 }
 
-// Top-left status lines (last few messages) drawn with the immediate-mode GUI --
-// no scene/canvas setup needed.
+// Top-left status lines drawn with the immediate-mode GUI -- no scene/canvas setup needed.
 public class WmvStatusOverlay : MonoBehaviour
 {
-    const int MaxLines = 6;
+    const int MaxLines = 8;
     readonly System.Collections.Generic.List<string> lines = new System.Collections.Generic.List<string>();
     GUIStyle style;
 
@@ -129,6 +319,7 @@ public class WmvStatusOverlay : MonoBehaviour
     {
         lines.Add(line);
         while (lines.Count > MaxLines) lines.RemoveAt(0);
+        Debug.Log("WMV status: " + line);
     }
 
     void OnGUI()
@@ -138,7 +329,7 @@ public class WmvStatusOverlay : MonoBehaviour
             style = new GUIStyle(GUI.skin.label) { fontSize = 14, richText = false };
             style.normal.textColor = new Color(0.92f, 0.92f, 0.95f);
         }
-        GUI.Label(new Rect(10, 8, Screen.width - 20, 22), "WMV Unity Renderer  (V1: runtime asset access)", style);
+        GUI.Label(new Rect(10, 8, Screen.width - 20, 22), "WMV Unity Renderer  (static M2 rendering)", style);
         for (int i = 0; i < lines.Count; i++)
             GUI.Label(new Rect(10, 30 + i * 20, Screen.width - 20, 22), lines[i], style);
     }

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -1,0 +1,769 @@
+// WmvModelBuilder.cs
+//
+// Turns the parsed M2 + skin + decoded textures into a live Unity object: one Mesh with a
+// submesh per WoW batch, one Material each, textures uploaded from decoded RGBA bytes.
+//
+// Everything it creates is tracked so a later load can destroy it: meshes, materials and
+// textures are not garbage-collected by Unity on their own, so a viewer that loads model after
+// model would leak GPU memory without the explicit Dispose here.
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Wmv.Wow;
+
+public class WmvRuntimeModel
+{
+    public GameObject Root;
+    public Mesh Mesh;
+    public Material[] Materials = new Material[0];
+    public Texture2D[] Textures = new Texture2D[0];
+    public Bounds Bounds;
+    public int VertexCount, TriangleCount, SubmeshCount;
+
+    /// <summary>Destroy every runtime resource this model owns.</summary>
+    public void Dispose()
+    {
+        if (Root != null) UnityEngine.Object.Destroy(Root);
+        if (Mesh != null) UnityEngine.Object.Destroy(Mesh);
+        foreach (var m in Materials) if (m != null) UnityEngine.Object.Destroy(m);
+        foreach (var t in Textures) if (t != null) UnityEngine.Object.Destroy(t);
+        Root = null;
+        Mesh = null;
+        Materials = new Material[0];
+        Textures = new Texture2D[0];
+    }
+}
+
+public static class WmvModelBuilder
+{
+    /// <summary>
+    /// Diagnostic switches, read from the player command line. They exist to isolate a visual
+    /// fault without rebuilding: run the player (or let WMV launch it) with the flag and the
+    /// rendering changes accordingly.
+    ///
+    ///   -wmvFlipV        invert the V texture coordinate (isolates a UV-orientation fault)
+    ///   -wmvForceOpaque  force every material opaque, ignoring the WoW blend mode
+    ///   -wmvForceSolid   the whole force-solid probe: force-opaque PLUS a fully opaque alpha
+    ///                    channel on every uploaded texture, so neither the material state nor
+    ///                    the texture can make anything translucent. If the model is STILL
+    ///                    see-through with this on, the fault is geometry, depth or winding --
+    ///                    not alpha.
+    ///   -wmvMatColors    replace textures with a flat per-material colour (isolates a
+    ///                    batch/material assignment fault from a texture fault)
+    ///   -wmvShowHidden   draw the batches the model hides at rest (see BatchIsVisible). Useful
+    ///                    for seeing WHAT is hidden; the hidden geometry usually covers the
+    ///                    detail it is meant to replace.
+    ///   -wmvOwnShader    resolve the renderer's own WmvOpaque shader before any pipeline
+    ///                    shader. The pipeline's Lit shaders cannot run the M2 combiner, so this
+    ///                    is how to see the second texture unit in a build where they exist.
+    /// </summary>
+    public static class Debug_
+    {
+        static bool parsed;
+        static bool flipV, forceOpaque, forceSolid, matColors, showHidden, ownShader;
+
+        static void Parse()
+        {
+            if (parsed) return;
+            parsed = true;
+            foreach (var a in System.Environment.GetCommandLineArgs())
+            {
+                if (a == "-wmvFlipV") flipV = true;
+                else if (a == "-wmvForceOpaque") forceOpaque = true;
+                else if (a == "-wmvForceSolid") forceSolid = true;
+                else if (a == "-wmvMatColors") matColors = true;
+                else if (a == "-wmvShowHidden") showHidden = true;
+                else if (a == "-wmvOwnShader") ownShader = true;
+            }
+            if (flipV || forceOpaque || forceSolid || matColors || showHidden || ownShader)
+                Debug.Log("WMV debug switches: flipV=" + flipV + " forceOpaque=" + forceOpaque +
+                          " forceSolid=" + forceSolid + " matColors=" + matColors +
+                          " showHidden=" + showHidden + " ownShader=" + ownShader);
+        }
+
+        public static bool FlipV { get { Parse(); return flipV; } }
+        public static bool ForceOpaque { get { Parse(); return forceOpaque || forceSolid; } }
+        public static bool ForceSolid { get { Parse(); return forceSolid; } }
+        public static bool MatColors { get { Parse(); return matColors; } }
+        public static bool ShowHidden { get { Parse(); return showHidden; } }
+        public static bool OwnShader { get { Parse(); return ownShader; } }
+    }
+
+    static readonly Color[] DebugColors =
+    {
+        Color.red, Color.green, Color.blue, Color.yellow, Color.cyan, Color.magenta,
+    };
+
+    /// <summary>
+    /// Build a renderable object. decodedTextures maps an M2 texture-slot index to its decoded
+    /// pixels; a slot with no entry renders untextured (white), which is what happens for a
+    /// replaceable texture the host could not resolve.
+    /// </summary>
+    public static WmvRuntimeModel Build(M2ParsedModel model, M2ParsedSkin skin,
+                                        Dictionary<int, BlpImage> decodedTextures,
+                                        string objectName, Action<string> log)
+    {
+        if (model == null || skin == null)
+            throw new WowParseException("builder: nothing to build");
+        if (model.Vertices.Length == 0)
+            throw new WowParseException("builder: model has no vertices");
+        if (skin.Batches.Length == 0)
+            throw new WowParseException("builder: skin profile has no draw batches");
+
+        var result = new WmvRuntimeModel();
+
+        // ---- geometry: all model vertices once, converted to Unity space --------------
+        int n = model.Vertices.Length;
+        var positions = new Vector3[n];
+        var normals = new Vector3[n];
+        var uvs = new Vector2[n];
+        for (int i = 0; i < n; i++)
+        {
+            float x, y, z;
+            WowCoordinateConverter.ConvertPosition(model.Vertices[i].Position, out x, out y, out z);
+            positions[i] = new Vector3(x, y, z);
+            WowCoordinateConverter.ConvertNormal(model.Vertices[i].Normal, out x, out y, out z);
+            normals[i] = new Vector3(x, y, z);
+            float u, v;
+            WowCoordinateConverter.ConvertTexCoord(model.Vertices[i].TexCoord0, out u, out v);
+            if (Debug_.FlipV) v = 1f - v;
+            uvs[i] = new Vector2(u, v);
+        }
+
+        if (log != null && model.Vertices.Length > 0)
+        {
+            float u0, v0;
+            WowCoordinateConverter.ConvertTexCoord(model.Vertices[0].TexCoord0, out u0, out v0);
+            log(string.Format("uv: {0} vertices, set 0 used (M2 carries 2 sets); vertex 0 raw " +
+                              "({1:F4},{2:F4}) -> unity ({3:F4},{4:F4}); V flipped by converter" +
+                              (Debug_.FlipV ? " and again by -wmvFlipV" : ""),
+                              model.Vertices.Length, model.Vertices[0].TexCoord0.X,
+                              model.Vertices[0].TexCoord0.Y, uvs[0].x, uvs[0].y));
+        }
+
+        var mesh = new Mesh { name = objectName + "_mesh" };
+        mesh.indexFormat = n > 65000
+            ? UnityEngine.Rendering.IndexFormat.UInt32
+            : UnityEngine.Rendering.IndexFormat.UInt16;
+        mesh.vertices = positions;
+        mesh.normals = normals;
+        mesh.uv = uvs;
+
+        // ---- one submesh per batch ----------------------------------------------------
+        var materials = new List<Material>();
+        var textures = new List<Texture2D>();
+        // Keyed by slot AND by whether the alpha channel was discarded, because the same slot
+        // can feed an opaque batch (alpha thrown away) and a blended one (alpha kept).
+        var textureCache = new Dictionary<int, Texture2D>();
+        var triangleSets = new List<int[]>();
+        int totalTriangles = 0;
+
+        // Resolve the shader up front: whether it can run the M2 combiner decides how the base
+        // texture's alpha has to be treated, which happens before any material is created.
+        FindRenderShader(log);
+        bool combinerAvailable = ShaderHasCombiner();
+
+        // Which batches the model actually wants drawn. Decided before the loop so that a model
+        // whose every batch is hidden still renders SOMETHING: that is far more likely to be a
+        // visibility rule this milestone does not implement than a model that draws nothing.
+        var visible = new bool[skin.Batches.Length];
+        var hiddenReasons = new string[skin.Batches.Length];
+        int hiddenCount = 0;
+        for (int i = 0; i < skin.Batches.Length; i++)
+        {
+            visible[i] = BatchIsVisible(model, skin.Batches[i], out hiddenReasons[i]);
+            if (!visible[i]) hiddenCount++;
+        }
+        bool drawHidden = Debug_.ShowHidden || hiddenCount == skin.Batches.Length;
+        if (hiddenCount == skin.Batches.Length && hiddenCount > 0 && log != null)
+            log("every batch is hidden at rest -- drawing them all rather than nothing; this is " +
+                "almost certainly a visibility rule this milestone does not implement");
+
+        for (int batchIndex = 0; batchIndex < skin.Batches.Length; batchIndex++)
+        {
+            M2Batch batch = skin.Batches[batchIndex];
+            M2MaterialDef mat = (batch.MaterialIndex < model.Materials.Length)
+                ? model.Materials[batch.MaterialIndex]
+                : default(M2MaterialDef);
+            M2BlendMode mode = Debug_.ForceOpaque ? M2BlendMode.Opaque : (M2BlendMode)mat.BlendMode;
+
+            // Does the model actually want this batch drawn right now? See BatchIsVisible.
+            if (!visible[batchIndex])
+            {
+                if (log != null)
+                    log(string.Format("batch: submesh {0} is HIDDEN at rest ({1}){2}",
+                                      batch.SubmeshIndex, hiddenReasons[batchIndex],
+                                      drawHidden ? " -- drawn anyway" : " -- skipped, as the legacy viewport does"));
+                if (!drawHidden)
+                    continue;
+            }
+
+            M2Submesh submesh = skin.Submeshes[batch.SubmeshIndex];
+            int[] indices = M2SkinParser.BuildTriangles(skin, submesh, n);
+            WowCoordinateConverter.FlipWinding(indices);   // handedness change reverses winding
+            triangleSets.Add(indices);
+            totalTriangles += indices.Length / 3;
+
+            // How this material combines its texture units, resolved exactly as the legacy
+            // renderer does. This milestone implements one combiner; the rest are logged and
+            // drawn from unit 0 alone, which is what happened to every one of them before.
+            var shader = M2ShaderTable.Resolve(batch.TextureCount, batch.ShaderId);
+            bool wantsCombiner = batch.TextureCount >= 2 &&
+                                 shader.PixelShader == PixelShaderOpaqueMod2xNaAlpha &&
+                                 shader.UvSource[1] == M2UvSource.Environment &&
+                                 mode == M2BlendMode.Opaque && !Debug_.ForceSolid;
+            bool useCombiner = wantsCombiner && combinerAvailable;
+
+            int textureSlot = ResolveTextureSlot(model, batch, 0);
+            int envSlot = useCombiner ? ResolveTextureSlot(model, batch, 1) : -1;
+
+            // The base texture's ALPHA is the combiner's mask -- pixel shader 12 folds unit 1 in
+            // where alpha is low -- so it must survive when the combiner runs. Discarding it is
+            // otherwise still the right call for an opaque material: nothing downstream should be
+            // able to read a channel WoW does not treat as transparency.
+            bool dropAlpha = Debug_.ForceSolid || (mode == M2BlendMode.Opaque && !useCombiner);
+
+            Texture2D tex = GetTexture(decodedTextures, textureCache, textures, textureSlot,
+                                       dropAlpha, false, objectName);
+            // Unit 1's own alpha is unused by the combiner; it is sampled by generated sphere-map
+            // coordinates, so it must not wrap.
+            Texture2D envTex = GetTexture(decodedTextures, textureCache, textures, envSlot,
+                                          true, true, objectName);
+
+            if (log != null)
+            {
+                log(string.Format("batch: submesh {0} ({1} tris) material {2} blend {3} flags 0x{4:X} " +
+                                  "twoSided {5} depthWriteOff {6} -> texture slot {7}{8}, alpha {9}",
+                                  batch.SubmeshIndex, indices.Length / 3, batch.MaterialIndex,
+                                  (M2BlendMode)mat.BlendMode, mat.Flags, mat.TwoSided,
+                                  mat.DepthWriteDisabled, textureSlot,
+                                  tex == null ? " (no texture)" : "",
+                                  dropAlpha ? "forced to 255" : "kept (combiner mask)"));
+                log(string.Format("batch: shaderId 0x{0:X4} -> {1} / {2} (combiner {3}), {4} texture unit(s), " +
+                                  "unit 1 uv {5}{6}",
+                                  batch.ShaderId, shader.PixelShaderName, shader.VertexShaderName,
+                                  shader.PixelShader, batch.TextureCount,
+                                  batch.TextureCount >= 2 ? shader.UvSource[1].ToString() : "n/a",
+                                  useCombiner ? " -> env slot " + envSlot + " bound"
+                                              : (batch.TextureCount >= 2
+                                                 ? (wantsCombiner
+                                                    ? " -- the resolved shader cannot run the combiner, unit 1 dropped"
+                                                    : " -- this combiner is not implemented yet, unit 1 dropped")
+                                                 : "")));
+            }
+
+            materials.Add(CreateMaterial(mat, mode, tex, envTex,
+                                         objectName + "_mat" + materials.Count, log));
+        }
+
+        if (hiddenCount > 0 && !drawHidden && log != null)
+            log(string.Format("{0} of {1} batch(es) hidden at rest -- pass -wmvShowHidden to draw them",
+                              hiddenCount, skin.Batches.Length));
+
+        mesh.subMeshCount = triangleSets.Count;
+        for (int i = 0; i < triangleSets.Count; i++)
+            mesh.SetTriangles(triangleSets[i], i, true);
+        mesh.RecalculateBounds();
+
+        // ---- scene object -------------------------------------------------------------
+        var go = new GameObject(objectName);
+        go.AddComponent<MeshFilter>().sharedMesh = mesh;
+        var renderer = go.AddComponent<MeshRenderer>();
+        renderer.sharedMaterials = materials.ToArray();
+
+        result.Root = go;
+        result.Mesh = mesh;
+        result.Materials = materials.ToArray();
+        result.Textures = textures.ToArray();
+        result.Bounds = mesh.bounds;
+        result.VertexCount = n;
+        result.TriangleCount = totalTriangles;
+        result.SubmeshCount = triangleSets.Count;
+        return result;
+    }
+
+    /// <summary>M2 pixel shader 12, "Combiners_Opaque_Mod2xNA_Alpha" -- the one combiner this
+    /// milestone implements. See WmvOpaque.shader.</summary>
+    const int PixelShaderOpaqueMod2xNaAlpha = 12;
+
+    /// <summary>
+    /// Resolve one TEXTURE UNIT of a batch to an M2 texture slot.
+    ///
+    /// A batch declares how many textures it loads (TextureCount) and where its run starts in the
+    /// model's texture-combo table (TextureComboIndex); unit k is entry TextureComboIndex + k.
+    /// Reading only the first entry -- which is what this used to do -- silently discards every
+    /// unit past the first, and with it every multi-texture effect the model asks for.
+    ///
+    /// Unit 0 falls back to slot 0 when the lookup is malformed, because a model with no texture
+    /// at all is worse than a model with the wrong one. A higher unit gets no such courtesy:
+    /// guessing a texture for it would invent an effect the model never asked for.
+    /// </summary>
+    static int ResolveTextureSlot(M2ParsedModel model, M2Batch batch, int unit)
+    {
+        if (unit < 0 || unit >= batch.TextureCount)
+            return -1;
+
+        int comboIndex = batch.TextureComboIndex + unit;
+        if (comboIndex >= 0 && comboIndex < model.TextureLookup.Length)
+        {
+            int slot = model.TextureLookup[comboIndex];
+            if (slot >= 0 && slot < model.Textures.Length)
+                return slot;
+        }
+        return (unit == 0 && model.Textures.Length > 0) ? 0 : -1;
+    }
+
+    /// <summary>
+    /// Does the model want this batch drawn in its rest pose?
+    ///
+    /// A model hides geometry it is not currently using by keying an animation track to zero
+    /// rather than by leaving the geometry out: an eye overlay, a glow, a blink. chicken2 is the
+    /// worked example -- its 18-triangle eye batch points at a colour entry whose alpha track is
+    /// 0, and the actual eye is painted into the skin texture on the head underneath. Drawing
+    /// that batch anyway covers the painted eye with a flat red patch.
+    ///
+    /// This mirrors the legacy viewport's own gate (ModelRenderPass::init):
+    ///
+    ///     ocol.w &gt; 0  &amp;&amp;  (colorIndex == -1 || ecol.w &gt; 0)
+    ///
+    /// where ocol.w comes from the texture-weight track and ecol.w from the colour entry's alpha
+    /// track -- and, note, ecol stays zero when the colour entry has no RGB track at all, so such
+    /// a batch is hidden too. Only animation 0 at time 0 is considered: this milestone renders a
+    /// static pose. When the model carries none of these tracks every batch is visible, which is
+    /// the behaviour before any of this was read.
+    /// </summary>
+    static bool BatchIsVisible(M2ParsedModel model, M2Batch batch, out string reason)
+    {
+        reason = null;
+
+        // texture weight (the transparency track)
+        if (model.TextureWeights.Length > 0)
+        {
+            int weightIndex = -1;
+            if (batch.TextureWeightComboIndex < model.TextureWeightLookup.Length)
+                weightIndex = model.TextureWeightLookup[batch.TextureWeightComboIndex];
+            else if (batch.TextureWeightComboIndex < model.TextureWeights.Length)
+                weightIndex = batch.TextureWeightComboIndex;   // no lookup table: index directly
+
+            if (weightIndex >= 0 && weightIndex < model.TextureWeights.Length &&
+                model.TextureWeights[weightIndex] <= 0f)
+            {
+                reason = "texture weight " + weightIndex + " is 0";
+                return false;
+            }
+        }
+
+        // colour entry alpha
+        if (batch.HasColor && model.Colors.Length > 0)
+        {
+            if (batch.ColorIndex >= model.Colors.Length)
+                return true;                       // out of range: not our call to hide it
+            M2ColorDef c = model.Colors[batch.ColorIndex];
+            if (!c.HasColorTrack)
+            {
+                reason = "colour " + batch.ColorIndex + " has no track for animation 0";
+                return false;
+            }
+            if (c.Alpha <= 0f)
+            {
+                reason = "colour " + batch.ColorIndex + " alpha is 0";
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Upload (or reuse) one texture slot. Slots are shared between batches, so the cache is keyed
+    /// by slot AND by how the alpha channel was treated -- the same slot can feed one batch whose
+    /// alpha is the combiner mask and another where it is discarded.
+    /// </summary>
+    static Texture2D GetTexture(Dictionary<int, BlpImage> decodedTextures,
+                                Dictionary<int, Texture2D> cache, List<Texture2D> owned,
+                                int slot, bool dropAlpha, bool clamp, string objectName)
+    {
+        if (slot < 0 || decodedTextures == null)
+            return null;
+        BlpImage decoded;
+        if (!decodedTextures.TryGetValue(slot, out decoded) || decoded == null)
+            return null;
+
+        int key = slot * 4 + (dropAlpha ? 2 : 0) + (clamp ? 1 : 0);
+        Texture2D tex;
+        if (cache.TryGetValue(key, out tex))
+            return tex;
+
+        tex = CreateTexture(decoded, objectName + "_tex" + slot + (dropAlpha ? "_opaque" : ""),
+                            dropAlpha);
+        if (clamp)
+            tex.wrapMode = TextureWrapMode.Clamp;
+        cache[key] = tex;
+        owned.Add(tex);
+        return tex;
+    }
+
+    /// <summary>
+    /// Can the resolved shader run the M2 combiner? Only the renderer's own WmvOpaque shader can;
+    /// a pipeline Lit shader has one texture slot and no idea what a sphere-mapped second unit is.
+    /// Probed by property rather than by name so a future shader gets the same treatment for free.
+    /// </summary>
+    static bool ShaderHasCombiner()
+    {
+        if (combinerProbed)
+            return combinerAvailable;
+        combinerProbed = true;
+        Shader s = FindRenderShader(null);
+        if (s == null)
+            return false;
+        var probe = new Material(s);
+        combinerAvailable = probe.HasProperty(CombinerModeProperty);
+        UnityEngine.Object.Destroy(probe);
+        return combinerAvailable;
+    }
+
+    const string CombinerModeProperty = "_CombinerMode";
+    const string SecondTexProperty = "_SecondTex";
+    static bool combinerProbed, combinerAvailable;
+
+    static Texture2D CreateTexture(BlpImage img, string name, bool dropAlpha)
+    {
+        // ROW ORDER: a BLP stores its rows top-down (row 0 = top of the image), but a Unity
+        // texture's raw data starts at the BOTTOM-left. Uploading the decoded bytes as-is
+        // therefore lands the image upside down -- and since the UV converter already flips V
+        // for Unity's bottom-up convention, the two flips cancel out and the model comes back
+        // textured with the wrong part of the sheet. Flip the rows once, here, and the standard
+        // Unity convention holds everywhere downstream.
+        int stride = img.Width * 4;
+        var pixels = new byte[img.Rgba.Length];
+        for (int y = 0; y < img.Height; y++)
+            Buffer.BlockCopy(img.Rgba, y * stride, pixels, (img.Height - 1 - y) * stride, stride);
+
+        // ALPHA: on an opaque WoW material the alpha channel is not transparency, and on a real
+        // creature skin it is nowhere near solid -- chicken2's is DXT5 with ~97% of its texels
+        // below 255 (min 15, mean 240). WoW ignores it; anything on this side that lets it reach
+        // a blend or an alpha test instead draws the bird as overlapping translucent shells. So
+        // for an opaque material the channel is discarded here rather than trusted downstream.
+        if (dropAlpha)
+            for (int i = 3; i < pixels.Length; i += 4) pixels[i] = 255;
+
+        // The decoder hands over mip 0 only. Upload it with SetPixelData(level 0) and let
+        // Apply(updateMipmaps: true) build the rest -- LoadRawTextureData on a mip-chained
+        // texture would expect data for every level and reject a mip-0-sized array.
+        var tex = new Texture2D(img.Width, img.Height, TextureFormat.RGBA32, true) { name = name };
+        tex.SetPixelData(pixels, 0);
+        tex.Apply(true, false);
+        tex.wrapMode = TextureWrapMode.Repeat;
+        tex.filterMode = FilterMode.Bilinear;
+        return tex;
+    }
+
+    /// <summary>
+    /// Minimum viable material for this milestone. Two rules matter more than fidelity here:
+    ///
+    ///   * the WoW blend mode decides transparency, never the texture. A creature skin carries an
+    ///     alpha channel whether or not the model wants blending, so keying off the texture turns
+    ///     a solid bird see-through.
+    ///   * the render state is set EXPLICITLY rather than inherited from the shader's defaults,
+    ///     AND the shader is chosen so that setting it actually does something -- see
+    ///     FindRenderShader. A shader that bakes its blending into the pass ignores every
+    ///     property written here without complaining.
+    ///
+    /// This is deliberately not a full WoW material system; see the blend-mode note below.
+    /// </summary>
+    static Material CreateMaterial(M2MaterialDef def, M2BlendMode mode, Texture2D tex,
+                                   Texture2D envTex, string name, Action<string> log)
+    {
+        var shader = FindRenderShader(log);
+        // Material(null) throws; Unity's error shader is always present and at least draws
+        // geometry, so a missing shader degrades to a visible (magenta) mesh, not a failed load.
+        var m = new Material(shader != null ? shader : Shader.Find("Hidden/InternalErrorShader"))
+        {
+            name = name
+        };
+        if (tex != null && !Debug_.MatColors) m.mainTexture = tex;
+        if (m.HasProperty("_Glossiness")) m.SetFloat("_Glossiness", 0f);      // Built-in
+        else if (m.HasProperty("_Smoothness")) m.SetFloat("_Smoothness", 0f); // URP/HDRP
+
+        // Second texture unit. The property only exists on the renderer's own shader, so on every
+        // other shader this is a no-op and the material stays exactly as it was.
+        if (m.HasProperty(CombinerModeProperty))
+        {
+            bool on = envTex != null && !Debug_.MatColors;
+            if (on) m.SetTexture(SecondTexProperty, envTex);
+            m.SetFloat(CombinerModeProperty, on ? PixelShaderOpaqueMod2xNaAlpha : 0);
+        }
+
+        string treatedAs;
+        switch (mode)
+        {
+            case M2BlendMode.Opaque:
+                SetOpaque(m);
+                treatedAs = "opaque";
+                break;
+
+            // Alpha-key is a cutout in WoW. Plain Alpha is genuinely blended, but for a static
+            // V1 creature a clip is the safer reading: it keeps depth writes and solid geometry
+            // instead of risking a see-through model, and looks right for the hair/feather/eye
+            // decals creatures actually use it for. Real blending is left for the material pass.
+            case M2BlendMode.AlphaKey:
+            case M2BlendMode.Alpha:
+                treatedAs = SetAlphaClip(m, 0.5f) ? "alpha clip (cutoff 0.5)"
+                                                  : "opaque (shader has no alpha-clip property)";
+                if (mode == M2BlendMode.Alpha && log != null)
+                    log("material: blend mode Alpha is drawn as an alpha clip in this milestone");
+                break;
+
+            default:
+                SetOpaque(m);
+                treatedAs = "opaque (blend mode not implemented)";
+                if (log != null)
+                    log(string.Format("material: blend mode {0} is not implemented yet -- drawing it opaque",
+                                      def.BlendMode));
+                break;
+        }
+
+        // Only the model's own flag may disable culling; nothing here turns it off globally.
+        if (m.HasProperty("_Cull"))
+            m.SetFloat("_Cull", (float)(def.TwoSided
+                ? UnityEngine.Rendering.CullMode.Off
+                : UnityEngine.Rendering.CullMode.Back));
+
+        if (Debug_.MatColors)
+        {
+            var c = DebugColors[Mathf.Abs(name.GetHashCode()) % DebugColors.Length];
+            if (m.HasProperty("_BaseColor")) m.SetColor("_BaseColor", c);
+            if (m.HasProperty("_Color")) m.SetColor("_Color", c);
+        }
+
+        LogMaterialState(m, def, mode, treatedAs, log);
+        return m;
+    }
+
+    /// <summary>Opaque, depth-writing, geometry queue -- stated explicitly across pipelines.</summary>
+    static void SetOpaque(Material m)
+    {
+        if (m.HasProperty("_Mode")) m.SetFloat("_Mode", 0f);        // Built-in Standard
+        if (m.HasProperty("_Surface")) m.SetFloat("_Surface", 0f);  // URP/HDRP: 0 = opaque
+        if (m.HasProperty("_Blend")) m.SetFloat("_Blend", 0f);
+        if (m.HasProperty("_AlphaClip")) m.SetFloat("_AlphaClip", 0f);
+        if (m.HasProperty("_SrcBlend")) m.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+        if (m.HasProperty("_DstBlend")) m.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+        if (m.HasProperty("_ZWrite")) m.SetInt("_ZWrite", 1);
+        m.DisableKeyword("_ALPHATEST_ON");
+        m.DisableKeyword("_ALPHABLEND_ON");
+        m.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+        m.DisableKeyword("_SURFACE_TYPE_TRANSPARENT");
+        m.SetOverrideTag("RenderType", "Opaque");
+        m.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Geometry;
+    }
+
+    /// <summary>
+    /// Alpha-tested cutout: still opaque as far as depth and sorting are concerned. Returns false
+    /// when the shader exposes no cutoff at all, in which case the material is left fully opaque
+    /// -- for this milestone a solid surface beats a see-through one.
+    /// </summary>
+    static bool SetAlphaClip(Material m, float cutoff)
+    {
+        SetOpaque(m);                                                // depth/blend state first
+        if (!m.HasProperty("_Cutoff") && !m.HasProperty("_AlphaCutoff"))
+            return false;
+        if (m.HasProperty("_Mode")) m.SetFloat("_Mode", 1f);         // Built-in Standard: cutout
+        if (m.HasProperty("_AlphaClip")) m.SetFloat("_AlphaClip", 1f); // URP
+        if (m.HasProperty("_Cutoff")) m.SetFloat("_Cutoff", cutoff);
+        if (m.HasProperty("_AlphaCutoff")) m.SetFloat("_AlphaCutoff", cutoff); // HDRP
+        m.EnableKeyword("_ALPHATEST_ON");
+        m.SetOverrideTag("RenderType", "TransparentCutout");
+        m.renderQueue = (int)UnityEngine.Rendering.RenderQueue.AlphaTest;
+        return true;
+    }
+
+    /// <summary>
+    /// Report what the material ACTUALLY is at runtime, not what it was asked to be. A property
+    /// the shader does not expose reads "n/a", which is the interesting case: it could not be set,
+    /// so whatever the shader bakes into its pass is what gets drawn.
+    /// </summary>
+    static void LogMaterialState(Material m, M2MaterialDef def, M2BlendMode mode,
+                                 string treatedAs, Action<string> log)
+    {
+        if (log == null) return;
+        Shader s = m.shader;
+        log(string.Format(
+            "material '{0}': shader '{1}' (shader default queue {2}) -> treated as {3}; " +
+            "renderQueue {4} RenderType '{5}' _Mode {6} _Surface {7} _AlphaClip {8} _SrcBlend {9} " +
+            "_DstBlend {10} _ZWrite {11} _Cull {12} _CombinerMode {13} keywords [{14}]; " +
+            "WoW blend {15} depthWriteOff {16} twoSided {17}",
+            m.name, s != null ? s.name : "<none>", s != null ? s.renderQueue : -1, treatedAs,
+            m.renderQueue, m.GetTag("RenderType", false, "<unset>"),
+            Prop(m, "_Mode"), Prop(m, "_Surface"), Prop(m, "_AlphaClip"), Prop(m, "_SrcBlend"),
+            Prop(m, "_DstBlend"), Prop(m, "_ZWrite"), Prop(m, "_Cull"), Prop(m, CombinerModeProperty),
+            string.Join(",", m.shaderKeywords), mode, def.DepthWriteDisabled, def.TwoSided));
+
+        if (!shaderCanRenderOpaque)
+            log("material '" + m.name + "': the resolved shader bakes blending, depth and culling " +
+                "into its pass, so the state above is ADVISORY ONLY -- it cannot be applied and " +
+                "the model will draw see-through. Add 'Standard' (or your pipeline's Lit shader) " +
+                "to Project Settings > Graphics > Always Included Shaders and rebuild the player.");
+    }
+
+    /// <summary>A property's value, or "n/a" when the shader does not expose it.</summary>
+    static string Prop(Material m, string name)
+    {
+        return m.HasProperty(name) ? m.GetFloat(name).ToString("0.##") : "n/a";
+    }
+
+    /// <summary>
+    /// Name of the shader shipped in Assets/Resources/. A Resources folder is never stripped from
+    /// a player build, which makes this the renderer's only guaranteed-present shader.
+    /// </summary>
+    const string OpaqueShaderResource = "WmvOpaque";
+
+    // Resolved once per session; Shader.Find is not free and the answer cannot change.
+    static Shader cachedShader;
+    static bool shaderResolved;
+    static bool shaderCanRenderOpaque;
+
+    /// <summary>
+    /// A shader to draw with, whatever pipeline the project uses and whatever survived build
+    /// stripping.
+    ///
+    /// Two things make this harder in a PLAYER than in the editor: Shader.Find only sees shaders
+    /// actually included in the build (a shader no asset references is stripped -- which is why a
+    /// runtime-built material can come out magenta even though the project looks fine in the
+    /// editor), and the name differs per render pipeline.
+    ///
+    /// The third thing, and the one that actually broke the render: a candidate is not usable just
+    /// because Shader.Find returned it. Sprites/Default is always included, so it always "wins" a
+    /// naive search -- and it bakes Blend One OneMinusSrcAlpha, ZWrite Off and Cull Off into its
+    /// pass. Those are not material properties, so nothing this class writes can undo them, and an
+    /// opaque WoW material silently renders as overlapping translucent shells. Every candidate is
+    /// therefore screened by Accept() before it is taken, and the search starts from the active
+    /// pipeline's own default material rather than from a name.
+    ///
+    /// Never throws: drawing the mesh with a fallback shader beats failing the load. If nothing
+    /// opaque-capable exists, that is said plainly in the log rather than rendered quietly wrong.
+    /// </summary>
+    public static Shader ResolveShader(Action<string> log) { return FindRenderShader(log); }
+
+    static Shader FindRenderShader(Action<string> log)
+    {
+        if (shaderResolved)
+            return cachedShader;
+        shaderResolved = true;
+
+        // A shader written for one render pipeline draws MAGENTA under another, so the pipeline
+        // decides which names may even be tried. null here means the built-in pipeline.
+        bool builtIn = UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline == null;
+
+        // The pipeline's Lit shaders cannot run the M2 combiner, so -wmvOwnShader exists to make
+        // the renderer's own shader win the search and show what the combiner does.
+        if (Debug_.OwnShader &&
+            Accept(Resources.Load<Shader>(OpaqueShaderResource),
+                   "using the renderer's own '" + OpaqueShaderResource + "' shader (-wmvOwnShader)", log))
+            return cachedShader;
+
+        // Best case: a real lit shader for the pipeline in use. Shader.Find only sees what
+        // survived build stripping, and a runtime-built material references nothing at build
+        // time, so any of these can come back null in a player that looks fine in the editor.
+        string[] lit = builtIn
+            ? new[] { "Standard", "Legacy Shaders/Diffuse", "Mobile/Diffuse" }
+            : new[] { "Universal Render Pipeline/Lit", "Universal Render Pipeline/Simple Lit",
+                      "HDRP/Lit" };
+        foreach (var name in lit)
+            if (Accept(Shader.Find(name), "using shader '" + name + "'", log))
+                return cachedShader;
+
+        // Next: the material Unity gives a new primitive. Unity picks it from the ACTIVE pipeline,
+        // so it is pipeline-correct by construction -- when it exists at all. In a stripped player
+        // it can come back as the magenta error shader, which Accept() rejects.
+        var probe = GameObject.CreatePrimitive(PrimitiveType.Quad);
+        var probeRenderer = probe != null ? probe.GetComponent<MeshRenderer>() : null;
+        var probeMaterial = probeRenderer != null ? probeRenderer.sharedMaterial : null;
+        var probeShader = probeMaterial != null ? probeMaterial.shader : null;
+        if (probe != null) UnityEngine.Object.Destroy(probe);
+        if (Accept(probeShader, "no named lit shader survived build stripping -- using the active " +
+                                "pipeline's default material shader '" +
+                                (probeShader != null ? probeShader.name : "?") + "'", log))
+            return cachedShader;
+
+        // The guarantee. Assets/Resources/WmvOpaque.shader ships with the renderer and anything
+        // under a Resources folder is always included in the build, so this rung cannot be
+        // stripped away like the named lookups above. Unlit, but opaque, textured and with its
+        // render state exposed as real properties -- which is what actually matters here.
+        if (Accept(Resources.Load<Shader>(OpaqueShaderResource),
+                   "no pipeline shader survived build stripping -- using the renderer's own " +
+                   "'" + OpaqueShaderResource + "' shader. Lighting is a fixed viewer key light " +
+                   "rather than the scene's; add a Lit shader to Project Settings > Graphics > " +
+                   "Always Included Shaders and rebuild the player for full lighting.", log))
+            return cachedShader;
+
+        // Unlit but still opaque: flat lighting, correct solidity.
+        string[] unlit = builtIn
+            ? new[] { "Unlit/Texture" }
+            : new[] { "Universal Render Pipeline/Unlit", "HDRP/Unlit" };
+        foreach (var name in unlit)
+            if (Accept(Shader.Find(name),
+                       "falling back to the unlit shader '" + name + "'", log))
+                return cachedShader;
+
+        // Nothing opaque-capable left -- which should now mean Assets/Resources went missing.
+        // Take a blended shader only so that something is visible at all, and say exactly what it
+        // will look like and how to fix it.
+        cachedShader = Shader.Find("Sprites/Default");
+        shaderCanRenderOpaque = false;
+        if (log != null)
+            log(cachedShader != null
+                ? "no opaque-capable shader found in this build -- falling back to 'Sprites/Default', " +
+                  "which forces alpha blending, no depth write and no back-face culling. The model " +
+                  "WILL look see-through. Copy Assets/Resources/ into the Unity project (it holds " +
+                  "the renderer's own opaque shader) and rebuild the player."
+                : "no shader could be resolved at all -- the model will draw with Unity's error " +
+                  "shader (magenta). Copy Assets/Resources/ into the Unity project and rebuild " +
+                  "the player.");
+        return cachedShader;
+    }
+
+    /// <summary>
+    /// Take a candidate only if an opaque WoW material can actually be drawn solid with it.
+    /// A shader either exposes the blend/depth knobs (_ZWrite, _SrcBlend, _Surface, _Mode) so the
+    /// state can be set, or it is opaque already -- which its own default render queue reports:
+    /// opaque shaders sort in Geometry, baked-transparent ones in Transparent. A shader that is
+    /// neither controllable nor opaque (Sprites/Default, the UI and particle shaders) would
+    /// swallow every state call in silence, so it is skipped and the reason logged.
+    /// </summary>
+    static bool Accept(Shader s, string message, Action<string> log)
+    {
+        if (s == null)
+            return false;
+
+        // The error shader draws magenta by definition, and it sorts in the geometry queue, so
+        // the opacity test below would happily wave it through. It is never an answer.
+        if (s.name != null && s.name.StartsWith("Hidden/"))
+        {
+            if (log != null)
+                log("skipping shader '" + s.name + "': it is one of Unity's internal shaders " +
+                    "(the magenta error shader is what a stripped build hands back here)");
+            return false;
+        }
+
+        var probe = new Material(s);
+        bool controllable = probe.HasProperty("_ZWrite") || probe.HasProperty("_SrcBlend") ||
+                            probe.HasProperty("_Surface") || probe.HasProperty("_Mode");
+        UnityEngine.Object.Destroy(probe);
+
+        bool naturallyOpaque = s.renderQueue < (int)UnityEngine.Rendering.RenderQueue.AlphaTest;
+        if (!controllable && !naturallyOpaque)
+        {
+            if (log != null)
+                log("skipping shader '" + s.name + "': it bakes transparency into its pass " +
+                    "(default queue " + s.renderQueue + ", no blend or depth properties), so an " +
+                    "opaque WoW material could not be drawn solid with it");
+            return false;
+        }
+
+        cachedShader = s;
+        shaderCanRenderOpaque = true;
+        if (log != null) log(message);
+        return true;
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvOrbitCamera.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvOrbitCamera.cs
@@ -1,64 +1,152 @@
 // WmvOrbitCamera.cs
 //
-// Simple orbit/zoom/pan controls for the embedded viewport:
+// Orbit / pan / zoom controls for the embedded viewport, plus bounds-driven framing so a newly
+// loaded model is visible immediately without touching the camera:
 //   left-drag  = orbit around the pivot
 //   right-drag = pan the pivot
 //   wheel      = zoom
-// Attached to the main camera by WmvMain.
+//
+// Frame() derives everything from the mesh bounds and the camera's own field of view -- there
+// are no per-model constants, so a chicken and a dragon both land nicely in view.
+//
+// INPUT BACKENDS
+//   The player must work in whatever project it is dropped into, so mouse reading is compiled
+//   against whichever backend is active:
+//
+//     Active Input Handling = "Input Manager (Old)"  -> ENABLE_LEGACY_INPUT_MANAGER
+//     Active Input Handling = "Input System (New)"   -> ENABLE_INPUT_SYSTEM
+//     Active Input Handling = "Both"                 -> both defined; the legacy path is used
+//
+//   Reading UnityEngine.Input while only the new backend is active throws
+//   InvalidOperationException *every frame*, which is what a plain Input.mousePosition call did
+//   here. If neither backend is available the camera keeps framing models and simply does not
+//   respond to the mouse, warning exactly once instead of once per frame.
 
 using UnityEngine;
+#if !ENABLE_LEGACY_INPUT_MANAGER && ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 public class WmvOrbitCamera : MonoBehaviour
 {
     public Vector3 pivot = Vector3.zero;
     public float distance = 4f;
-    public float yaw = 0f;
-    public float pitch = 20f;
+    public float yaw = 30f;
+    public float pitch = 15f;
 
-    const float OrbitSpeed = 0.25f;   // degrees per pixel
-    const float PanSpeed = 0.0025f;   // world units per pixel per distance
+    const float OrbitSpeed = 0.25f;    // degrees per pixel
+    const float PanSpeed = 0.0025f;    // world units per pixel, scaled by distance
     const float ZoomSpeed = 0.12f;
-    const float MinDistance = 0.2f;
-    const float MaxDistance = 200f;
+    const float MinDistance = 0.05f;
+    const float MaxDistance = 500f;
 
     Vector3 lastMouse;
+    bool warnedNoInput;
 
-    void Start()
+    void Start() { Apply(); }
+
+    /// <summary>
+    /// Point the camera at a model's bounds from a three-quarter angle, far enough back that
+    /// the whole thing fits the vertical field of view with a small margin.
+    /// </summary>
+    public void Frame(Bounds bounds)
     {
+        pivot = bounds.center;
+
+        float radius = bounds.extents.magnitude;
+        if (radius <= 0.0001f) radius = 1f;
+
+        var cam = GetComponent<Camera>();
+        float fov = (cam != null ? cam.fieldOfView : 60f) * Mathf.Deg2Rad;
+        distance = Mathf.Clamp(radius / Mathf.Max(0.05f, Mathf.Sin(fov * 0.5f)) * 1.25f,
+                               MinDistance, MaxDistance);
+
+        // Keep near/far sane for models that span a few centimetres or a few hundred metres.
+        if (cam != null)
+        {
+            cam.nearClipPlane = Mathf.Max(0.01f, distance * 0.01f);
+            cam.farClipPlane = Mathf.Max(100f, distance * 20f);
+        }
+
+        yaw = 30f;
+        pitch = 15f;
         Apply();
+    }
+
+    // ---------------------------------------------------------------- input backends
+
+    /// <summary>True when a mouse could be read at all (false disables orbit input silently).</summary>
+    bool ReadMouse(out Vector3 position, out bool leftHeld, out bool rightHeld, out float scroll)
+    {
+        position = Vector3.zero;
+        leftHeld = rightHeld = false;
+        scroll = 0f;
+
+#if ENABLE_LEGACY_INPUT_MANAGER
+        position = Input.mousePosition;
+        leftHeld = Input.GetMouseButton(0);
+        rightHeld = Input.GetMouseButton(1);
+        scroll = Input.GetAxis("Mouse ScrollWheel");
+        return true;
+#elif ENABLE_INPUT_SYSTEM
+        var mouse = Mouse.current;
+        if (mouse == null)
+            return false;
+        Vector2 p = mouse.position.ReadValue();
+        position = new Vector3(p.x, p.y, 0f);
+        leftHeld = mouse.leftButton.isPressed;
+        rightHeld = mouse.rightButton.isPressed;
+        // The legacy axis is normalised to roughly +/-0.1 per notch; the Input System reports
+        // raw scroll units (120 per notch on Windows). Scale so both feel the same.
+        scroll = mouse.scroll.ReadValue().y / 1200f;
+        return true;
+#else
+        if (!warnedNoInput)
+        {
+            warnedNoInput = true;
+            Debug.LogWarning("WMV: no input backend is available (neither the legacy Input " +
+                             "Manager nor the Input System package) -- camera orbit is disabled. " +
+                             "Models are still framed automatically.");
+        }
+        return false;
+#endif
     }
 
     void Update()
     {
-        var mouse = Input.mousePosition;
+        Vector3 mouse;
+        bool leftHeld, rightHeld;
+        float scroll;
+        if (!ReadMouse(out mouse, out leftHeld, out rightHeld, out scroll))
+            return;
+
         var delta = mouse - lastMouse;
+        bool hadMouse = lastMouse != Vector3.zero;
         lastMouse = mouse;
+        if (!hadMouse)
+            return;    // first frame: no meaningful delta yet
 
         bool changed = false;
-
-        if (Input.GetMouseButton(0) && !Input.GetMouseButtonDown(0))
+        if (leftHeld)
         {
             yaw += delta.x * OrbitSpeed;
             pitch = Mathf.Clamp(pitch - delta.y * OrbitSpeed, -89f, 89f);
             changed = true;
         }
-        else if (Input.GetMouseButton(1) && !Input.GetMouseButtonDown(1))
+        else if (rightHeld)
         {
-            var t = transform;
-            pivot -= t.right * (delta.x * PanSpeed * distance);
-            pivot -= t.up * (delta.y * PanSpeed * distance);
+            pivot -= transform.right * (delta.x * PanSpeed * distance);
+            pivot -= transform.up * (delta.y * PanSpeed * distance);
             changed = true;
         }
 
-        var scroll = Input.GetAxis("Mouse ScrollWheel");
         if (Mathf.Abs(scroll) > 0.0001f)
         {
             distance = Mathf.Clamp(distance * (1f - scroll * ZoomSpeed * 10f), MinDistance, MaxDistance);
             changed = true;
         }
 
-        if (changed)
-            Apply();
+        if (changed) Apply();
     }
 
     void Apply()

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/BlpDecoder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/BlpDecoder.cs
@@ -1,0 +1,301 @@
+// BlpDecoder.cs
+//
+// Runtime BLP2 decoder: the texture bytes WMV serves over IPC become a plain RGBA32 pixel
+// array the Unity side uploads straight into a Texture2D. Nothing is written to disk -- no
+// PNG, no DDS, no intermediate file of any kind.
+//
+// BLP2 header (little-endian):
+//   0x00  char   magic[4]        "BLP2"
+//   0x04  uint32 version         1
+//   0x08  uint8  colorEncoding   1 = palettized, 2 = DXT, 3 = uncompressed BGRA
+//   0x09  uint8  alphaSize       0, 1, 4 or 8 bits
+//   0x0A  uint8  preferredFormat DXT selector when colorEncoding == 2
+//   0x0B  uint8  hasMips
+//   0x0C  uint32 width
+//   0x10  uint32 height
+//   0x14  uint32 mipOffsets[16]
+//   0x54  uint32 mipSizes[16]
+//   0x94  uint32 palette[256]    BGRA, only meaningful for colorEncoding 1
+//   0x494 pixel data
+//
+// SUPPORTED ENCODINGS
+//   1 (palettized, alphaSize 0/1/4/8) and 2 (DXT1/DXT3/DXT5) -- between them these cover
+//   creature skins, which is what this milestone renders. Encoding 3 (raw BGRA) is also
+//   handled since it is a two-line case. Anything else raises WowParseException naming the
+//   encoding, so an unsupported texture is reported rather than decoded into garbage.
+
+using System;
+
+namespace Wmv.Wow
+{
+    public class BlpImage
+    {
+        public int Width, Height;
+        public byte[] Rgba;          // Width*Height*4, RGBA order, top row first
+        public int MipLevel;
+        public string Encoding = ""; // human-readable, for diagnostics
+        public bool HasAlpha;
+    }
+
+    public static class BlpDecoder
+    {
+        const int HeaderSize = 0x494;
+
+        /// <summary>Decode one mip level (default: the largest) to RGBA32.</summary>
+        public static BlpImage Decode(byte[] file, int mipLevel = 0)
+        {
+            if (file == null || file.Length < HeaderSize)
+                throw new WowParseException(string.Format(
+                    "blp: asset is {0} bytes, smaller than the {1}-byte header", file == null ? 0 : file.Length, HeaderSize));
+
+            var c = new ByteCursor(file, "blp");
+            string magic = c.ReadMagic();
+            if (magic != "BLP2")
+                throw new WowParseException("blp: expected a BLP2 header, found '" + magic + "'");
+            uint version = c.ReadUInt32();
+            if (version != 1)
+                throw new WowParseException("blp: unsupported BLP2 version " + version);
+
+            byte colorEncoding = c.ReadByte();
+            byte alphaSize = c.ReadByte();
+            byte preferredFormat = c.ReadByte();
+            c.ReadByte();  // hasMips
+            int width = (int)c.ReadUInt32();
+            int height = (int)c.ReadUInt32();
+            if (width <= 0 || height <= 0 || width > 16384 || height > 16384)
+                throw new WowParseException(string.Format("blp: implausible dimensions {0}x{1}", width, height));
+
+            var mipOffsets = new uint[16];
+            var mipSizes = new uint[16];
+            for (int i = 0; i < 16; i++) mipOffsets[i] = c.ReadUInt32();
+            for (int i = 0; i < 16; i++) mipSizes[i] = c.ReadUInt32();
+
+            if (mipLevel < 0 || mipLevel > 15 || mipSizes[mipLevel] == 0)
+                throw new WowParseException("blp: mip level " + mipLevel + " is not present");
+
+            int mipWidth = Math.Max(1, width >> mipLevel);
+            int mipHeight = Math.Max(1, height >> mipLevel);
+            int dataOffset = (int)mipOffsets[mipLevel];
+            int dataSize = (int)mipSizes[mipLevel];
+            c.Require(dataOffset, dataSize);
+
+            var img = new BlpImage
+            {
+                Width = mipWidth,
+                Height = mipHeight,
+                MipLevel = mipLevel,
+                Rgba = new byte[mipWidth * mipHeight * 4],
+                HasAlpha = alphaSize > 0,
+            };
+
+            switch (colorEncoding)
+            {
+                case 1:
+                    img.Encoding = "palettized/a" + alphaSize;
+                    DecodePalettized(file, c, dataOffset, dataSize, alphaSize, img);
+                    break;
+                case 2:
+                    img.Encoding = DxtName(preferredFormat, alphaSize);
+                    DecodeDxt(file, c, dataOffset, dataSize, preferredFormat, alphaSize, img);
+                    break;
+                case 3:
+                    img.Encoding = "bgra8888";
+                    DecodeRawBgra(file, c, dataOffset, dataSize, img);
+                    break;
+                default:
+                    throw new WowParseException(string.Format(
+                        "blp: unsupported colorEncoding {0} (alphaSize {1}, preferredFormat {2}) -- " +
+                        "only palettized (1), DXT (2) and raw BGRA (3) are implemented",
+                        colorEncoding, alphaSize, preferredFormat));
+            }
+            return img;
+        }
+
+        static string DxtName(byte preferredFormat, byte alphaSize)
+        {
+            if (preferredFormat == 0 || alphaSize <= 1) return "dxt1";
+            if (preferredFormat == 1) return "dxt3";
+            return "dxt5";
+        }
+
+        // ---------------------------------------------------------------- palettized
+
+        static void DecodePalettized(byte[] file, ByteCursor c, int dataOffset, int dataSize,
+                                     byte alphaSize, BlpImage img)
+        {
+            int pixels = img.Width * img.Height;
+            if (dataSize < pixels)
+                throw new WowParseException(string.Format(
+                    "blp: palettized mip holds {0} bytes for {1} pixels", dataSize, pixels));
+
+            // palette entries are BGRA
+            const int PaletteOffset = 0x94;
+            c.Require(PaletteOffset, 256 * 4);
+
+            int alphaOffset = dataOffset + pixels;
+            int alphaBytes = alphaSize == 8 ? pixels
+                           : alphaSize == 4 ? (pixels + 1) / 2
+                           : alphaSize == 1 ? (pixels + 7) / 8
+                           : 0;
+            if (alphaBytes > 0)
+                c.Require(alphaOffset, alphaBytes);
+
+            for (int i = 0; i < pixels; i++)
+            {
+                int p = file[dataOffset + i] * 4;
+                img.Rgba[i * 4 + 0] = file[PaletteOffset + p + 2];  // R  (palette is BGRA)
+                img.Rgba[i * 4 + 1] = file[PaletteOffset + p + 1];  // G
+                img.Rgba[i * 4 + 2] = file[PaletteOffset + p + 0];  // B
+
+                byte a = 255;
+                switch (alphaSize)
+                {
+                    case 8: a = file[alphaOffset + i]; break;
+                    case 4:
+                    {
+                        byte both = file[alphaOffset + (i >> 1)];
+                        int nibble = ((i & 1) == 0) ? (both & 0x0F) : (both >> 4);
+                        a = (byte)(nibble * 17);   // 0..15 -> 0..255
+                        break;
+                    }
+                    case 1:
+                    {
+                        byte bits = file[alphaOffset + (i >> 3)];
+                        a = (byte)(((bits >> (i & 7)) & 1) != 0 ? 255 : 0);
+                        break;
+                    }
+                }
+                img.Rgba[i * 4 + 3] = a;
+            }
+        }
+
+        // ---------------------------------------------------------------- raw BGRA
+
+        static void DecodeRawBgra(byte[] file, ByteCursor c, int dataOffset, int dataSize, BlpImage img)
+        {
+            int pixels = img.Width * img.Height;
+            if (dataSize < pixels * 4)
+                throw new WowParseException(string.Format(
+                    "blp: raw mip holds {0} bytes for {1} pixels", dataSize, pixels));
+            for (int i = 0; i < pixels; i++)
+            {
+                img.Rgba[i * 4 + 0] = file[dataOffset + i * 4 + 2];
+                img.Rgba[i * 4 + 1] = file[dataOffset + i * 4 + 1];
+                img.Rgba[i * 4 + 2] = file[dataOffset + i * 4 + 0];
+                img.Rgba[i * 4 + 3] = file[dataOffset + i * 4 + 3];
+            }
+        }
+
+        // ---------------------------------------------------------------- DXT
+
+        static void DecodeDxt(byte[] file, ByteCursor c, int dataOffset, int dataSize,
+                              byte preferredFormat, byte alphaSize, BlpImage img)
+        {
+            string kind = DxtName(preferredFormat, alphaSize);
+            int blockBytes = (kind == "dxt1") ? 8 : 16;
+            int blocksX = Math.Max(1, (img.Width + 3) / 4);
+            int blocksY = Math.Max(1, (img.Height + 3) / 4);
+            long needed = (long)blocksX * blocksY * blockBytes;
+            if (dataSize < needed)
+                throw new WowParseException(string.Format(
+                    "blp: {0} mip holds {1} bytes, needs {2} for {3}x{4}", kind, dataSize, needed, img.Width, img.Height));
+
+            var color = new byte[16 * 4];
+            for (int by = 0; by < blocksY; by++)
+            {
+                for (int bx = 0; bx < blocksX; bx++)
+                {
+                    int block = dataOffset + (by * blocksX + bx) * blockBytes;
+                    int colorBlock = (kind == "dxt1") ? block : block + 8;
+                    DecodeColorBlock(file, colorBlock, kind == "dxt1", color);
+
+                    if (kind == "dxt3") DecodeAlphaBlockExplicit(file, block, color);
+                    else if (kind == "dxt5") DecodeAlphaBlockInterpolated(file, block, color);
+
+                    for (int py = 0; py < 4; py++)
+                    {
+                        int y = by * 4 + py;
+                        if (y >= img.Height) break;
+                        for (int px = 0; px < 4; px++)
+                        {
+                            int x = bx * 4 + px;
+                            if (x >= img.Width) break;
+                            int src = (py * 4 + px) * 4;
+                            int dst = (y * img.Width + x) * 4;
+                            img.Rgba[dst + 0] = color[src + 0];
+                            img.Rgba[dst + 1] = color[src + 1];
+                            img.Rgba[dst + 2] = color[src + 2];
+                            img.Rgba[dst + 3] = color[src + 3];
+                        }
+                    }
+                }
+            }
+        }
+
+        static void DecodeColorBlock(byte[] f, int o, bool dxt1, byte[] outRgba)
+        {
+            ushort c0 = (ushort)(f[o] | (f[o + 1] << 8));
+            ushort c1 = (ushort)(f[o + 2] | (f[o + 3] << 8));
+            uint bits = (uint)(f[o + 4] | (f[o + 5] << 8) | (f[o + 6] << 16) | (f[o + 7] << 24));
+
+            var r = new byte[4]; var g = new byte[4]; var b = new byte[4]; var a = new byte[4];
+            Rgb565(c0, out r[0], out g[0], out b[0]); a[0] = 255;
+            Rgb565(c1, out r[1], out g[1], out b[1]); a[1] = 255;
+
+            if (!dxt1 || c0 > c1)
+            {
+                r[2] = (byte)((2 * r[0] + r[1]) / 3); g[2] = (byte)((2 * g[0] + g[1]) / 3); b[2] = (byte)((2 * b[0] + b[1]) / 3); a[2] = 255;
+                r[3] = (byte)((r[0] + 2 * r[1]) / 3); g[3] = (byte)((g[0] + 2 * g[1]) / 3); b[3] = (byte)((b[0] + 2 * b[1]) / 3); a[3] = 255;
+            }
+            else
+            {
+                r[2] = (byte)((r[0] + r[1]) / 2); g[2] = (byte)((g[0] + g[1]) / 2); b[2] = (byte)((b[0] + b[1]) / 2); a[2] = 255;
+                r[3] = 0; g[3] = 0; b[3] = 0; a[3] = 0;   // punch-through transparent
+            }
+
+            for (int i = 0; i < 16; i++)
+            {
+                int sel = (int)((bits >> (i * 2)) & 3);
+                outRgba[i * 4 + 0] = r[sel];
+                outRgba[i * 4 + 1] = g[sel];
+                outRgba[i * 4 + 2] = b[sel];
+                outRgba[i * 4 + 3] = a[sel];
+            }
+        }
+
+        static void Rgb565(ushort v, out byte r, out byte g, out byte b)
+        {
+            r = (byte)(((v >> 11) & 0x1F) * 255 / 31);
+            g = (byte)(((v >> 5) & 0x3F) * 255 / 63);
+            b = (byte)((v & 0x1F) * 255 / 31);
+        }
+
+        static void DecodeAlphaBlockExplicit(byte[] f, int o, byte[] outRgba)   // DXT3
+        {
+            for (int i = 0; i < 16; i++)
+            {
+                byte both = f[o + (i >> 1)];
+                int nibble = ((i & 1) == 0) ? (both & 0x0F) : (both >> 4);
+                outRgba[i * 4 + 3] = (byte)(nibble * 17);
+            }
+        }
+
+        static void DecodeAlphaBlockInterpolated(byte[] f, int o, byte[] outRgba)   // DXT5
+        {
+            var a = new byte[8];
+            a[0] = f[o]; a[1] = f[o + 1];
+            if (a[0] > a[1])
+                for (int i = 0; i < 6; i++) a[2 + i] = (byte)(((6 - i) * a[0] + (1 + i) * a[1]) / 7);
+            else
+            {
+                for (int i = 0; i < 4; i++) a[2 + i] = (byte)(((4 - i) * a[0] + (1 + i) * a[1]) / 5);
+                a[6] = 0; a[7] = 255;
+            }
+
+            ulong bits = 0;
+            for (int i = 0; i < 6; i++) bits |= (ulong)f[o + 2 + i] << (8 * i);
+            for (int i = 0; i < 16; i++)
+                outRgba[i * 4 + 3] = a[(int)((bits >> (i * 3)) & 7)];
+        }
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/ByteCursor.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/ByteCursor.cs
@@ -1,0 +1,136 @@
+// ByteCursor.cs
+//
+// Bounds-checked little-endian reader for the raw WoW asset bytes WMV serves over IPC.
+// Every read validates against the buffer length, so a truncated or malformed asset raises
+// WowParseException with a useful message instead of throwing IndexOutOfRange somewhere deep
+// in a parser -- or, worse, silently reading neighbouring memory.
+//
+// Deliberately free of UnityEngine references: the whole parsing layer is plain C# so it can
+// be unit-tested outside the editor.
+
+using System;
+
+namespace Wmv.Wow
+{
+    /// <summary>A malformed, truncated or unsupported WoW asset. Always carries context.</summary>
+    public class WowParseException : Exception
+    {
+        public WowParseException(string message) : base(message) { }
+    }
+
+    public struct ByteCursor
+    {
+        readonly byte[] data;
+        readonly string what;   // asset description, for error messages
+        int pos;
+
+        public ByteCursor(byte[] data, string what, int start = 0)
+        {
+            if (data == null) throw new WowParseException((what ?? "asset") + ": no data");
+            this.data = data;
+            this.what = what ?? "asset";
+            this.pos = start;
+        }
+
+        public int Position { get { return pos; } set { Require(value, 0); pos = value; } }
+        public int Length { get { return data.Length; } }
+        public byte[] Data { get { return data; } }
+
+        /// <summary>Throws unless [offset, offset+count) lies inside the buffer.</summary>
+        public void Require(int offset, int count)
+        {
+            if (offset < 0 || count < 0 || offset > data.Length || count > data.Length - offset)
+                throw new WowParseException(string.Format(
+                    "{0}: read of {1} byte(s) at offset {2} is outside the {3}-byte asset",
+                    what, count, offset, data.Length));
+        }
+
+        public void Seek(int offset)
+        {
+            Require(offset, 0);
+            pos = offset;
+        }
+
+        public byte ReadByte()
+        {
+            Require(pos, 1);
+            return data[pos++];
+        }
+
+        public sbyte ReadSByte() { return (sbyte)ReadByte(); }
+
+        public ushort ReadUInt16()
+        {
+            Require(pos, 2);
+            ushort v = (ushort)(data[pos] | (data[pos + 1] << 8));
+            pos += 2;
+            return v;
+        }
+
+        public short ReadInt16() { return (short)ReadUInt16(); }
+
+        public uint ReadUInt32()
+        {
+            Require(pos, 4);
+            uint v = (uint)(data[pos] | (data[pos + 1] << 8) | (data[pos + 2] << 16) | (data[pos + 3] << 24));
+            pos += 4;
+            return v;
+        }
+
+        public int ReadInt32() { return (int)ReadUInt32(); }
+
+        public float ReadSingle()
+        {
+            uint bits = ReadUInt32();
+            float f = BitConverter.ToSingle(BitConverter.GetBytes(bits), 0);
+            if (float.IsNaN(f) || float.IsInfinity(f))
+                throw new WowParseException(string.Format("{0}: non-finite float at offset {1}", what, pos - 4));
+            return f;
+        }
+
+        public string ReadMagic()
+        {
+            Require(pos, 4);
+            string s = string.Format("{0}{1}{2}{3}", (char)data[pos], (char)data[pos + 1],
+                                                     (char)data[pos + 2], (char)data[pos + 3]);
+            pos += 4;
+            return s;
+        }
+
+        /// <summary>
+        /// An M2Array: a (count, offset) pair. The offset is relative to the start of the
+        /// structure the array belongs to (for an M2 that is the MD21 payload, not the file),
+        /// which is why the caller passes the base it should be resolved against.
+        /// </summary>
+        public M2Array ReadArray()
+        {
+            uint count = ReadUInt32();
+            uint offset = ReadUInt32();
+            return new M2Array((int)count, (int)offset);
+        }
+
+        /// <summary>Validate that an array of fixed-size elements fits inside the buffer.</summary>
+        public void RequireArray(M2Array arr, int elementSize, string name)
+        {
+            if (arr.Count == 0)
+                return;
+            if (arr.Count < 0 || arr.Offset < 0)
+                throw new WowParseException(string.Format("{0}: {1} has a negative count/offset ({2}/{3})",
+                                                          what, name, arr.Count, arr.Offset));
+            long bytes = (long)arr.Count * elementSize;
+            if (bytes > int.MaxValue)
+                throw new WowParseException(string.Format("{0}: {1} claims {2} elements -- implausible",
+                                                          what, name, arr.Count));
+            Require(arr.Offset, (int)bytes);
+        }
+    }
+
+    /// <summary>(count, offset) pair as stored in M2/skin headers.</summary>
+    public struct M2Array
+    {
+        public readonly int Count;
+        public readonly int Offset;
+        public M2Array(int count, int offset) { Count = count; Offset = offset; }
+        public override string ToString() { return string.Format("count={0} offset={1}", Count, Offset); }
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -60,6 +60,40 @@ namespace Wmv.Wow
         public bool DepthWriteDisabled { get { return (Flags & 0x10) != 0; } }
     }
 
+    /// <summary>
+    /// One entry of the M2 "colors" array, reduced to what a static render needs.
+    ///
+    /// Each entry holds two animation tracks -- an RGB track and an alpha track -- and a draw
+    /// batch points at one of them through its ColorIndex. The alpha track is how a model hides
+    /// geometry it does not currently want drawn: an eye overlay, a glow, a blink. The legacy
+    /// OpenGL renderer refuses to draw a batch whose entry resolves to zero alpha, which is why
+    /// a model can ship geometry that is never visible at rest.
+    ///
+    /// Only the value at the start of animation 0 is kept: this milestone renders a static pose.
+    /// </summary>
+    public struct M2ColorDef
+    {
+        /// <summary>The RGB track carries data for animation 0. When it does not, the legacy
+        /// renderer treats the batch as invisible rather than as untinted.</summary>
+        public bool HasColorTrack;
+
+        /// <summary>Alpha at the start of animation 0; 1 when the track carries no data.</summary>
+        public float Alpha;
+    }
+
+    /// <summary>
+    /// Where a texture unit takes its texture coordinates from. Matches the codes the OpenGL
+    /// renderer uses in ModelRenderPass::uvSource, which are derived from the material's vertex
+    /// shader name (Diffuse_T1_Env -> unit 0 = T1, unit 1 = Env).
+    /// </summary>
+    public enum M2UvSource
+    {
+        TexCoord0 = 0,
+        TexCoord1 = 1,
+        Environment = 2,   // sphere map generated from the view-space normal, not a stored UV set
+        TexCoord2 = 3,
+    }
+
     public enum M2BlendMode
     {
         Opaque = 0,
@@ -82,6 +116,16 @@ namespace Wmv.Wow
         public M2TextureDef[] Textures = new M2TextureDef[0];
         public M2MaterialDef[] Materials = new M2MaterialDef[0];
         public ushort[] TextureLookup = new ushort[0];   // batch.textureComboIndex -> texture index
+
+        /// <summary>The "colors" array: batch.ColorIndex selects one. Empty when the header is
+        /// too short to carry it, in which case every batch is treated as visible.</summary>
+        public M2ColorDef[] Colors = new M2ColorDef[0];
+
+        /// <summary>The "texture_weights" array, resolved to the value at animation 0 time 0.
+        /// A batch reaches one through TextureWeightLookup[batch.TextureWeightComboIndex].</summary>
+        public float[] TextureWeights = new float[0];
+
+        public ushort[] TextureWeightLookup = new ushort[0];
         public int SkinProfileCount;
         public int[] SkinFileDataIDs = new int[0];       // SFID chunk
         public int[] TextureFileDataIDs = new int[0];    // TXID chunk (0 where replaceable)
@@ -113,6 +157,20 @@ namespace Wmv.Wow
         public ushort MaterialLayer;
         public ushort TextureCount;
         public ushort TextureComboIndex;
+
+        /// <summary>Indexes the model's texture-coord-combo table, one entry per texture unit.
+        /// Parsed for completeness; modern creature M2s ship an empty table and take their
+        /// per-unit UV routing from the shader id instead. 0xFFFF means "none".</summary>
+        public ushort TextureCoordComboIndex;
+
+        /// <summary>Indexes the model's texture-weight-combo table -- the second animated input
+        /// to the legacy renderer's visibility gate.</summary>
+        public ushort TextureWeightComboIndex;
+
+        public ushort TextureTransformComboIndex;
+
+        /// <summary>No colour entry: the legacy renderer's gate ignores the colour track.</summary>
+        public bool HasColor { get { return ColorIndex != 0xFFFF; } }
     }
 
     /// <summary>A parsed .skin profile.</summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -1,0 +1,128 @@
+// M2Model.cs
+//
+// Plain result types for the runtime M2/skin parsers. No UnityEngine types: the parsing layer
+// stays testable outside the editor, and the Unity-side builder converts these into Mesh /
+// Material / Texture2D.
+
+namespace Wmv.Wow
+{
+    public struct WowVec2
+    {
+        public float X, Y;
+        public WowVec2(float x, float y) { X = x; Y = y; }
+    }
+
+    public struct WowVec3
+    {
+        public float X, Y, Z;
+        public WowVec3(float x, float y, float z) { X = x; Y = y; Z = z; }
+        public override string ToString() { return string.Format("({0:F3}, {1:F3}, {2:F3})", X, Y, Z); }
+    }
+
+    /// <summary>One M2 vertex (48 bytes on disk).</summary>
+    public struct M2Vertex
+    {
+        public WowVec3 Position;
+        public WowVec3 Normal;
+        public WowVec2 TexCoord0;
+        public WowVec2 TexCoord1;
+        public byte BoneWeight0, BoneWeight1, BoneWeight2, BoneWeight3;   // preserved, unused in the static milestone
+        public byte BoneIndex0, BoneIndex1, BoneIndex2, BoneIndex3;
+    }
+
+    /// <summary>
+    /// An M2 texture slot. Type 0 carries a real filename in the file; any other type is a
+    /// "replaceable" texture (creature skin, item skin, ...) whose actual asset lives in the
+    /// client database -- for those the renderer asks WMV (getModelTextures).
+    /// </summary>
+    public struct M2TextureDef
+    {
+        public uint Type;
+        public uint Flags;
+        public string FileName;      // empty for replaceable textures
+        public int FileDataID;       // from the TXID chunk when present; 0 when replaceable
+
+        public bool IsReplaceable { get { return Type != 0; } }
+        public bool WrapX { get { return (Flags & 0x1) != 0; } }
+        public bool WrapY { get { return (Flags & 0x2) != 0; } }
+    }
+
+    /// <summary>M2 render flags + blend mode (the "texFlags"/materials array).</summary>
+    public struct M2MaterialDef
+    {
+        public ushort Flags;
+        public ushort BlendMode;
+
+        public bool Unlit { get { return (Flags & 0x01) != 0; } }
+        public bool NoFog { get { return (Flags & 0x02) != 0; } }
+        public bool TwoSided { get { return (Flags & 0x04) != 0; } }
+        public bool DepthTestDisabled { get { return (Flags & 0x08) != 0; } }
+        public bool DepthWriteDisabled { get { return (Flags & 0x10) != 0; } }
+    }
+
+    public enum M2BlendMode
+    {
+        Opaque = 0,
+        AlphaKey = 1,      // cutout
+        Alpha = 2,
+        NoAlphaAdd = 3,
+        Add = 4,
+        Mod = 5,
+        Mod2x = 6,
+        BlendAdd = 7,
+    }
+
+    /// <summary>A parsed M2 (the parts this milestone needs).</summary>
+    public class M2ParsedModel
+    {
+        public string Name = "";
+        public uint Version;
+        public uint GlobalFlags;
+        public M2Vertex[] Vertices = new M2Vertex[0];
+        public M2TextureDef[] Textures = new M2TextureDef[0];
+        public M2MaterialDef[] Materials = new M2MaterialDef[0];
+        public ushort[] TextureLookup = new ushort[0];   // batch.textureComboIndex -> texture index
+        public int SkinProfileCount;
+        public int[] SkinFileDataIDs = new int[0];       // SFID chunk
+        public int[] TextureFileDataIDs = new int[0];    // TXID chunk (0 where replaceable)
+        public int BoneCount;
+
+        /// <summary>Model-space bounds of the vertex positions (WoW axes).</summary>
+        public WowVec3 BoundsMin, BoundsMax;
+    }
+
+    /// <summary>One renderable section of the skin profile (a "geoset"/submesh).</summary>
+    public struct M2Submesh
+    {
+        public ushort Id;
+        public ushort Level;
+        public ushort VertexStart, VertexCount;
+        public ushort IndexStart, IndexCount;   // into the skin's triangle-index array
+    }
+
+    /// <summary>A draw call: which submesh with which material/texture.</summary>
+    public struct M2Batch
+    {
+        public byte Flags;
+        public sbyte PriorityPlane;
+        public ushort ShaderId;
+        public ushort SubmeshIndex;
+        public ushort GeosetIndex;
+        public ushort ColorIndex;
+        public ushort MaterialIndex;
+        public ushort MaterialLayer;
+        public ushort TextureCount;
+        public ushort TextureComboIndex;
+    }
+
+    /// <summary>A parsed .skin profile.</summary>
+    public class M2ParsedSkin
+    {
+        public ushort[] VertexLookup = new ushort[0];   // skin vertex -> M2 vertex index
+        public ushort[] Triangles = new ushort[0];      // indices into VertexLookup
+        public M2Submesh[] Submeshes = new M2Submesh[0];
+        public M2Batch[] Batches = new M2Batch[0];
+
+        public int TriangleCount { get { return Triangles.Length / 3; } }
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
@@ -39,9 +39,15 @@ namespace Wmv.Wow
         const int OfsVertices = 0x3C;
         const int OfsNumSkinProfiles = 0x44;
         const int OfsTextures = 0x50;
+        const int OfsColors = 0x48;        // M2Color[]: an RGB track + an alpha track each
         const int OfsMaterials = 0x70;     // "texFlags": render flags + blend mode
+        const int OfsTextureWeights = 0x58;
         const int OfsTextureLookup = 0x80;
+        const int OfsTextureWeightLookup = 0x90;
         const int MinHeaderSize = 0x84 + 8;
+
+        const int ColorStride = 40;        // two M2Tracks
+        const int TrackStride = 20;        // interpolation + globalSeq + two nested M2Arrays
 
         /// <summary>Parse an .m2 asset. Throws WowParseException on anything malformed.</summary>
         public static M2ParsedModel Parse(byte[] file)
@@ -125,7 +131,112 @@ namespace Wmv.Wow
                 model.TextureLookup[i] = c.ReadUInt16();
             }
 
+            ReadVisibilityTracks(c, model);
+
             return model;
+        }
+
+        /// <summary>
+        /// Read the two animated inputs that decide whether a draw batch is drawn at all: the
+        /// colors[] array (an RGB track plus an alpha track, selected by batch.ColorIndex) and
+        /// texture_weights[] (selected through texture_weight_combos). A model hides geometry it
+        /// does not currently want -- an eye overlay, a glow, a blink -- by keying one of these to
+        /// zero, and the legacy OpenGL renderer skips such a batch entirely rather than drawing it
+        /// transparent. See WmvModelBuilder.BatchVisibility.
+        ///
+        /// These arrays sit past the header offsets the rest of this parser needs, so a shorter
+        /// header simply yields empty arrays -- which the builder reads as "everything visible",
+        /// the behaviour before this was parsed.
+        /// </summary>
+        static void ReadVisibilityTracks(ByteCursor c, M2ParsedModel model)
+        {
+            if (c.Length < OfsTextureWeightLookup + 8)
+                return;
+
+            c.Seek(OfsColors);
+            M2Array colors = c.ReadArray();
+            if (colors.Count > 0 && FitsArray(c, colors, ColorStride))
+            {
+                model.Colors = new M2ColorDef[colors.Count];
+                for (int i = 0; i < colors.Count; i++)
+                {
+                    int rec = colors.Offset + i * ColorStride;
+                    float ignored;
+                    model.Colors[i].HasColorTrack = ReadTrackFirstValue(c, rec, false, out ignored);
+                    float alpha;
+                    model.Colors[i].Alpha = ReadTrackFirstValue(c, rec + TrackStride, true, out alpha)
+                                            ? alpha : 1f;
+                }
+            }
+
+            c.Seek(OfsTextureWeights);
+            M2Array weights = c.ReadArray();
+            if (weights.Count > 0 && FitsArray(c, weights, TrackStride))
+            {
+                model.TextureWeights = new float[weights.Count];
+                for (int i = 0; i < weights.Count; i++)
+                {
+                    float w;
+                    model.TextureWeights[i] =
+                        ReadTrackFirstValue(c, weights.Offset + i * TrackStride, true, out w) ? w : 1f;
+                }
+            }
+
+            c.Seek(OfsTextureWeightLookup);
+            M2Array weightLookup = c.ReadArray();
+            if (weightLookup.Count > 0 && FitsArray(c, weightLookup, 2))
+            {
+                model.TextureWeightLookup = new ushort[weightLookup.Count];
+                for (int i = 0; i < weightLookup.Count; i++)
+                {
+                    c.Seek(weightLookup.Offset + i * 2);
+                    model.TextureWeightLookup[i] = c.ReadUInt16();
+                }
+            }
+        }
+
+        static bool FitsArray(ByteCursor c, M2Array arr, int stride)
+        {
+            return arr.Offset >= 0 && arr.Count >= 0 &&
+                   (long)arr.Offset + (long)arr.Count * stride <= c.Length;
+        }
+
+        /// <summary>
+        /// Read one M2Track and report whether animation 0 carries any data, plus that animation's
+        /// first value. Layout:
+        ///
+        ///     uint16 interpolationType; uint16 globalSequence;
+        ///     M2Array&lt;M2Array&lt;uint32&gt;&gt; timestamps;
+        ///     M2Array&lt;M2Array&lt;T&gt;&gt;      values;
+        ///
+        /// i.e. one nested array per animation. Only animation 0 at time 0 is read: this milestone
+        /// renders a static pose, exactly as the legacy renderer does with animtime 0. Values are
+        /// fixed16 (32767 == 1.0) for the alpha and weight tracks; asFixed16 is false when the
+        /// caller only wants to know whether the track has data at all (the RGB track).
+        /// </summary>
+        static bool ReadTrackFirstValue(ByteCursor c, int trackOffset, bool asFixed16, out float value)
+        {
+            value = 0f;
+            if (trackOffset < 0 || trackOffset + TrackStride > c.Length)
+                return false;
+
+            c.Seek(trackOffset + 12);            // skip interpolation + globalSequence + timestamps
+            M2Array values = c.ReadArray();
+            if (values.Count <= 0 || values.Offset < 0 || values.Offset + 8 > c.Length)
+                return false;
+
+            c.Seek(values.Offset);               // animation 0's own array
+            M2Array anim0 = c.ReadArray();
+            if (anim0.Count <= 0)
+                return false;
+            if (!asFixed16)
+                return true;
+
+            if (anim0.Offset < 0 || anim0.Offset + 2 > c.Length)
+                return false;
+            c.Seek(anim0.Offset);
+            value = c.ReadInt16() / 32767f;
+            return true;
         }
 
         /// <summary>Walk the top-level chunk table. Empty when the asset is a bare MD20.</summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
@@ -14,7 +14,7 @@
 //   model itself lives in the MD21 chunk and *every offset inside it is relative to the start
 //   of that chunk's payload*, not to the start of the file. Sibling chunks carry the
 //   FileDataIDs of related assets: SFID (skin profiles), TXID (textures), SKID/AFID/BFID/PFID
-//   (skeleton/animations/bones/physics -- not used in this milestone).
+//   (additional file-reference chunks -- not used in this milestone).
 //
 // The MD20 header layout below matches the one WMV's own loader uses (Source/games/wow/
 // modelheaders.h): count/offset pairs, with nViews being a lone uint32 because view (LOD) data

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
@@ -1,0 +1,241 @@
+// M2Parser.cs
+//
+// Runtime parser for the M2 bytes WMV serves over IPC. No files, no disk: byte[] in, parsed
+// model out.
+//
+// SUPPORTED FORMAT
+//   Modern retail M2 ("MD21"-chunked, MD20 payload). Verified against War Within / Midnight
+//   retail data: creature/chicken/chicken.m2 is MD20 version 272. A bare (unchunked) MD20 file
+//   is also accepted, which covers older data, but nothing older than the MD20 header layout
+//   below is supported -- this milestone deliberately targets the version current retail ships.
+//
+// CHUNKED WRAPPER
+//   A modern .m2 is a sequence of {char magic[4]; uint32 size; byte payload[size]} chunks. The
+//   model itself lives in the MD21 chunk and *every offset inside it is relative to the start
+//   of that chunk's payload*, not to the start of the file. Sibling chunks carry the
+//   FileDataIDs of related assets: SFID (skin profiles), TXID (textures), SKID/AFID/BFID/PFID
+//   (skeleton/animations/bones/physics -- not used in this milestone).
+//
+// The MD20 header layout below matches the one WMV's own loader uses (Source/games/wow/
+// modelheaders.h): count/offset pairs, with nViews being a lone uint32 because view (LOD) data
+// moved out into the .skin files.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Wmv.Wow
+{
+    public static class M2Parser
+    {
+        public const int VertexStride = 48;
+        const int TextureStride = 16;
+        const int MaterialStride = 4;
+
+        // MD20 header offsets (relative to the MD21 payload)
+        const int OfsName = 0x08;
+        const int OfsGlobalFlags = 0x10;
+        const int OfsBones = 0x2C;
+        const int OfsVertices = 0x3C;
+        const int OfsNumSkinProfiles = 0x44;
+        const int OfsTextures = 0x50;
+        const int OfsMaterials = 0x70;     // "texFlags": render flags + blend mode
+        const int OfsTextureLookup = 0x80;
+        const int MinHeaderSize = 0x84 + 8;
+
+        /// <summary>Parse an .m2 asset. Throws WowParseException on anything malformed.</summary>
+        public static M2ParsedModel Parse(byte[] file)
+        {
+            if (file == null || file.Length < 8)
+                throw new WowParseException("m2: asset is empty or too small to hold a header");
+
+            var model = new M2ParsedModel();
+            var chunks = ReadChunks(file);
+
+            int md21Offset = 0, md21Size = file.Length;
+            if (chunks.Count > 0)
+            {
+                if (!chunks.ContainsKey("MD21"))
+                    throw new WowParseException("m2: chunked asset without an MD21 chunk");
+                md21Offset = chunks["MD21"].Offset;
+                md21Size = chunks["MD21"].Count;
+
+                model.SkinFileDataIDs = ReadIdChunk(file, chunks, "SFID");
+                model.TextureFileDataIDs = ReadIdChunk(file, chunks, "TXID");
+            }
+
+            // Work on the MD21 payload as its own address space -- offsets inside are relative
+            // to it, so a slice keeps every later read honest about its bounds.
+            var payload = new byte[md21Size];
+            if (md21Offset + md21Size > file.Length)
+                throw new WowParseException("m2: MD21 chunk extends past the end of the asset");
+            Buffer.BlockCopy(file, md21Offset, payload, 0, md21Size);
+
+            var c = new ByteCursor(payload, "m2");
+            if (payload.Length < MinHeaderSize)
+                throw new WowParseException(string.Format(
+                    "m2: header is truncated ({0} bytes, need at least {1})", payload.Length, MinHeaderSize));
+
+            string magic = c.ReadMagic();
+            if (magic != "MD20")
+                throw new WowParseException("m2: expected an MD20 header, found '" + magic + "'");
+            model.Version = c.ReadUInt32();
+
+            c.Seek(OfsName);
+            M2Array name = c.ReadArray();
+            model.Name = ReadString(c, name);
+
+            c.Seek(OfsGlobalFlags);
+            model.GlobalFlags = c.ReadUInt32();
+
+            c.Seek(OfsBones);
+            model.BoneCount = c.ReadArray().Count;
+
+            c.Seek(OfsNumSkinProfiles);
+            model.SkinProfileCount = (int)c.ReadUInt32();
+
+            c.Seek(OfsVertices);
+            M2Array verts = c.ReadArray();
+            c.RequireArray(verts, VertexStride, "vertices");
+            model.Vertices = ReadVertices(c, verts, model);
+
+            c.Seek(OfsTextures);
+            M2Array textures = c.ReadArray();
+            c.RequireArray(textures, TextureStride, "textures");
+            model.Textures = ReadTextures(c, textures, model);
+
+            c.Seek(OfsMaterials);
+            M2Array materials = c.ReadArray();
+            c.RequireArray(materials, MaterialStride, "materials");
+            model.Materials = new M2MaterialDef[materials.Count];
+            for (int i = 0; i < materials.Count; i++)
+            {
+                c.Seek(materials.Offset + i * MaterialStride);
+                model.Materials[i].Flags = c.ReadUInt16();
+                model.Materials[i].BlendMode = c.ReadUInt16();
+            }
+
+            c.Seek(OfsTextureLookup);
+            M2Array texLookup = c.ReadArray();
+            c.RequireArray(texLookup, 2, "textureLookup");
+            model.TextureLookup = new ushort[texLookup.Count];
+            for (int i = 0; i < texLookup.Count; i++)
+            {
+                c.Seek(texLookup.Offset + i * 2);
+                model.TextureLookup[i] = c.ReadUInt16();
+            }
+
+            return model;
+        }
+
+        /// <summary>Walk the top-level chunk table. Empty when the asset is a bare MD20.</summary>
+        public static Dictionary<string, M2Array> ReadChunks(byte[] file)
+        {
+            var chunks = new Dictionary<string, M2Array>();
+            if (file.Length < 8)
+                return chunks;
+            // A bare MD20 starts with its own magic; only treat the file as chunked otherwise.
+            if (file[0] == 'M' && file[1] == 'D' && file[2] == '2' && file[3] == '0')
+                return chunks;
+
+            int offset = 0;
+            while (offset + 8 <= file.Length)
+            {
+                string magic = string.Format("{0}{1}{2}{3}", (char)file[offset], (char)file[offset + 1],
+                                                             (char)file[offset + 2], (char)file[offset + 3]);
+                uint size = (uint)(file[offset + 4] | (file[offset + 5] << 8) |
+                                  (file[offset + 6] << 16) | (file[offset + 7] << 24));
+                offset += 8;
+                if (size > (uint)(file.Length - offset))
+                    throw new WowParseException(string.Format(
+                        "m2: chunk '{0}' claims {1} bytes but only {2} remain", magic, size, file.Length - offset));
+                chunks[magic] = new M2Array((int)size, offset);   // Count = size, Offset = payload
+                offset += (int)size;
+            }
+            return chunks;
+        }
+
+        static int[] ReadIdChunk(byte[] file, Dictionary<string, M2Array> chunks, string magic)
+        {
+            M2Array chunk;
+            if (!chunks.TryGetValue(magic, out chunk))
+                return new int[0];
+            int n = chunk.Count / 4;
+            var ids = new int[n];
+            var c = new ByteCursor(file, "m2:" + magic);
+            for (int i = 0; i < n; i++)
+            {
+                c.Seek(chunk.Offset + i * 4);
+                ids[i] = c.ReadInt32();
+            }
+            return ids;
+        }
+
+        static string ReadString(ByteCursor c, M2Array arr)
+        {
+            if (arr.Count <= 1)
+                return "";
+            c.Require(arr.Offset, arr.Count);
+            var sb = new StringBuilder(arr.Count);
+            for (int i = 0; i < arr.Count; i++)
+            {
+                byte b = c.Data[arr.Offset + i];
+                if (b == 0) break;
+                sb.Append((char)b);
+            }
+            return sb.ToString();
+        }
+
+        static M2Vertex[] ReadVertices(ByteCursor c, M2Array arr, M2ParsedModel model)
+        {
+            var verts = new M2Vertex[arr.Count];
+            float minX = float.MaxValue, minY = float.MaxValue, minZ = float.MaxValue;
+            float maxX = float.MinValue, maxY = float.MinValue, maxZ = float.MinValue;
+
+            for (int i = 0; i < arr.Count; i++)
+            {
+                c.Seek(arr.Offset + i * VertexStride);
+                M2Vertex v;
+                v.Position = new WowVec3(c.ReadSingle(), c.ReadSingle(), c.ReadSingle());
+                v.BoneWeight0 = c.ReadByte(); v.BoneWeight1 = c.ReadByte();
+                v.BoneWeight2 = c.ReadByte(); v.BoneWeight3 = c.ReadByte();
+                v.BoneIndex0 = c.ReadByte(); v.BoneIndex1 = c.ReadByte();
+                v.BoneIndex2 = c.ReadByte(); v.BoneIndex3 = c.ReadByte();
+                v.Normal = new WowVec3(c.ReadSingle(), c.ReadSingle(), c.ReadSingle());
+                v.TexCoord0 = new WowVec2(c.ReadSingle(), c.ReadSingle());
+                v.TexCoord1 = new WowVec2(c.ReadSingle(), c.ReadSingle());
+                verts[i] = v;
+
+                if (v.Position.X < minX) minX = v.Position.X;
+                if (v.Position.Y < minY) minY = v.Position.Y;
+                if (v.Position.Z < minZ) minZ = v.Position.Z;
+                if (v.Position.X > maxX) maxX = v.Position.X;
+                if (v.Position.Y > maxY) maxY = v.Position.Y;
+                if (v.Position.Z > maxZ) maxZ = v.Position.Z;
+            }
+
+            if (arr.Count > 0)
+            {
+                model.BoundsMin = new WowVec3(minX, minY, minZ);
+                model.BoundsMax = new WowVec3(maxX, maxY, maxZ);
+            }
+            return verts;
+        }
+
+        static M2TextureDef[] ReadTextures(ByteCursor c, M2Array arr, M2ParsedModel model)
+        {
+            var textures = new M2TextureDef[arr.Count];
+            for (int i = 0; i < arr.Count; i++)
+            {
+                c.Seek(arr.Offset + i * TextureStride);
+                textures[i].Type = c.ReadUInt32();
+                textures[i].Flags = c.ReadUInt32();
+                M2Array fileName = c.ReadArray();
+                textures[i].FileName = ReadString(c, fileName);
+                // TXID (when present) is parallel to this array; 0 means "replaceable, ask the host".
+                textures[i].FileDataID = (i < model.TextureFileDataIDs.Length) ? model.TextureFileDataIDs[i] : 0;
+            }
+            return textures;
+        }
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2ShaderTable.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2ShaderTable.cs
@@ -1,0 +1,202 @@
+// M2ShaderTable.cs
+//
+// Which combiner a material uses, and where each of its texture units takes its coordinates from.
+//
+// A modern M2 material does not describe its own blending arithmetic. It carries a shader id, and
+// that id plus the number of textures the batch loads selects a Blizzard "combiner shader" by
+// name -- one name for the pixel side (how the textures are combined) and one for the vertex side
+// (which UV set, or the environment sphere map, feeds each unit). Without this step a
+// multi-texture material looks like a single-texture one and every unit past the first is
+// silently dropped.
+//
+// The tables below are the same ones the legacy OpenGL renderer resolves in
+// Source/games/wow/WoWModel.cpp, kept name-for-name so the two renderers classify a material
+// identically. Resolving a name costs nothing and changes no rendering on its own; what a
+// renderer then does with the result is its own business (see WmvModelBuilder, which implements
+// the subset this milestone needs and says so in the log when it meets one it does not).
+//
+// Deliberately free of UnityEngine references, like the rest of this folder.
+
+using System.Collections.Generic;
+
+namespace Wmv.Wow
+{
+    public static class M2ShaderTable
+    {
+        /// <summary>Set in a shader id when the low bits index SHADER_ARRAY directly.</summary>
+        public const int ExplicitShaderBit = 0x8000;
+
+        struct ShaderEntry
+        {
+            public readonly string PS, VS;
+            public ShaderEntry(string ps, string vs) { PS = ps; VS = vs; }
+        }
+
+        // index == (shaderId & 0x7FFF) when the 0x8000 "explicit shader" bit is set
+        static readonly ShaderEntry[] ShaderArray =
+        {
+            new ShaderEntry("Combiners_Opaque_Mod2xNA_Alpha",           "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Opaque_AddAlpha",                "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Opaque_AddAlpha_Alpha",          "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Opaque_Mod2xNA_Alpha_Add",       "Diffuse_T1_Env_T1"),
+            new ShaderEntry("Combiners_Mod_AddAlpha",                   "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Opaque_AddAlpha",                "Diffuse_T1_T1"),
+            new ShaderEntry("Combiners_Mod_AddAlpha",                   "Diffuse_T1_T1"),
+            new ShaderEntry("Combiners_Mod_AddAlpha_Alpha",             "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Opaque_Alpha_Alpha",             "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Opaque_Mod2xNA_Alpha_3s",        "Diffuse_T1_Env_T1"),
+            new ShaderEntry("Combiners_Opaque_AddAlpha_Wgt",            "Diffuse_T1_T1"),
+            new ShaderEntry("Combiners_Mod_Add_Alpha",                  "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Opaque_ModNA_Alpha",             "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Mod_AddAlpha_Wgt",               "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Mod_AddAlpha_Wgt",               "Diffuse_T1_T1"),
+            new ShaderEntry("Combiners_Opaque_AddAlpha_Wgt",            "Diffuse_T1_T2"),
+            new ShaderEntry("Combiners_Opaque_Mod_Add_Wgt",             "Diffuse_T1_Env"),
+            new ShaderEntry("Combiners_Opaque_Mod2xNA_Alpha_UnshAlpha", "Diffuse_T1_Env_T1"),
+            new ShaderEntry("Combiners_Mod_Dual_Crossfade",             "Diffuse_T1"),
+            new ShaderEntry("Combiners_Mod_Depth",                      "Diffuse_EdgeFade_T1"),
+            new ShaderEntry("Combiners_Opaque_Mod2xNA_Alpha_Alpha",     "Diffuse_T1_Env_T2"),
+            new ShaderEntry("Combiners_Mod_Mod",                        "Diffuse_EdgeFade_T1_T2"),
+            new ShaderEntry("Combiners_Mod_Masked_Dual_Crossfade",      "Diffuse_T1_T2"),
+            new ShaderEntry("Combiners_Opaque_Alpha",                   "Diffuse_T1_T1"),
+            new ShaderEntry("Combiners_Opaque_Mod2xNA_Alpha_UnshAlpha", "Diffuse_T1_Env_T2"),
+            new ShaderEntry("Combiners_Mod_Depth",                      "Diffuse_EdgeFade_Env"),
+            new ShaderEntry("Guild",                                    "Diffuse_T1_T2_T1"),
+            new ShaderEntry("Guild_NoBorder",                           "Diffuse_T1_T2"),
+            new ShaderEntry("Guild_Opaque",                             "Diffuse_T1_T2_T1"),
+            new ShaderEntry("Illum",                                    "Diffuse_T1_T1"),
+            new ShaderEntry("Combiners_Mod_Mod_Mod_Const",              "Diffuse_T1_T2_T3"),
+            new ShaderEntry("Combiners_Mod_Mod_Mod_Const",              "Color_T1_T2_T3"),
+            new ShaderEntry("Combiners_Opaque",                         "Diffuse_T1"),
+            new ShaderEntry("Combiners_Mod_Mod2x",                      "Diffuse_EdgeFade_T1_T2"),
+            new ShaderEntry("Combiners_Mod",                            "Diffuse_EdgeFade_T1"),
+            new ShaderEntry("Combiners_Mod_Mod_Depth",                  "Diffuse_EdgeFade_T1_T2"),
+        };
+
+        // pixel-shader name -> combiner id. The numbering matches the OpenGL renderer's GLSL
+        // combiner so a variant implemented on one side can be read straight across to the other.
+        static readonly Dictionary<string, int> PixelShaderIds = new Dictionary<string, int>
+        {
+            { "Combiners_Opaque", 0 }, { "Combiners_Mod", 1 }, { "Combiners_Opaque_Mod", 2 },
+            { "Combiners_Opaque_Mod2x", 3 }, { "Combiners_Opaque_Mod2xNA", 4 }, { "Combiners_Opaque_Opaque", 5 },
+            { "Combiners_Mod_Mod", 6 }, { "Combiners_Mod_Mod2x", 7 }, { "Combiners_Mod_Add", 8 },
+            { "Combiners_Mod_Mod2xNA", 9 }, { "Combiners_Mod_AddNA", 10 }, { "Combiners_Mod_Opaque", 11 },
+            { "Combiners_Opaque_Mod2xNA_Alpha", 12 }, { "Combiners_Opaque_AddAlpha", 13 },
+            { "Combiners_Opaque_AddAlpha_Alpha", 14 }, { "Combiners_Opaque_Mod2xNA_Alpha_Add", 15 },
+            { "Combiners_Mod_AddAlpha", 16 }, { "Combiners_Mod_AddAlpha_Alpha", 17 },
+            { "Combiners_Opaque_Alpha_Alpha", 18 }, { "Combiners_Opaque_Mod2xNA_Alpha_3s", 19 },
+            { "Combiners_Opaque_AddAlpha_Wgt", 20 }, { "Combiners_Mod_Add_Alpha", 21 },
+            { "Combiners_Opaque_ModNA_Alpha", 22 }, { "Combiners_Mod_AddAlpha_Wgt", 23 },
+            { "Combiners_Opaque_Mod_Add_Wgt", 24 }, { "Combiners_Opaque_Mod2xNA_Alpha_UnshAlpha", 25 },
+            { "Combiners_Mod_Dual_Crossfade", 26 }, { "Combiners_Opaque_Mod2xNA_Alpha_Alpha", 27 },
+            { "Combiners_Mod_Masked_Dual_Crossfade", 28 }, { "Combiners_Opaque_Alpha", 29 },
+            { "Guild", 30 }, { "Guild_NoBorder", 31 }, { "Guild_Opaque", 32 },
+            { "Combiners_Mod_Depth", 33 }, { "Illum", 34 }, { "Combiners_Mod_Mod_Mod_Const", 35 },
+            { "Combiners_Mod_Mod_Depth", 36 },
+        };
+
+        public static string GetPixelShaderName(int textureCount, int shaderId)
+        {
+            if ((shaderId & ExplicitShaderBit) != 0)
+            {
+                int id = shaderId & 0x7FFF;
+                return (id >= ShaderArray.Length) ? "Combiners_Opaque" : ShaderArray[id].PS;
+            }
+            if (textureCount == 1)
+                return ((shaderId & 0x70) != 0) ? "Combiners_Mod" : "Combiners_Opaque";
+            if ((shaderId & 0x70) != 0)
+            {
+                switch (shaderId & 7)
+                {
+                    case 3: return "Combiners_Mod_Add";
+                    case 4: return "Combiners_Mod_Mod2x";
+                    case 6: return "Combiners_Mod_Mod2xNA";
+                    case 7: return "Combiners_Mod_AddNA";
+                    default: return "Combiners_Mod_Mod";
+                }
+            }
+            switch (shaderId & 7)
+            {
+                case 0: return "Combiners_Opaque_Opaque";
+                case 3:
+                case 7: return "Combiners_Opaque_AddAlpha";
+                case 4: return "Combiners_Opaque_Mod2x";
+                case 6: return "Combiners_Opaque_Mod2xNA";
+                default: return "Combiners_Opaque_Mod";
+            }
+        }
+
+        public static string GetVertexShaderName(int textureCount, int shaderId)
+        {
+            if ((shaderId & ExplicitShaderBit) != 0)
+            {
+                int id = shaderId & 0x7FFF;
+                return (id >= ShaderArray.Length) ? "Diffuse_T1" : ShaderArray[id].VS;
+            }
+            if (textureCount == 1)
+            {
+                if ((shaderId & 0x80) != 0) return "Diffuse_Env";
+                return ((shaderId & 0x4000) != 0) ? "Diffuse_T2" : "Diffuse_T1";
+            }
+            if ((shaderId & 0x80) != 0)
+                return ((shaderId & 0x8) != 0) ? "Diffuse_Env_Env" : "Diffuse_Env_T1";
+            if ((shaderId & 0x8) != 0) return "Diffuse_T1_Env";
+            return ((shaderId & 0x4000) != 0) ? "Diffuse_T1_T2" : "Diffuse_T1_T1";
+        }
+
+        public static int PixelShaderNameToId(string name)
+        {
+            int id;
+            return PixelShaderIds.TryGetValue(name, out id) ? id : 0;
+        }
+
+        /// <summary>
+        /// Per-unit UV routing, read off the vertex-shader name: Diffuse_T1_Env means unit 0 takes
+        /// UV set 0 and unit 1 is an environment sphere map. "EdgeFade" is a fade term, not a unit,
+        /// and is skipped. Units the name does not mention keep the defaults.
+        /// </summary>
+        public static M2UvSource[] UvSourceForVertexShaderName(string name)
+        {
+            var outSrc = new[] { M2UvSource.TexCoord0, M2UvSource.TexCoord1,
+                                 M2UvSource.TexCoord2, M2UvSource.TexCoord2 };
+            if (string.IsNullOrEmpty(name))
+                return outSrc;
+
+            string s = name;
+            foreach (var prefix in new[] { "BW_Diffuse_", "Diffuse_", "Color_" })
+            {
+                if (s.StartsWith(prefix)) { s = s.Substring(prefix.Length); break; }
+            }
+
+            int unit = 0;
+            foreach (var token in s.Split('_'))
+            {
+                if (unit >= 4) break;
+                if (token.Length == 0 || token == "EdgeFade") continue;
+                if (token == "T1") outSrc[unit++] = M2UvSource.TexCoord0;
+                else if (token == "T2") outSrc[unit++] = M2UvSource.TexCoord1;
+                else if (token == "T3") outSrc[unit++] = M2UvSource.TexCoord2;
+                else if (token == "Env") outSrc[unit++] = M2UvSource.Environment;
+            }
+            return outSrc;
+        }
+
+        /// <summary>Everything a renderer needs to know about one batch's material combine.</summary>
+        public struct Resolved
+        {
+            public string PixelShaderName, VertexShaderName;
+            public int PixelShader;              // id shared with the OpenGL renderer's GLSL combiner
+            public M2UvSource[] UvSource;        // one entry per texture unit
+        }
+
+        public static Resolved Resolve(int textureCount, int shaderId)
+        {
+            Resolved r;
+            r.PixelShaderName = GetPixelShaderName(textureCount, shaderId);
+            r.VertexShaderName = GetVertexShaderName(textureCount, shaderId);
+            r.PixelShader = PixelShaderNameToId(r.PixelShaderName);
+            r.UvSource = UvSourceForVertexShaderName(r.VertexShaderName);
+            return r;
+        }
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2SkinParser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2SkinParser.cs
@@ -110,6 +110,9 @@ namespace Wmv.Wow
                 b.MaterialLayer = c.ReadUInt16();
                 b.TextureCount = c.ReadUInt16();
                 b.TextureComboIndex = c.ReadUInt16();
+                b.TextureCoordComboIndex = c.ReadUInt16();
+                b.TextureWeightComboIndex = c.ReadUInt16();
+                b.TextureTransformComboIndex = c.ReadUInt16();
                 if (b.SubmeshIndex >= skin.Submeshes.Length)
                     throw new WowParseException(string.Format(
                         "skin: batch {0} references submesh {1} of {2}", i, b.SubmeshIndex, skin.Submeshes.Length));

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2SkinParser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2SkinParser.cs
@@ -1,0 +1,143 @@
+// M2SkinParser.cs
+//
+// Runtime parser for a modern .skin profile (magic "SKIN"), fetched over IPC by the FileDataID
+// the M2's SFID chunk carries.
+//
+// TOPOLOGY -- the part that is easy to get wrong: renderable triangles come from TWO levels of
+// indirection, not one.
+//
+//     triangle index  ->  skin VertexLookup[]  ->  M2 vertex array
+//
+// The skin's "triangles" array holds indices into the skin's own vertex-lookup table, and that
+// table holds indices into the model's vertex array. A submesh's IndexStart/IndexCount are
+// positions in the *triangle* array, and its VertexStart/VertexCount are positions in the
+// *lookup* array. Resolving one level and stopping produces a scrambled mesh, so both levels
+// are validated here and resolved in BuildTriangles.
+
+namespace Wmv.Wow
+{
+    public static class M2SkinParser
+    {
+        const int SubmeshStride = 48;
+        const int BatchStride = 24;
+        const int HeaderSize = 0x30;
+
+        public static M2ParsedSkin Parse(byte[] file)
+        {
+            if (file == null || file.Length < HeaderSize)
+                throw new WowParseException("skin: asset is empty or smaller than the header");
+
+            var c = new ByteCursor(file, "skin");
+            string magic = c.ReadMagic();
+            if (magic != "SKIN")
+                throw new WowParseException("skin: expected a SKIN header, found '" + magic + "'");
+
+            M2Array vertices = c.ReadArray();     // 0x04
+            M2Array triangles = c.ReadArray();    // 0x0C
+            c.ReadArray();                        // 0x14 bones (not needed for a static mesh)
+            M2Array submeshes = c.ReadArray();    // 0x1C
+            M2Array batches = c.ReadArray();      // 0x24
+
+            c.RequireArray(vertices, 2, "skin vertex lookup");
+            c.RequireArray(triangles, 2, "skin triangles");
+            c.RequireArray(submeshes, SubmeshStride, "skin submeshes");
+            c.RequireArray(batches, BatchStride, "skin batches");
+
+            if (triangles.Count % 3 != 0)
+                throw new WowParseException(string.Format(
+                    "skin: triangle index count {0} is not a multiple of 3", triangles.Count));
+
+            var skin = new M2ParsedSkin();
+
+            skin.VertexLookup = new ushort[vertices.Count];
+            for (int i = 0; i < vertices.Count; i++)
+            {
+                c.Seek(vertices.Offset + i * 2);
+                skin.VertexLookup[i] = c.ReadUInt16();
+            }
+
+            skin.Triangles = new ushort[triangles.Count];
+            for (int i = 0; i < triangles.Count; i++)
+            {
+                c.Seek(triangles.Offset + i * 2);
+                ushort idx = c.ReadUInt16();
+                if (idx >= skin.VertexLookup.Length)
+                    throw new WowParseException(string.Format(
+                        "skin: triangle index {0} at position {1} is outside the {2}-entry vertex lookup",
+                        idx, i, skin.VertexLookup.Length));
+                skin.Triangles[i] = idx;
+            }
+
+            skin.Submeshes = new M2Submesh[submeshes.Count];
+            for (int i = 0; i < submeshes.Count; i++)
+            {
+                c.Seek(submeshes.Offset + i * SubmeshStride);
+                M2Submesh s;
+                s.Id = c.ReadUInt16();
+                s.Level = c.ReadUInt16();
+                s.VertexStart = c.ReadUInt16();
+                s.VertexCount = c.ReadUInt16();
+                s.IndexStart = c.ReadUInt16();
+                s.IndexCount = c.ReadUInt16();
+                // remaining fields (bone counts, centre/sort positions, radius) are not needed here
+
+                if (s.IndexCount % 3 != 0)
+                    throw new WowParseException(string.Format(
+                        "skin: submesh {0} has {1} indices, not a multiple of 3", i, s.IndexCount));
+                if ((long)s.IndexStart + s.IndexCount > skin.Triangles.Length)
+                    throw new WowParseException(string.Format(
+                        "skin: submesh {0} spans indices [{1},{2}) beyond the {3} available",
+                        i, s.IndexStart, s.IndexStart + s.IndexCount, skin.Triangles.Length));
+                if ((long)s.VertexStart + s.VertexCount > skin.VertexLookup.Length)
+                    throw new WowParseException(string.Format(
+                        "skin: submesh {0} spans vertices [{1},{2}) beyond the {3} available",
+                        i, s.VertexStart, s.VertexStart + s.VertexCount, skin.VertexLookup.Length));
+                skin.Submeshes[i] = s;
+            }
+
+            skin.Batches = new M2Batch[batches.Count];
+            for (int i = 0; i < batches.Count; i++)
+            {
+                c.Seek(batches.Offset + i * BatchStride);
+                M2Batch b;
+                b.Flags = c.ReadByte();
+                b.PriorityPlane = c.ReadSByte();
+                b.ShaderId = c.ReadUInt16();
+                b.SubmeshIndex = c.ReadUInt16();
+                b.GeosetIndex = c.ReadUInt16();
+                b.ColorIndex = c.ReadUInt16();
+                b.MaterialIndex = c.ReadUInt16();
+                b.MaterialLayer = c.ReadUInt16();
+                b.TextureCount = c.ReadUInt16();
+                b.TextureComboIndex = c.ReadUInt16();
+                if (b.SubmeshIndex >= skin.Submeshes.Length)
+                    throw new WowParseException(string.Format(
+                        "skin: batch {0} references submesh {1} of {2}", i, b.SubmeshIndex, skin.Submeshes.Length));
+                skin.Batches[i] = b;
+            }
+
+            return skin;
+        }
+
+        /// <summary>
+        /// Resolve one submesh's triangles into indices in the MODEL's vertex array, validating
+        /// every hop. Returns indices in WoW winding order; the coordinate converter is what
+        /// flips them for Unity.
+        /// </summary>
+        public static int[] BuildTriangles(M2ParsedSkin skin, M2Submesh submesh, int modelVertexCount)
+        {
+            var indices = new int[submesh.IndexCount];
+            for (int i = 0; i < submesh.IndexCount; i++)
+            {
+                ushort skinIndex = skin.Triangles[submesh.IndexStart + i];
+                int modelIndex = skin.VertexLookup[skinIndex];
+                if (modelIndex >= modelVertexCount)
+                    throw new WowParseException(string.Format(
+                        "skin: vertex lookup entry {0} points at model vertex {1} of {2}",
+                        skinIndex, modelIndex, modelVertexCount));
+                indices[i] = modelIndex;
+            }
+            return indices;
+        }
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/WowCoordinateConverter.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/WowCoordinateConverter.cs
@@ -1,0 +1,78 @@
+// WowCoordinateConverter.cs
+//
+// THE single place where WoW's coordinate convention becomes Unity's. Nothing else in the
+// renderer is allowed to flip a sign: if something looks mirrored or inside-out, it is fixed
+// here and everything downstream follows.
+//
+//   WoW model space : right-handed, Z up, +X forward (the direction the model faces),
+//                     +Y to the model's left. 1 unit ~= 1 yard.
+//   Unity           : left-handed, Y up, +Z forward, +X right.
+//
+// Mapping (forward -> forward, up -> up, left -> -right):
+//
+//     unity.x = -wow.y      (right       = -left)
+//     unity.y =  wow.z      (up          =  up)
+//     unity.z =  wow.x      (forward     =  forward)
+//
+// That matrix has determinant -1 -- it reverses handedness, which is exactly what converting
+// between a right- and a left-handed system must do. A mirroring transform also reverses
+// triangle orientation, so triangle winding is flipped alongside it (FlipWinding) to keep
+// front faces facing out and Unity's default back-face culling correct.
+//
+// Scale: left at 1.0. WoW units are yards and Unity units are metres, so a model comes out
+// ~9% smaller than life; that is irrelevant for viewing and the camera frames by bounds
+// anyway. Introducing a scale factor here (0.9144) would be the one-line change.
+
+namespace Wmv.Wow
+{
+    public static class WowCoordinateConverter
+    {
+        /// <summary>Unity units per WoW unit. 1.0 keeps model space as authored.</summary>
+        public const float Scale = 1.0f;
+
+        /// <summary>Convert a WoW model-space position to Unity space.</summary>
+        public static void ConvertPosition(WowVec3 wow, out float x, out float y, out float z)
+        {
+            x = -wow.Y * Scale;
+            y = wow.Z * Scale;
+            z = wow.X * Scale;
+        }
+
+        /// <summary>
+        /// Convert a WoW normal. Same linear map as positions but without scale, so unit
+        /// normals stay unit length.
+        /// </summary>
+        public static void ConvertNormal(WowVec3 wow, out float x, out float y, out float z)
+        {
+            x = -wow.Y;
+            y = wow.Z;
+            z = wow.X;
+        }
+
+        /// <summary>
+        /// WoW texture coordinates have V running down from the top; Unity's run up from the
+        /// bottom, so V is flipped once, here.
+        /// </summary>
+        public static void ConvertTexCoord(WowVec2 wow, out float u, out float v)
+        {
+            u = wow.X;
+            v = 1.0f - wow.Y;
+        }
+
+        /// <summary>
+        /// Reverse each triangle's winding, compensating for the handedness flip above.
+        /// Operates in place on a triangle list (length must be a multiple of 3).
+        /// </summary>
+        public static void FlipWinding(int[] indices)
+        {
+            if (indices == null)
+                return;
+            for (int i = 0; i + 2 < indices.Length; i += 3)
+            {
+                int tmp = indices[i + 1];
+                indices[i + 1] = indices[i + 2];
+                indices[i + 2] = tmp;
+            }
+        }
+    }
+}

--- a/Tools/UnityRendererProject/README.md
+++ b/Tools/UnityRendererProject/README.md
@@ -15,10 +15,15 @@ build and run time.
 
 ## Build steps
 
-1. Install a Unity LTS (2021.3 or newer; any recent LTS works — the scripts use only
-   core UnityEngine + .NET `TcpClient`).
-2. Create a new **3D (Built-in Render Pipeline)** project named e.g. `WmvUnityRenderer`.
-3. Copy the `Assets/Scripts/` folder from here into the project's `Assets/`.
+1. Install a Unity LTS (2021.3 or newer, including Unity 6 — the scripts use only core
+   UnityEngine + .NET `TcpClient`).
+2. Create a new 3D project named e.g. `WmvUnityRenderer`. **Built-in Render Pipeline is the
+   simplest project to test with**, but **URP (including Unity 6) and HDRP work too** — the
+   builder resolves a shader per pipeline (see *Render pipelines and shader stripping* below).
+3. Copy **both** `Assets/Scripts/` and `Assets/Resources/` from here into the project's
+   `Assets/`. `Assets/Resources/` is not optional: it holds the renderer's own opaque shader,
+   and a Resources folder is the only place Unity will not strip it from a player build (see
+   *Render pipelines and shader stripping*).
 4. Create an empty GameObject in the default scene and add the **WmvMain** component to
    it. (It builds the camera rig, light, test cube, status overlay and the IPC client at
    runtime — no other scene setup needed.)
@@ -26,6 +31,9 @@ build and run time.
    - **Resolution and Presentation → Run In Background: ON** (required — otherwise the
      player pauses whenever the WMV window has focus, which is always).
    - Fullscreen Mode: *Windowed*.
+   - **Active Input Handling: any of Old / New / Both.** The camera compiles against whichever
+     backend is active (`ENABLE_LEGACY_INPUT_MANAGER` / `ENABLE_INPUT_SYSTEM`); with *Both* it
+     uses the legacy path. No project setting needs changing just to avoid input exceptions.
 6. **File → Build Settings → Windows x86_64 → Build**, and build **into**
    `tools\unity-renderer\` next to `wowmodelviewer.exe`, with the executable named
    `UnityRenderer.exe`.
@@ -35,13 +43,128 @@ build and run time.
 Do **not** commit the build output (exe, `UnityRenderer_Data/`, `UnityPlayer.dll`, …) to
 this repository.
 
+## Render pipelines and shader stripping
+
+The renderer builds its materials at runtime, so it asks `Shader.Find` for one. Two things make
+that awkward in a **player build** (as opposed to the editor):
+
+- the shader name differs per pipeline, and
+- Unity strips shaders that no asset in the build references — which is why a runtime-built
+  material, or even an untouched primitive, can come out **magenta** in a player while looking
+  fine in the editor.
+
+And a third thing, the one that actually broke the first working render: **a shader is not
+usable just because `Shader.Find` returned it.** `Sprites/Default` is always included, so it wins
+any naive search — and it bakes `Blend One OneMinusSrcAlpha`, `ZWrite Off` and `Cull Off` into the
+pass. Those are *not* material properties, so `HasProperty`-guarded calls to set `_ZWrite` or
+`_SrcBlend` against it do nothing at all, in silence, and an opaque WoW material draws as a stack
+of translucent shells. Every candidate is therefore screened before it is taken: it must expose
+the blend/depth knobs, or already be opaque (its own default render queue says which), and it must
+not be one of Unity's `Hidden/` internal shaders.
+
+`WmvModelBuilder` tries, in order:
+
+| | Shader | |
+|---|---|---|
+| 1 | lit, for the active pipeline — `Standard`, `Legacy Shaders/Diffuse`, `Mobile/Diffuse` (Built-in) or `Universal Render Pipeline/Lit`, `.../Simple Lit`, `HDRP/Lit` (SRP) | best match to the OpenGL viewport |
+| 2 | the shader on a primitive's default material | pipeline-correct by construction — Unity picks it from the *active* pipeline |
+| 3 | **`Resources.Load("WmvOpaque")`** — `Assets/Resources/WmvOpaque.shader` | the guarantee: a Resources folder is never stripped |
+| 4 | unlit — `Unlit/Texture` (Built-in) or `Universal Render Pipeline/Unlit`, `HDRP/Unlit` (SRP) | flat, but solid |
+| 5 | `Sprites/Default` | last resort only; logs that the model **will** look see-through |
+
+The names are restricted to the pipeline in use, because a shader written for one pipeline renders
+magenta under another. Rungs 1, 2 and 4 are all strippable — in a real URP player build with an
+otherwise empty scene, *every one of them* came back missing or as the magenta error shader. Rung 3
+is why the renderer no longer depends on that going well.
+
+It never fails the load, and it always logs which shader it took and why. Adding the shader you
+want to **Project Settings → Graphics → Always Included Shaders** and rebuilding is still the way
+to get full pipeline lighting.
+
+Three consequences worth knowing:
+
+- The **render state is set explicitly**, never inherited from the shader's defaults — and the
+  shader is chosen so that setting it actually does something.
+- Transparency follows the **WoW blend mode only**, never the presence of an alpha channel in
+  the texture. Creature skins have one regardless: chicken2's is DXT5 with ~97% of its texels
+  below 255. On an opaque material that channel is **discarded at upload** rather than trusted.
+- Every material load logs its real runtime state — chosen shader, render queue, `RenderType`,
+  `_SrcBlend`/`_DstBlend`/`_ZWrite`/`_Cull`/`_Mode`/`_Surface`/`_AlphaClip` (or `n/a` where the
+  shader does not expose them), enabled keywords, and the WoW blend/two-sided/depth-write flags
+  it came from.
+
+## Texture units, combiners and hidden geometry
+
+Three things about an M2 material are easy to miss, and missing any of them looks like a texturing
+bug rather than a missing feature:
+
+**A batch can load more than one texture.** It declares how many (`textureCount`) and where its run
+starts in the texture-combo table (`textureComboIndex`); unit *k* is entry `textureComboIndex + k`.
+Reading only the first entry drops every unit past the first, silently. chicken2's two batches each
+declare two units.
+
+**The material does not describe how they combine.** That is selected by its shader id: the id plus
+the texture count names a Blizzard combiner (`Wow/M2ShaderTable.cs`, the same table the OpenGL
+viewport resolves). chicken2's `shaderId 0x8000` resolves to
+`Combiners_Opaque_Mod2xNA_Alpha` / `Diffuse_T1_Env` — unit 1 is an **environment sphere map**
+generated from the view-space normal, not a stored UV set, and the combine is
+
+```
+rgb = lerp(unit0.rgb * unit1.rgb * 2, unit0.rgb, unit0.a)
+```
+
+so the **base texture's alpha channel is the reflection mask**, not transparency. On chicken2's skin
+that mask is white everywhere except the eye pupil, which is exactly where the model wants a
+reflective highlight. Only this one combiner is implemented; any other is logged by name and drawn
+from unit 0 alone, which is what happened to all of them before. The combiner needs the renderer's
+own `WmvOpaque` shader — a pipeline Lit shader has one texture slot and no idea what a sphere-mapped
+second unit is — so on those the second unit is dropped and the log says so. `-wmvOwnShader` forces
+the renderer's own shader if you want to see it.
+
+**A model hides geometry by keying an animation track to zero, not by leaving it out.** An eye
+overlay, a glow, a blink. The OpenGL viewport refuses to draw a batch whose colour entry resolves to
+zero alpha (`ModelRenderPass::init`), and so does this renderer. chicken2 is the worked example: it
+ships an 18-triangle eye overlay pointing at a colour entry whose alpha track is 0, while the actual
+eye is painted into the skin texture on the head underneath. Drawing that batch anyway covers the
+painted eye with a flat red patch. `-wmvShowHidden` draws them if you want to see what is hidden.
+
+## Debug switches
+
+Pass these on the player command line to isolate a visual fault without rebuilding:
+
+| Flag | Effect |
+|---|---|
+| `-wmvFlipV` | invert the V texture coordinate — isolates a UV-orientation fault |
+| `-wmvForceOpaque` | force every material opaque, ignoring the WoW blend mode |
+| `-wmvForceSolid` | force-opaque **plus** a fully opaque alpha channel on every uploaded texture. If the model is still see-through with this on, the fault is geometry, depth or winding — not alpha |
+| `-wmvMatColors` | replace textures with a flat per-material colour — separates a batch/material assignment fault from a texture fault |
+| `-wmvShowHidden` | draw the batches the model hides at rest — shows *what* is hidden, and usually what it was covering |
+| `-wmvOwnShader` | resolve the renderer's own `WmvOpaque` shader ahead of any pipeline shader — the only one that can run an M2 combiner |
+
+Each model load also logs its UV sample, per-batch material/blend/texture-slot mapping, the alpha
+treatment per texture, which batches are hidden at rest and why, the resolved combiner and per-unit
+UV routing, the full runtime material state, and the shader that was chosen.
+
 ## Scripts
 
 | File | Role |
 |---|---|
-| `WmvMain.cs` | Bootstrap: camera rig, light, test cube, on-screen status text, wires the IPC handlers. On `loadWoWModel` it requests the model raw bytes from WMV and reports byte length + SHA-1 (V1: no parsing/rendering yet). |
-| `WmvIpcClient.cs` | IPC client (protocol v1): connects back to the WMV server given by `-wmvPort`, sends `unityReady`, receives `loadWoWModel`, sends `getAsset` / `getAssetByFileDataID`, decodes + hash-checks `assetResponse`. |
-| `WmvOrbitCamera.cs` | Orbit / pan / zoom controls for the viewport. |
+| `WmvMain.cs` | Bootstrap (camera rig, light, placeholder, status overlay) and the load pipeline: on `loadWoWModel` it fetches the .m2, parses it, fetches the .skin profile named by SFID, resolves and fetches textures, builds the mesh and frames the camera. |
+| `WmvIpcClient.cs` | IPC client (protocol v1): connects back to the WMV server given by `-wmvPort`, sends `unityReady`, receives `loadWoWModel`, sends `getAsset` / `getAssetByFileDataID` / `getModelTextures`, decodes + hash-checks `assetResponse`. |
+| `WmvModelBuilder.cs` | Parsed model + skin + decoded textures -> Unity `Mesh` (one submesh per WoW batch), `Material` and `Texture2D`; owns and disposes those runtime resources so repeated loads do not leak. |
+| `Wow/M2Parser.cs` | Chunked M2 (MD21/MD20 v272): header, vertices, textures, materials, lookups, SFID/TXID. |
+| `Wow/M2SkinParser.cs` | .skin profile: vertex lookup, triangles, submeshes, batches, and the two-level index resolution into model vertices. |
+| `Wow/BlpDecoder.cs` | BLP2 -> RGBA32 in memory (palettized, DXT1/3/5, raw BGRA). |
+| `Wow/M2ShaderTable.cs` | Shader id + texture count -> combiner name/id and per-unit UV routing. Pure data, no rendering; the same table the OpenGL viewport resolves. |
+| `Wow/WowCoordinateConverter.cs` | The single WoW -> Unity axis/winding/UV conversion. |
+| `Assets/Resources/WmvOpaque.shader` | The renderer's own opaque textured shader, kept under `Resources/` so a player build cannot strip it. Exposes `_SrcBlend`/`_DstBlend`/`_ZWrite`/`_Cull`/`_Cutoff` as real properties, and carries the second texture unit + M2 combiner 12. |
+| `Wow/ByteCursor.cs` | Bounds-checked little-endian reader shared by the parsers. |
+| `WmvOrbitCamera.cs` | Orbit / pan / zoom controls plus bounds-driven framing of a loaded model. |
+
+The parsing layer under `Assets/Scripts/Wow/` deliberately has no `UnityEngine` dependency, so
+it can be compiled and unit-tested outside the editor -- see `Tests/WowParserTests.cs`, which is
+framework-free (`WowParserTests.RunAll()` returns a failure count) and covers valid/truncated/
+out-of-range M2 and skin data, the BLP encodings and the coordinate conversion.
 
 ## How embedding works
 
@@ -81,6 +204,9 @@ cl fake_unity_renderer.c user32.lib gdi32.lib shell32.lib ws2_32.lib /Fe:UnityRe
 
 Drop the result at `tools\unity-renderer\UnityRenderer.exe` to test the WMV side without
 installing Unity -- interactively via `View -> Unity Renderer`, or headlessly with
-`wowmodelviewer.exe -mo creature/chicken/chicken.m2 -unityipctest` (logs `[unityipc-test]
+`wowmodelviewer.exe -mo creature/chicken2/chicken2.m2 -unityipctest` (logs `[unityipc-test]
 RESULT: PASS|FAIL` in `userSettings\log.txt`; the stub own log is
-`userSettings\unityRenderer.log`).
+`userSettings\unityRenderer.log`). `creature/chicken2/chicken2.m2` is the primary target
+because it is a current, database-backed creature; `creature/chicken/chicken.m2` is kept as a
+regression case for the labelled `convention` texture fallback -- no creature display
+references it any more.

--- a/Tools/UnityRendererProject/TestStub/fake_unity_renderer.c
+++ b/Tools/UnityRendererProject/TestStub/fake_unity_renderer.c
@@ -228,6 +228,29 @@ static void handle_line(const char * line)
       ipc_send(req);
       _snprintf(req, sizeof(req), "{\"type\":\"bogusMessage\",\"requestId\":\"s%d\"}", g_nextRequest++);
       ipc_send(req);
+      /* metadata request: WMV resolves the model textures from the client database */
+      _snprintf(req, sizeof(req), "{\"type\":\"getModelTextures\",\"requestId\":\"s%d\",\"fileDataID\":%lld}",
+                g_nextRequest++, fdid);
+      ipc_send(req);
+    }
+  }
+  else if (strcmp(type, "modelTextures") == 0)
+  {
+    int ok = 0;
+    long long fdid = 0;
+    char err[256] = {0};
+    json_get_bool(line, "ok", &ok);
+    json_get_int(line, "fileDataID", &fdid);
+    if (ok)
+    {
+      logf("recv: modelTextures for %lld -> %.400s", fdid, line);
+      status("Model textures resolved");
+    }
+    else
+    {
+      json_get_string(line, "error", err, sizeof(err));
+      logf("recv: modelTextures for %lld failed: %s", fdid, err);
+      status("Model textures: %s", err);
     }
   }
   else if (strcmp(type, "assetResponse") == 0)

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -1,0 +1,373 @@
+// WowParserTests.cs
+//
+// Unit tests for the runtime parsing layer (M2, skin, BLP, coordinate conversion).
+//
+// Deliberately framework-free: the parsers are plain C# with no UnityEngine dependency, so
+// these run anywhere a C# compiler exists -- `WowParserTests.RunAll()` returns the failure
+// count and prints one line per case. That keeps them runnable in CI or from a console harness
+// without a Unity install, and they can be wrapped in [Test] methods for the Unity Test
+// Framework later without changing the assertions.
+//
+// Every fixture is a hand-built byte array. NO extracted WoW asset is committed here: the
+// fixtures encode only format structure (headers, offsets, counts), not game content.
+
+using System;
+using System.Collections.Generic;
+using Wmv.Wow;
+
+namespace Wmv.Wow.Tests
+{
+    public static class WowParserTests
+    {
+        static int failures;
+        static readonly List<string> log = new List<string>();
+
+        // ---------------------------------------------------------------- tiny assert kit
+
+        static void Check(bool condition, string name)
+        {
+            if (condition) log.Add("  PASS  " + name);
+            else { log.Add("  FAIL  " + name); failures++; }
+        }
+
+        static void Throws<T>(Action action, string name) where T : Exception
+        {
+            try
+            {
+                action();
+                log.Add("  FAIL  " + name + " (expected " + typeof(T).Name + ", nothing was thrown)");
+                failures++;
+            }
+            catch (T) { log.Add("  PASS  " + name); }
+            catch (Exception e)
+            {
+                log.Add("  FAIL  " + name + " (expected " + typeof(T).Name + ", got " + e.GetType().Name + ")");
+                failures++;
+            }
+        }
+
+        static void Near(float actual, float expected, string name, float eps = 1e-4f)
+        {
+            Check(Math.Abs(actual - expected) <= eps, name + " (expected " + expected + ", got " + actual + ")");
+        }
+
+        // ---------------------------------------------------------------- fixture builders
+
+        static void PutU32(byte[] b, int o, uint v)
+        {
+            b[o] = (byte)v; b[o + 1] = (byte)(v >> 8); b[o + 2] = (byte)(v >> 16); b[o + 3] = (byte)(v >> 24);
+        }
+
+        static void PutU16(byte[] b, int o, ushort v) { b[o] = (byte)v; b[o + 1] = (byte)(v >> 8); }
+
+        static void PutF32(byte[] b, int o, float v) { Buffer.BlockCopy(BitConverter.GetBytes(v), 0, b, o, 4); }
+
+        static void PutMagic(byte[] b, int o, string m)
+        {
+            for (int i = 0; i < 4; i++) b[o + i] = (byte)m[i];
+        }
+
+        /// <summary>Minimal but structurally valid MD20 payload with `vertexCount` vertices.</summary>
+        static byte[] BuildM2Payload(int vertexCount, int textureCount = 1, uint textureType = 11)
+        {
+            const int headerSize = 0x100;
+            int vertsOffset = headerSize;
+            int texOffset = vertsOffset + vertexCount * 48;
+            int matOffset = texOffset + textureCount * 16;
+            int lookupOffset = matOffset + 4;
+            int total = lookupOffset + 2;
+
+            var b = new byte[total];
+            PutMagic(b, 0, "MD20");
+            PutU32(b, 0x04, 272);
+            PutU32(b, 0x08, 0); PutU32(b, 0x0C, 0);            // name
+            PutU32(b, 0x10, 0);                                 // globalFlags
+            PutU32(b, 0x2C, 1); PutU32(b, 0x30, 0);             // bones (count only matters)
+            PutU32(b, 0x3C, (uint)vertexCount); PutU32(b, 0x40, (uint)vertsOffset);
+            PutU32(b, 0x44, 1);                                 // numSkinProfiles
+            PutU32(b, 0x50, (uint)textureCount); PutU32(b, 0x54, (uint)texOffset);
+            PutU32(b, 0x70, 1); PutU32(b, 0x74, (uint)matOffset);
+            PutU32(b, 0x80, 1); PutU32(b, 0x84, (uint)lookupOffset);
+
+            for (int i = 0; i < vertexCount; i++)
+            {
+                int o = vertsOffset + i * 48;
+                PutF32(b, o + 0, i);            // position
+                PutF32(b, o + 4, i * 2);
+                PutF32(b, o + 8, i * 3);
+                PutF32(b, o + 20, 0f);          // normal (after 4 weight + 4 index bytes)
+                PutF32(b, o + 24, 0f);
+                PutF32(b, o + 28, 1f);
+                PutF32(b, o + 32, 0.25f);       // uv0
+                PutF32(b, o + 36, 0.75f);
+            }
+            for (int i = 0; i < textureCount; i++)
+            {
+                PutU32(b, texOffset + i * 16 + 0, textureType);
+                PutU32(b, texOffset + i * 16 + 4, 3);   // flags: wrap x|y
+            }
+            PutU16(b, matOffset, 0);        // material flags
+            PutU16(b, matOffset + 2, 1);    // blend mode: alpha key
+            PutU16(b, lookupOffset, 0);     // textureLookup[0] -> slot 0
+            return b;
+        }
+
+        static byte[] WrapChunked(byte[] md20Payload, int[] sfid, int[] txid)
+        {
+            int total = 8 + md20Payload.Length + (sfid != null ? 8 + sfid.Length * 4 : 0)
+                                               + (txid != null ? 8 + txid.Length * 4 : 0);
+            var b = new byte[total];
+            int o = 0;
+            PutMagic(b, o, "MD21"); PutU32(b, o + 4, (uint)md20Payload.Length); o += 8;
+            Buffer.BlockCopy(md20Payload, 0, b, o, md20Payload.Length); o += md20Payload.Length;
+            if (sfid != null)
+            {
+                PutMagic(b, o, "SFID"); PutU32(b, o + 4, (uint)(sfid.Length * 4)); o += 8;
+                foreach (int id in sfid) { PutU32(b, o, (uint)id); o += 4; }
+            }
+            if (txid != null)
+            {
+                PutMagic(b, o, "TXID"); PutU32(b, o + 4, (uint)(txid.Length * 4)); o += 8;
+                foreach (int id in txid) { PutU32(b, o, (uint)id); o += 4; }
+            }
+            return b;
+        }
+
+        /// <summary>Skin with `vertexCount` lookup entries and one submesh covering `triangles`.</summary>
+        static byte[] BuildSkin(int vertexCount, ushort[] triangles, ushort submeshIndexCount = 0xFFFF,
+                                ushort lookupOverride = 0xFFFF)
+        {
+            const int headerSize = 0x30;
+            int vertOffset = headerSize;
+            int triOffset = vertOffset + vertexCount * 2;
+            int subOffset = triOffset + triangles.Length * 2;
+            int batchOffset = subOffset + 48;
+            int total = batchOffset + 24;
+
+            var b = new byte[total];
+            PutMagic(b, 0, "SKIN");
+            PutU32(b, 0x04, (uint)vertexCount); PutU32(b, 0x08, (uint)vertOffset);
+            PutU32(b, 0x0C, (uint)triangles.Length); PutU32(b, 0x10, (uint)triOffset);
+            PutU32(b, 0x14, 0); PutU32(b, 0x18, 0);                 // bones
+            PutU32(b, 0x1C, 1); PutU32(b, 0x20, (uint)subOffset);   // submeshes
+            PutU32(b, 0x24, 1); PutU32(b, 0x28, (uint)batchOffset); // batches
+
+            for (int i = 0; i < vertexCount; i++)
+                PutU16(b, vertOffset + i * 2, lookupOverride == 0xFFFF ? (ushort)i : lookupOverride);
+            for (int i = 0; i < triangles.Length; i++)
+                PutU16(b, triOffset + i * 2, triangles[i]);
+
+            PutU16(b, subOffset + 0, 0);                     // id
+            PutU16(b, subOffset + 2, 0);                     // level
+            PutU16(b, subOffset + 4, 0);                     // vertexStart
+            PutU16(b, subOffset + 6, (ushort)vertexCount);   // vertexCount
+            PutU16(b, subOffset + 8, 0);                     // indexStart
+            PutU16(b, subOffset + 10, submeshIndexCount == 0xFFFF ? (ushort)triangles.Length : submeshIndexCount);
+
+            b[batchOffset] = 0;                              // flags
+            PutU16(b, batchOffset + 4, 0);                   // submeshIndex
+            PutU16(b, batchOffset + 14, 1);                  // textureCount
+            PutU16(b, batchOffset + 16, 0);                  // textureComboIndex
+            return b;
+        }
+
+        /// <summary>BLP2 with one palettized mip level.</summary>
+        static byte[] BuildBlpPalettized(int w, int h, byte alphaSize)
+        {
+            const int headerSize = 0x494;
+            int pixels = w * h;
+            int alphaBytes = alphaSize == 8 ? pixels : alphaSize == 4 ? (pixels + 1) / 2
+                           : alphaSize == 1 ? (pixels + 7) / 8 : 0;
+            var b = new byte[headerSize + pixels + alphaBytes];
+            PutMagic(b, 0, "BLP2");
+            PutU32(b, 0x04, 1);
+            b[0x08] = 1;            // palettized
+            b[0x09] = alphaSize;
+            b[0x0A] = 0;
+            b[0x0B] = 0;
+            PutU32(b, 0x0C, (uint)w);
+            PutU32(b, 0x10, (uint)h);
+            PutU32(b, 0x14, headerSize);                       // mipOffsets[0]
+            PutU32(b, 0x54, (uint)(pixels + alphaBytes));      // mipSizes[0]
+            // palette entry 1 = pure red; palette entries are BGRA, so bytes are 00 00 FF 00
+            PutU32(b, 0x94 + 4, 0x00FF0000u);
+            for (int i = 0; i < pixels; i++) b[headerSize + i] = 1;
+            for (int i = 0; i < alphaBytes; i++) b[headerSize + pixels + i] = 0xFF;
+            return b;
+        }
+
+        // ---------------------------------------------------------------- the tests
+
+        public static int RunAll(Action<string> output = null)
+        {
+            failures = 0;
+            log.Clear();
+
+            log.Add("M2Parser");
+            M2Tests();
+            log.Add("M2SkinParser");
+            SkinTests();
+            log.Add("BlpDecoder");
+            BlpTests();
+            log.Add("WowCoordinateConverter");
+            CoordinateTests();
+
+            log.Add(failures == 0 ? "ALL TESTS PASSED" : (failures + " TEST(S) FAILED"));
+            if (output != null)
+                foreach (var l in log) output(l);
+            return failures;
+        }
+
+        public static string LastReport { get { return string.Join(Environment.NewLine, log.ToArray()); } }
+
+        static void M2Tests()
+        {
+            // valid header + arrays, chunked exactly like retail
+            byte[] file = WrapChunked(BuildM2Payload(3), new[] { 473370 }, new[] { 0 });
+            M2ParsedModel m = M2Parser.Parse(file);
+            Check(m.Version == 272, "M2: version read");
+            Check(m.Vertices.Length == 3, "M2: vertex count");
+            Check(m.SkinFileDataIDs.Length == 1 && m.SkinFileDataIDs[0] == 473370, "M2: SFID chunk read");
+            Check(m.TextureFileDataIDs.Length == 1 && m.TextureFileDataIDs[0] == 0, "M2: TXID chunk read");
+            Check(m.Textures.Length == 1 && m.Textures[0].IsReplaceable, "M2: replaceable texture detected");
+            Check(m.Materials.Length == 1 && m.Materials[0].BlendMode == 1, "M2: material blend mode");
+            Near(m.Vertices[1].Position.X, 1f, "M2: vertex position X");
+            Near(m.Vertices[1].TexCoord0.Y, 0.75f, "M2: vertex uv V");
+            Check(m.BoundsMax.Z == 6f && m.BoundsMin.X == 0f, "M2: bounds computed");
+
+            // a bare (unchunked) MD20 is accepted too
+            M2ParsedModel bare = M2Parser.Parse(BuildM2Payload(2));
+            Check(bare.Vertices.Length == 2, "M2: bare MD20 accepted");
+
+            // truncated header
+            var truncated = new byte[64];
+            PutMagic(truncated, 0, "MD20");
+            Throws<WowParseException>(() => M2Parser.Parse(truncated), "M2: truncated header rejected");
+
+            // wrong magic
+            var wrongMagic = BuildM2Payload(1);
+            PutMagic(wrongMagic, 0, "XXXX");
+            Throws<WowParseException>(() => M2Parser.Parse(wrongMagic), "M2: wrong magic rejected");
+
+            // vertex array offset points past the end
+            var badOffset = BuildM2Payload(3);
+            PutU32(badOffset, 0x40, (uint)(badOffset.Length + 1000));
+            Throws<WowParseException>(() => M2Parser.Parse(badOffset), "M2: out-of-range array offset rejected");
+
+            // implausible count (overflow guard)
+            var badCount = BuildM2Payload(3);
+            PutU32(badCount, 0x3C, 0x40000000u);
+            Throws<WowParseException>(() => M2Parser.Parse(badCount), "M2: overflowing array count rejected");
+
+            // chunk larger than the file
+            var badChunk = WrapChunked(BuildM2Payload(1), null, null);
+            PutU32(badChunk, 4, (uint)(badChunk.Length * 4));
+            Throws<WowParseException>(() => M2Parser.Parse(badChunk), "M2: oversized chunk rejected");
+        }
+
+        static void SkinTests()
+        {
+            ushort[] tris = { 0, 1, 2, 2, 1, 0 };
+            M2ParsedSkin skin = M2SkinParser.Parse(BuildSkin(3, tris));
+            Check(skin.VertexLookup.Length == 3, "skin: vertex lookup count");
+            Check(skin.TriangleCount == 2, "skin: triangle count");
+            Check(skin.Submeshes.Length == 1 && skin.Submeshes[0].IndexCount == 6, "skin: submesh range");
+            Check(skin.Batches.Length == 1 && skin.Batches[0].TextureCount == 1, "skin: batch parsed");
+
+            int[] resolved = M2SkinParser.BuildTriangles(skin, skin.Submeshes[0], 3);
+            Check(resolved.Length == 6 && resolved[0] == 0 && resolved[3] == 2, "skin: two-level index resolution");
+
+            // triangle index outside the vertex lookup
+            ushort[] badTris = { 0, 1, 9 };
+            Throws<WowParseException>(() => M2SkinParser.Parse(BuildSkin(3, badTris)),
+                                      "skin: triangle index beyond lookup rejected");
+
+            // lookup entry pointing past the model's vertex array
+            M2ParsedSkin badLookup = M2SkinParser.Parse(BuildSkin(3, tris, 0xFFFF, 250));
+            Throws<WowParseException>(() => M2SkinParser.BuildTriangles(badLookup, badLookup.Submeshes[0], 3),
+                                      "skin: out-of-range model vertex index rejected");
+
+            // submesh claiming more indices than exist
+            Throws<WowParseException>(() => M2SkinParser.Parse(BuildSkin(3, tris, 300)),
+                                      "skin: invalid submesh range rejected");
+
+            // index count not a multiple of 3
+            ushort[] oddTris = { 0, 1 };
+            Throws<WowParseException>(() => M2SkinParser.Parse(BuildSkin(3, oddTris)),
+                                      "skin: non-multiple-of-3 index count rejected");
+
+            // wrong magic
+            byte[] wrong = BuildSkin(3, tris);
+            PutMagic(wrong, 0, "NOPE");
+            Throws<WowParseException>(() => M2SkinParser.Parse(wrong), "skin: wrong magic rejected");
+        }
+
+        static void BlpTests()
+        {
+            // the encoding chicken's skin actually uses (palettized + 8-bit alpha)
+            BlpImage img = BlpDecoder.Decode(BuildBlpPalettized(4, 4, 8));
+            Check(img.Width == 4 && img.Height == 4, "BLP: dimensions");
+            Check(img.Rgba.Length == 4 * 4 * 4, "BLP: decoded byte size");
+            Check(img.Rgba[0] == 255 && img.Rgba[1] == 0 && img.Rgba[2] == 0, "BLP: palette colour (BGRA->RGBA)");
+            Check(img.Rgba[3] == 255, "BLP: 8-bit alpha applied");
+            Check(img.Encoding == "palettized/a8", "BLP: encoding reported");
+
+            BlpImage noAlpha = BlpDecoder.Decode(BuildBlpPalettized(4, 4, 0));
+            Check(noAlpha.Rgba[3] == 255, "BLP: alphaSize 0 is opaque");
+
+            BlpImage a1 = BlpDecoder.Decode(BuildBlpPalettized(8, 8, 1));
+            Check(a1.Rgba[3] == 255, "BLP: 1-bit alpha applied");
+
+            // malformed header
+            Throws<WowParseException>(() => BlpDecoder.Decode(new byte[10]), "BLP: truncated header rejected");
+
+            byte[] wrongMagic = BuildBlpPalettized(4, 4, 8);
+            PutMagic(wrongMagic, 0, "BLP1");
+            Throws<WowParseException>(() => BlpDecoder.Decode(wrongMagic), "BLP: wrong magic rejected");
+
+            // unsupported colour encoding must say so explicitly
+            byte[] unsupported = BuildBlpPalettized(4, 4, 8);
+            unsupported[0x08] = 9;
+            Throws<WowParseException>(() => BlpDecoder.Decode(unsupported), "BLP: unsupported encoding rejected");
+
+            // mip level that is not present
+            Throws<WowParseException>(() => BlpDecoder.Decode(BuildBlpPalettized(4, 4, 8), 3),
+                                      "BLP: absent mip level rejected");
+
+            // implausible dimensions
+            byte[] huge = BuildBlpPalettized(4, 4, 8);
+            PutU32(huge, 0x0C, 100000);
+            Throws<WowParseException>(() => BlpDecoder.Decode(huge), "BLP: implausible dimensions rejected");
+        }
+
+        static void CoordinateTests()
+        {
+            // WoW (X forward, Y left, Z up) -> Unity (Z forward, X right, Y up)
+            float x, y, z;
+            WowCoordinateConverter.ConvertPosition(new WowVec3(1f, 2f, 3f), out x, out y, out z);
+            Near(x, -2f, "coords: X = -wowY (right = -left)");
+            Near(y, 3f, "coords: Y = wowZ (up)");
+            Near(z, 1f, "coords: Z = wowX (forward)");
+
+            WowCoordinateConverter.ConvertNormal(new WowVec3(0f, 0f, 1f), out x, out y, out z);
+            Near(x, 0f, "coords: up normal X");
+            Near(y, 1f, "coords: up normal stays up");
+            Near(z, 0f, "coords: up normal Z");
+
+            // conversion must preserve normal length (no scale leaking in)
+            WowCoordinateConverter.ConvertNormal(new WowVec3(0.6f, 0f, 0.8f), out x, out y, out z);
+            Near((float)Math.Sqrt(x * x + y * y + z * z), 1f, "coords: normals stay unit length");
+
+            float u, v;
+            WowCoordinateConverter.ConvertTexCoord(new WowVec2(0.25f, 0.75f), out u, out v);
+            Near(u, 0.25f, "coords: U unchanged");
+            Near(v, 0.25f, "coords: V flipped for Unity");
+
+            // winding must reverse, because the axis map is orientation-reversing
+            var tri = new[] { 0, 1, 2, 3, 4, 5 };
+            WowCoordinateConverter.FlipWinding(tri);
+            Check(tri[0] == 0 && tri[1] == 2 && tri[2] == 1, "coords: winding flipped (triangle 1)");
+            Check(tri[3] == 3 && tri[4] == 5 && tri[5] == 4, "coords: winding flipped (triangle 2)");
+        }
+    }
+}

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -135,7 +135,8 @@ namespace Wmv.Wow.Tests
 
         /// <summary>Skin with `vertexCount` lookup entries and one submesh covering `triangles`.</summary>
         static byte[] BuildSkin(int vertexCount, ushort[] triangles, ushort submeshIndexCount = 0xFFFF,
-                                ushort lookupOverride = 0xFFFF)
+                                ushort lookupOverride = 0xFFFF, ushort batchColorIndex = 0xFFFF,
+                                ushort batchTextureCount = 1)
         {
             const int headerSize = 0x30;
             int vertOffset = headerSize;
@@ -166,8 +167,12 @@ namespace Wmv.Wow.Tests
 
             b[batchOffset] = 0;                              // flags
             PutU16(b, batchOffset + 4, 0);                   // submeshIndex
-            PutU16(b, batchOffset + 14, 1);                  // textureCount
+            PutU16(b, batchOffset + 8, batchColorIndex);     // colorIndex
+            PutU16(b, batchOffset + 14, batchTextureCount);  // textureCount
             PutU16(b, batchOffset + 16, 0);                  // textureComboIndex
+            PutU16(b, batchOffset + 18, 0xFFFF);             // textureCoordComboIndex
+            PutU16(b, batchOffset + 20, 0);                  // textureWeightComboIndex
+            PutU16(b, batchOffset + 22, 0);                  // textureTransformComboIndex
             return b;
         }
 
@@ -211,6 +216,10 @@ namespace Wmv.Wow.Tests
             BlpTests();
             log.Add("WowCoordinateConverter");
             CoordinateTests();
+            log.Add("M2ShaderTable");
+            ShaderTableTests();
+            log.Add("Visibility tracks");
+            VisibilityTests();
 
             log.Add(failures == 0 ? "ALL TESTS PASSED" : (failures + " TEST(S) FAILED"));
             if (output != null)
@@ -338,6 +347,147 @@ namespace Wmv.Wow.Tests
             byte[] huge = BuildBlpPalettized(4, 4, 8);
             PutU32(huge, 0x0C, 100000);
             Throws<WowParseException>(() => BlpDecoder.Decode(huge), "BLP: implausible dimensions rejected");
+        }
+
+        /// <summary>
+        /// The shader table decides which combiner a material uses and where each texture unit
+        /// takes its coordinates from. Getting this wrong is invisible -- the model still renders,
+        /// just with every unit past the first silently dropped -- so it is worth pinning down.
+        /// chicken2's own material (2 units, shaderId 0x8000) is the worked example.
+        /// </summary>
+        static void ShaderTableTests()
+        {
+            var r = M2ShaderTable.Resolve(2, 0x8000);
+            Check(r.PixelShaderName == "Combiners_Opaque_Mod2xNA_Alpha", "shader: 0x8000 -> pixel shader name");
+            Check(r.PixelShader == 12, "shader: 0x8000 -> combiner id 12");
+            Check(r.VertexShaderName == "Diffuse_T1_Env", "shader: 0x8000 -> vertex shader name");
+            Check(r.UvSource[0] == M2UvSource.TexCoord0, "shader: unit 0 samples uv set 0");
+            Check(r.UvSource[1] == M2UvSource.Environment, "shader: unit 1 is an environment sphere map");
+
+            // 0x8000 | 21 -> Combiners_Mod_Mod / Diffuse_EdgeFade_T1_T2: EdgeFade is a fade term,
+            // not a texture unit, so unit 1 must still come out as uv set 1.
+            var edge = M2ShaderTable.Resolve(2, 0x8000 | 21);
+            Check(edge.VertexShaderName == "Diffuse_EdgeFade_T1_T2", "shader: edge-fade vertex shader name");
+            Check(edge.UvSource[0] == M2UvSource.TexCoord0 && edge.UvSource[1] == M2UvSource.TexCoord1,
+                  "shader: EdgeFade is skipped when assigning units");
+
+            // an explicit id past the end of the table must degrade, not throw
+            var over = M2ShaderTable.Resolve(2, 0x8000 | 999);
+            Check(over.PixelShaderName == "Combiners_Opaque" && over.VertexShaderName == "Diffuse_T1",
+                  "shader: out-of-range explicit id falls back");
+
+            // without the explicit bit the id is decoded from its bit fields instead
+            Check(M2ShaderTable.GetPixelShaderName(1, 0) == "Combiners_Opaque",
+                  "shader: single texture, no flags -> opaque");
+            Check(M2ShaderTable.GetPixelShaderName(1, 0x70) == "Combiners_Mod",
+                  "shader: single texture, mod flag");
+            Check(M2ShaderTable.GetVertexShaderName(2, 0x8) == "Diffuse_T1_Env",
+                  "shader: two textures, env flag");
+        }
+
+        /// <summary>
+        /// A model hides geometry it is not currently using by keying an animation track to zero
+        /// rather than by leaving the geometry out. Reading those tracks is what stops the
+        /// renderer drawing a hidden overlay on top of the detail it is meant to replace.
+        /// </summary>
+        static void VisibilityTests()
+        {
+            byte[] payload = BuildM2PayloadWithTracks(new[] { 0f, 1f }, 1f);
+            M2ParsedModel m = M2Parser.Parse(payload);
+
+            Check(m.Colors.Length == 2, "tracks: colours parsed");
+            Check(m.Colors[0].HasColorTrack && m.Colors[1].HasColorTrack, "tracks: colour RGB tracks present");
+            Near(m.Colors[0].Alpha, 0f, "tracks: colour 0 alpha is 0");
+            Near(m.Colors[1].Alpha, 1f, "tracks: colour 1 alpha is 1");
+            Check(m.TextureWeights.Length == 1, "tracks: texture weights parsed");
+            Near(m.TextureWeights[0], 1f, "tracks: texture weight value");
+            Check(m.TextureWeightLookup.Length == 1 && m.TextureWeightLookup[0] == 0,
+                  "tracks: texture weight lookup parsed");
+
+            // a header with no such arrays must leave them empty, not throw: that is what makes
+            // "no tracks" mean "everything visible" rather than "everything hidden".
+            M2ParsedModel plain = M2Parser.Parse(BuildM2Payload(2));
+            Check(plain.Colors.Length == 0 && plain.TextureWeights.Length == 0,
+                  "tracks: absent arrays parse as empty");
+
+            // the batch fields those tracks are reached through
+            var skin = M2SkinParser.Parse(BuildSkin(3, new ushort[] { 0, 1, 2 },
+                                                    batchColorIndex: 0, batchTextureCount: 2));
+            Check(skin.Batches[0].ColorIndex == 0 && skin.Batches[0].HasColor,
+                  "tracks: batch colour index parsed");
+            Check(skin.Batches[0].TextureWeightComboIndex == 0, "tracks: batch weight combo index parsed");
+            Check(skin.Batches[0].TextureCoordComboIndex == 0xFFFF, "tracks: batch coord combo index parsed");
+
+            // a batch with no colour entry is never hidden by one
+            var noColor = M2SkinParser.Parse(BuildSkin(3, new ushort[] { 0, 1, 2 }));
+            Check(!noColor.Batches[0].HasColor, "tracks: 0xFFFF colour index means 'no colour entry'");
+
+            // two texture units resolve to two different slots through the same combo run
+            M2ParsedModel two = M2Parser.Parse(BuildM2PayloadWithTracks(new[] { 1f }, 1f, texLookup: new ushort[] { 0, 1 }));
+            Check(two.TextureLookup.Length == 2 && two.TextureLookup[0] == 0 && two.TextureLookup[1] == 1,
+                  "tracks: texture combo run resolves both units");
+        }
+
+        /// <summary>
+        /// An M2 payload carrying colour and texture-weight tracks. Each track is
+        /// {uint16 interpolation, uint16 globalSeq, M2Array timestamps, M2Array values}, where
+        /// both arrays are arrays OF arrays -- one per animation.
+        /// </summary>
+        static byte[] BuildM2PayloadWithTracks(float[] colorAlphas, float weight, ushort[] texLookup = null)
+        {
+            if (texLookup == null) texLookup = new ushort[] { 0 };
+            const int headerSize = 0x100;
+            int vertsOffset = headerSize;
+            int texOffset = vertsOffset + 1 * 48;
+            int matOffset = texOffset + 1 * 16;
+            int lookupOffset = matOffset + 4;
+            int colorsOffset = lookupOffset + texLookup.Length * 2;
+            int weightsOffset = colorsOffset + colorAlphas.Length * 40;
+            int weightLookupOffset = weightsOffset + 20;
+            // one nested-array header + one value per track, laid out after everything else
+            int poolOffset = weightLookupOffset + 2;
+            int total = poolOffset + (colorAlphas.Length * 2 + 1) * (8 + 2) + 64;
+
+            var b = new byte[total];
+            PutMagic(b, 0, "MD20");
+            PutU32(b, 0x04, 272);
+            PutU32(b, 0x3C, 1); PutU32(b, 0x40, (uint)vertsOffset);
+            PutU32(b, 0x44, 1);
+            PutU32(b, 0x50, 1); PutU32(b, 0x54, (uint)texOffset);
+            PutU32(b, 0x70, 1); PutU32(b, 0x74, (uint)matOffset);
+            PutU32(b, 0x80, (uint)texLookup.Length); PutU32(b, 0x84, (uint)lookupOffset);
+            PutU32(b, 0x48, (uint)colorAlphas.Length); PutU32(b, 0x4C, (uint)colorsOffset);
+            PutU32(b, 0x58, 1); PutU32(b, 0x5C, (uint)weightsOffset);
+            PutU32(b, 0x90, 1); PutU32(b, 0x94, (uint)weightLookupOffset);
+
+            PutU32(b, texOffset, 11);
+            for (int i = 0; i < texLookup.Length; i++) PutU16(b, lookupOffset + i * 2, texLookup[i]);
+            PutU16(b, weightLookupOffset, 0);
+
+            int pool = poolOffset;
+            // Writes one M2Track at trackOffset holding a single fixed16 value, and returns the
+            // next free byte in the pool.
+            Func<int, float, int> writeTrack = (trackOffset, value) =>
+            {
+                int inner = pool;                       // the value itself
+                PutU16(b, inner, (ushort)(short)(value * 32767f));
+                pool += 2;
+                int outer = pool;                       // M2Array pointing at it
+                PutU32(b, outer, 1); PutU32(b, outer + 4, (uint)inner);
+                pool += 8;
+                PutU32(b, trackOffset + 12, 1);         // values: one animation
+                PutU32(b, trackOffset + 16, (uint)outer);
+                return pool;
+            };
+
+            for (int i = 0; i < colorAlphas.Length; i++)
+            {
+                int rec = colorsOffset + i * 40;
+                writeTrack(rec, 1f);                    // RGB track: only its presence is read
+                writeTrack(rec + 20, colorAlphas[i]);   // alpha track
+            }
+            writeTrack(weightsOffset, weight);
+            return b;
         }
 
         static void CoordinateTests()

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -108,7 +108,27 @@ viewport uses). Player side: `Tools/UnityRendererProject/Assets/Scripts/WmvIpcCl
 { "type": "unityReady", "protocolVersion": 1 }
 { "type": "getAsset", "requestId": "abc123", "path": "creature/chicken/chicken.m2" }
 { "type": "getAssetByFileDataID", "requestId": "abc124", "fileDataID": 123456 }
+{ "type": "getModelTextures", "requestId": "abc125", "fileDataID": 123200 }
 ```
+
+`getModelTextures` answers with `modelTextures { requestId, ok, fileDataID, textures:[{ index,
+fileDataID, source }] }`. It exists because a modern M2 does **not** name its replaceable
+textures: a creature skin's TXID entry is 0 and its texture array carries no filename, because
+the actual skin comes from the client database.
+
+- **`source: "database"` -- the normal, authoritative route.** WMV resolves the skin from
+  `CreatureDisplayInfo` joined to `CreatureModelData` on the model's FileDataID: the same
+  relation the legacy viewer's own skin list uses. This is the path any current creature takes,
+  and the path the primary validation target `creature/chicken2/chicken2.m2` exercises.
+- **`source: "convention"` -- a labelled fallback, not a substitute.** A handful of legacy
+  assets are still shipped in CASC but referenced by no creature display at all (for example
+  `creature/chicken/chicken.m2`, superseded by `chicken2`), so the database has nothing to say
+  about them. Rather than render them untextured, WMV looks for the conventional sibling skin
+  in the listfile and marks the result `convention`, so the renderer -- and anyone reading the
+  logs -- can tell a naming guess from database truth. A model that resolves only this way is
+  a regression case, never the proof that texture resolution works.
+
+The response carries metadata only; bytes are still fetched with `getAssetByFileDataID`.
 
 **WMV -> player**
 
@@ -156,6 +176,39 @@ launches the installed player (TestStub or a real build) embedded in the off-scr
 in-process, and shuts the player down. Result lines carry the `[unityipc-test]` prefix
 (`RESULT: PASS|FAIL`).
 
+## Status
+
+**Implemented**
+
+- Runtime CASC/MPQ asset access: the player asks WMV for raw WoW files over IPC and never
+  touches game archives or the disk itself.
+- Static M2 mesh rendering: the modern chunked M2 (MD21 / MD20 version 272 as current retail
+  ships) and its .skin profile are parsed at runtime into a Unity mesh with per-batch
+  submeshes, converted to Unity's coordinate system with corrected winding.
+- Runtime BLP decoding for the formats the creature pipeline uses: palettized (alpha 0/1/4/8),
+  DXT1 / DXT3 / DXT5 and raw BGRA, decoded straight from the received bytes into an in-memory
+  texture. Anything else is reported by name instead of being decoded into garbage.
+- Basic materials: opaque, alpha-key and alpha blending, two-sided when the model asks for it.
+  Blend modes beyond that log a diagnostic and draw opaque.
+- Model textures the M2 does not name (replaceable creature skins) are resolved by WMV from
+  the client database and handed to the player as FileDataIDs (`getModelTextures`), labelled
+  `database` or -- for orphaned legacy assets only -- `convention`.
+- Bounds-driven camera framing, so a loaded model is visible immediately.
+
+**Not yet implemented**
+
+- Skeletal animation (bone data is parsed and preserved, but nothing is animated or skinned).
+- The full WoW material system (shader/combiner effects, texture animation, environment
+  mapping, colour/transparency tracks).
+- Particles and ribbons.
+- The character / equipment pipeline (customization, attachments, geoset rules).
+- Maps, terrain, WMOs, fog.
+- Full parity with the legacy OpenGL renderer.
+
+Unity remains the migration target and the intended primary renderer; the OpenGL viewport
+remains the legacy/fallback renderer during the migration. There is no asset-export workflow:
+every byte the renderer uses arrives over IPC at runtime and nothing is written to disk.
+
 ## Migration roadmap
 
 - **V0 (merged):** `View -> Unity Renderer` opens a dockable pane, launches the player
@@ -165,9 +218,13 @@ in-process, and shuts the player down. Result lines carry the `[unityipc-test]` 
   back, announces `unityReady`, receives `loadWoWModel` and fetches the model's raw bytes with
   `getAsset` / `getAssetByFileDataID`, served by WMV from the active client (CASC or MPQ) and
   verified by byte length + SHA-1 on the player side. No M2 parsing or mesh rendering yet.
-- **V2: direct rendering.** Unity-side M2 + skin + BLP loaders built on these bytes (plus
-  metadata requests added to the same channel as needed) render
-  `creature/chicken/chicken.m2` directly from WoW data. Binary framing for asset payloads.
+- **V2 (this branch): direct rendering.** Unity-side M2 + skin + BLP loaders built on those
+  bytes render a WoW model directly from game data as a static mesh -- parsed, converted,
+  textured and framed at runtime. Primary validation target is
+  `creature/chicken2/chicken2.m2`, a current, database-backed creature: 1632 vertices, 796
+  triangles, 2 submeshes, 2 materials (opaque + alpha), skin resolved through
+  `CreatureDisplayInfo` to a 256x256 DXT5 texture. Binary framing for asset payloads is still
+  open.
 - **V3+ (Unity first):** characters + customization, equipment/attachments, animation,
   maps/terrain/fog, OBS-friendly backgrounds and scene/stream features -- each built on the
   Unity pipeline, with the legacy OpenGL viewport kept as fallback until parity.


### PR DESCRIPTION
Third step of the Unity renderer migration after the embedded Unity viewport and runtime asset-access IPC.

This adds initial static M2 rendering in the embedded Unity renderer. A WoW model is loaded through WMW, transferred over runtime IPC, parsed on the Unity side, and rendered as a textured static mesh.

### Includes

- Runtime M2 parsing
- `.skin` parsing
- BLP2 texture decoding
- WoW-to-Unity coordinate conversion
- Static mesh construction in Unity
- Material and texture ownership/disposal
- `getModelTextures` IPC metadata lookup for replaceable creature skins
- Database-backed texture resolution through `CreatureDisplayInfo` / `CreatureModelData`
- Clearly-labelled convention fallback for orphaned legacy assets
- `Assets/Resources/WmvOpaque.shader` to avoid Unity player shader stripping
- Initial support for chicken2's combiner/env texture case
- Hidden batch/color-alpha gate matching the existing OpenGL path

### Validation

Validated with `creature/chicken2/chicken2.m2` in a real Unity 6 URP player build.

The model renders in the embedded Unity viewport as a static textured mesh. The chicken2 eye overlay issue was fixed by matching the OpenGL batch visibility gate; the environment texture is bound as unit 1 for the combiner path.

Checks:
- 72 parser tests pass
- Unity script type-check passes across input backends
- `-unityipctest` passes
- OpenGL/headless path unaffected
- no OBJ/FBX/GLB export workflow
- no files exported to disk
- Unity player build output is not committed

### Out of scope

- animation
- skinning
- full material system
- particles/ribbons
- characters/equipment
- maps
- fog
- OBS/Tiltify integration

Unity remains optional at build and runtime. The Unity player is built locally and is not committed.