### PR TITLE
Sync Unity renderer with selected model skin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Embedded Unity renderer: it now shows the skin you picked.** A creature normally has several
+  skins -- `chicken2` offers seven -- and the renderer was resolving whichever one the database
+  listed first, so the Unity viewport could show a white chicken while the OpenGL viewport showed
+  the spotted one the user had selected (or the one "Random Skins" had rolled). The app now
+  answers "which textures does this model use" from its own skin selector rather than from the
+  database default, and pushes a `modelSkin` message whenever the selection changes -- from the
+  dropdown, from the default chosen on model load, from NPC import, and from the per-slot
+  folder-texture lists. The player re-uploads only the textures that actually changed and keeps
+  the mesh it already built: a skin change alters which image a material samples, nothing about
+  the geometry. Re-picking the skin already on screen fetches nothing. Texture metadata now
+  carries the WoW texture *type* rather than a bare position, because a model's texture-variation
+  order and its M2 texture-slot order need not agree. Geoset variations (a display that toggles
+  geometry) remain out of scope for this static-M2 milestone.
 - **Embedded Unity renderer: static WoW models now render (M2 + BLP at runtime).** The Unity
   viewport no longer just fetches bytes -- it turns them into a visible model. On `loadWoWModel`
   the player fetches the `.m2`, parses it, fetches the `.skin` profile the model names, resolves

--- a/Source/wowmodelviewer/UnityAssetAccess.cpp
+++ b/Source/wowmodelviewer/UnityAssetAccess.cpp
@@ -11,6 +11,10 @@
 #include "HardDriveFile.h"
 #include "GameDatabase.h"   // sqlResult / GAMEDATABASE query surface
 #include "WoWFolder.h"
+#include "animcontrol.h"    // the skin selector: what the viewport is actually showing
+#include "globalvars.h"
+#include "modelviewer.h"
+#include "wow_enums.h"      // TEXTURE_GAMEOBJECT1
 #include "logger/Logger.h"
 
 namespace
@@ -204,6 +208,16 @@ UnityAssetAccess::Result UnityAssetAccess::readByPath(const QString & path)
   return r;
 }
 
+const char * UnityAssetAccess::sourceName(ModelTexture::Source source)
+{
+  switch (source)
+  {
+    case ModelTexture::Selection:  return "selection";
+    case ModelTexture::Convention: return "convention";
+    default:                       return "database";
+  }
+}
+
 bool UnityAssetAccess::resolveModelTextures(int m2FileDataID, std::vector<ModelTexture> & out, QString & error)
 {
   out.clear();
@@ -218,9 +232,32 @@ bool UnityAssetAccess::resolveModelTextures(int m2FileDataID, std::vector<ModelT
     return false;
   }
 
-  // 1) Authoritative: the creature's skins live on CreatureDisplayInfo, keyed to the model
-  //    through CreatureModelData.FileDataID -- the same relation the viewer's own skin list
-  //    uses (AnimControl::UpdateModel). Take the first display: the viewer's default skin.
+  // 0) What the viewport is showing. A creature normally has several skins -- chicken2 has seven
+  //    -- and which one is on screen is a UI fact the database cannot answer: it only knows the
+  //    default. Guarded on the model actually being the displayed one, so a request about some
+  //    other model still falls through to the database below.
+  if (g_modelViewer && g_modelViewer->animControl && g_selModel && g_selModel->gamefile &&
+      (int)g_selModel->gamefile->fileDataId() == m2FileDataID)
+  {
+    std::vector<std::pair<int, int> > selected;
+    if (g_modelViewer->animControl->selectedSkinTextures(selected))
+    {
+      for (size_t i = 0; i < selected.size(); i++)
+      {
+        ModelTexture t;
+        t.index = (int)i;
+        t.type = selected[i].first;
+        t.fileDataID = selected[i].second;
+        t.source = ModelTexture::Selection;
+        out.push_back(t);
+      }
+      return true;
+    }
+  }
+
+  // 1) The model's DEFAULT skin: the creature's skins live on CreatureDisplayInfo, keyed to the
+  //    model through CreatureModelData.FileDataID -- the same relation the viewer's own skin list
+  //    uses (AnimControl::UpdateModel). Take the first display.
   //    Column count differs across client generations, so try the widest form first.
   const char * queries[] = {
     "SELECT TextureVariationFileDataID1, TextureVariationFileDataID2, TextureVariationFileDataID3, "
@@ -246,8 +283,11 @@ bool UnityAssetAccess::resolveModelTextures(int m2FileDataID, std::vector<ModelT
       {
         ModelTexture t;
         t.index = (int)i;
+        // Variation i feeds creature-skin slot i, exactly as the viewer's own skin list does
+        // (TextureGroup::base is TEXTURE_GAMEOBJECT1 and SetSkin applies base + i).
+        t.type = TEXTURE_GAMEOBJECT1 + (int)i;
         t.fileDataID = id;
-        t.fromDatabase = true;
+        t.source = ModelTexture::Database;
         out.push_back(t);
       }
     }
@@ -273,8 +313,9 @@ bool UnityAssetAccess::resolveModelTextures(int m2FileDataID, std::vector<ModelT
       {
         ModelTexture t;
         t.index = 0;
+        t.type = TEXTURE_GAMEOBJECT1;
         t.fileDataID = id;
-        t.fromDatabase = false;
+        t.source = ModelTexture::Convention;
         out.push_back(t);
         LOG_INFO << "[unityipc] no creature display for model" << m2FileDataID
                  << "-- using the conventional sibling skin" << cand << "(fileDataID" << id << ")";

--- a/Source/wowmodelviewer/UnityAssetAccess.h
+++ b/Source/wowmodelviewer/UnityAssetAccess.h
@@ -50,17 +50,38 @@ public:
   // database. Only WMV can answer that -- it owns the DB -- so the renderer asks for it.
   struct ModelTexture
   {
-    int index = 0;         // slot in the model's texture array / variation index
-    int fileDataID = 0;    // resolved texture FileDataID (fetch it with readByFileDataID)
-    bool fromDatabase = true; // true: CreatureDisplayInfo (authoritative). false: the model is
-                              // not referenced by any creature display any more (legacy asset)
-                              // and this is the conventional sibling skin found in the listfile.
+    // Where the answer came from. Reported to the renderer so a naming guess is never mistaken
+    // for database truth, and so a stale default is never mistaken for what is on screen.
+    enum Source
+    {
+      Selection,   // the skin the viewport is showing right now (the app's own skin selector)
+      Database,    // CreatureDisplayInfo -- authoritative, but only about the DEFAULT skin
+      Convention,  // a listfile naming guess, for models no creature display references
+    };
+
+    int index = 0;       // position among the display's texture variations
+    int type = 0;        // WoW texture TYPE this feeds: TEXTURE_GAMEOBJECT1 (11) is the first
+                         // creature skin, 12 and 13 the second and third. The renderer maps it
+                         // onto the M2 texture slot(s) declaring that type -- which is the only
+                         // correct mapping, since variation order and slot order need not agree.
+    int fileDataID = 0;  // resolved texture FileDataID (fetch it with readByFileDataID)
+    Source source = Database;
   };
 
-  // Resolve the texture(s) of a model that the M2 itself does not name, using the same
-  // CreatureDisplayInfo -> CreatureModelData relation the viewer uses for its own skin list.
-  // Returns the FIRST display's variations (the viewer's own default skin). False with a
-  // reason when there is no client, no database or no matching creature display.
+  // "database" / "selection" / "convention" -- the wire spelling of ModelTexture::Source.
+  static const char * sourceName(ModelTexture::Source source);
+
+  // Resolve the texture(s) of a model that the M2 itself does not name.
+  //
+  // Tries, in order:
+  //   1. the skin the viewport is CURRENTLY showing, from the app's own skin selector. A model
+  //      usually has several skins (chicken2 has seven) and the database can only say which is
+  //      the default, so this is the only source that answers "what is on screen".
+  //   2. CreatureDisplayInfo -> CreatureModelData, the same relation the viewer's skin list is
+  //      built from -- the model's default skin, used before a selection exists.
+  //   3. the conventional sibling skin from the listfile, for legacy models no creature display
+  //      references any more.
+  // False with a reason when none of them can answer.
   static bool resolveModelTextures(int m2FileDataID, std::vector<ModelTexture> & out, QString & error);
 
   // Name of the active client's storage backend ("CASC"/"MPQ"/"Unknown") -- for logging.

--- a/Source/wowmodelviewer/UnityIpcServer.cpp
+++ b/Source/wowmodelviewer/UnityIpcServer.cpp
@@ -277,6 +277,50 @@ void UnityIpcServer::queueJson(const QJsonObject & obj)
 #endif
 }
 
+QJsonArray UnityIpcServer::textureArray(const std::vector<UnityAssetAccess::ModelTexture> & textures)
+{
+  QJsonArray arr;
+  for (const UnityAssetAccess::ModelTexture & t : textures)
+  {
+    QJsonObject o;
+    o["index"] = t.index;
+    o["type"] = t.type;
+    o["fileDataID"] = t.fileDataID;
+    o["source"] = UnityAssetAccess::sourceName(t.source);
+    arr.append(o);
+  }
+  return arr;
+}
+
+void UnityIpcServer::sendModelSkin(int m2FileDataID)
+{
+  if (!m_client || !m_unityReady || m2FileDataID <= 0)
+    return;
+
+  std::vector<UnityAssetAccess::ModelTexture> textures;
+  QString error;
+  if (!UnityAssetAccess::resolveModelTextures(m2FileDataID, textures, error))
+  {
+    // Not an error worth shouting about: a model with no resolvable skin simply has nothing to
+    // follow, and the player keeps what it already has.
+    LOG_INFO << "[unityipc] modelSkin for" << m2FileDataID << "not sent:" << error;
+    return;
+  }
+
+  QJsonObject msg;
+  msg["type"] = "modelSkin";
+  msg["ok"] = true;              // same shape as a modelTextures reply, so one reader handles both
+  msg["fileDataID"] = m2FileDataID;
+  msg["textures"] = textureArray(textures);
+  m_stats.skinPushes++;
+  m_stats.lastSkin = QString("%1 (%2)").arg(textures[0].fileDataID)
+                                       .arg(UnityAssetAccess::sourceName(textures[0].source));
+  LOG_INFO << "[unityipc] -> modelSkin fileDataID=" << m2FileDataID << "textures=" << (int)textures.size()
+           << "source=" << UnityAssetAccess::sourceName(textures[0].source)
+           << "first=" << textures[0].fileDataID;
+  queueJson(msg);
+}
+
 void UnityIpcServer::sendLoadWoWModel(const QString & path, int fileDataID, const QString & client)
 {
   QJsonObject msg;
@@ -356,18 +400,11 @@ void UnityIpcServer::handleGetModelTextures(const QJsonObject & msg)
   resp["fileDataID"] = fdid;
   if (ok)
   {
-    QJsonArray arr;
-    for (const UnityAssetAccess::ModelTexture & t : textures)
-    {
-      QJsonObject o;
-      o["index"] = t.index;
-      o["fileDataID"] = t.fileDataID;
-      o["source"] = t.fromDatabase ? "database" : "convention";
-      arr.append(o);
-    }
-    resp["textures"] = arr;
+    resp["textures"] = textureArray(textures);
     m_stats.responsesOk++;
-    LOG_INFO << "[unityipc] -> modelTextures" << requestId << "resolved" << (int)textures.size() << "texture(s)";
+    LOG_INFO << "[unityipc] -> modelTextures" << requestId << "resolved" << (int)textures.size()
+             << "texture(s) from" << UnityAssetAccess::sourceName(textures.empty()
+                  ? UnityAssetAccess::ModelTexture::Database : textures[0].source);
   }
   else
   {

--- a/Source/wowmodelviewer/UnityIpcServer.h
+++ b/Source/wowmodelviewer/UnityIpcServer.h
@@ -25,12 +25,23 @@
  *       "byteLength":123456, "sha1":"...", "encoding":"base64", "data":"..." }
  *     { "type":"assetResponse", "requestId":"abc123", "ok":false, "error":"not found" }
  *     { "type":"modelTextures", "requestId":"abc125", "ok":true, "fileDataID":123200,
- *       "textures":[ { "index":0, "fileDataID":123199 } ] }
+ *       "textures":[ { "index":0, "type":11, "fileDataID":123199, "source":"selection" } ] }
+ *     { "type":"modelSkin", "fileDataID":1521037,
+ *       "textures":[ { "index":0, "type":11, "fileDataID":1521061, "source":"selection" } ] }
  *
  * getModelTextures exists because modern M2s do NOT name their replaceable textures (a
  * creature skin's TXID entry is 0 and the texture array carries no filename) -- the skin comes
  * from the client database, which only WMV can read. It returns metadata only; the renderer
  * still fetches the bytes with getAssetByFileDataID.
+ *
+ * "type" is the WoW texture TYPE the texture feeds (11/12/13 for the three creature skin slots),
+ * NOT a position: variation order and M2 texture-slot order need not agree, so the renderer maps
+ * the type onto the slots that declare it. "source" says where the answer came from --
+ * "selection" is the skin the viewport is showing right now, "database" only the model's default.
+ *
+ * modelSkin is pushed whenever the displayed skin changes (the dropdown, or the default chosen on
+ * model load). Same payload as modelTextures, no request: the player swaps the texture and keeps
+ * the mesh it already built.
  *
  * Implementation: plain Winsock2, non-blocking, polled from the GUI thread by a wxTimer (the
  * app has no Qt event loop, so QTcpServer signals would never fire; and GAMEDIRECTORY must be
@@ -49,9 +60,14 @@
 #include <functional>
 #include <string>
 
+#include <vector>
+
 #include <QByteArray>
+#include <QJsonArray>
 #include <QJsonObject>
 #include <QString>
+
+#include "UnityAssetAccess.h"
 
 class UnityIpcServer : public wxEvtHandler
 {
@@ -75,6 +91,11 @@ public:
   // empty/0. Queued if the player is connected; dropped (logged) otherwise.
   void sendLoadWoWModel(const QString & path, int fileDataID, const QString & client = QStringLiteral("active"));
 
+  // Runtime command: the skin on display changed. Resolves the model's textures the same way
+  // getModelTextures does -- so the push and the reply can never disagree -- and sends them
+  // unasked. No-op when the player is not connected, or when nothing can be resolved.
+  void sendModelSkin(int m2FileDataID);
+
   // Raised (on the GUI thread) when the player's unityReady arrives -- the host uses it to
   // push the currently displayed model.
   std::function<void()> onUnityReady;
@@ -91,9 +112,11 @@ public:
     int responsesOk = 0;
     int responsesError = 0;
     long long bytesServed = 0;
+    int skinPushes = 0;     // modelSkin messages sent (the displayed skin changed)
     QString lastRequest;    // "path" or "fileDataID n"
     QString lastProvider;   // "CASC" / "MPQ" / ""
     QString lastError;
+    QString lastSkin;       // "<fileDataID> (<source>)" of the last skin pushed
   };
   const Stats & stats() const { return m_stats; }
 
@@ -105,6 +128,7 @@ private:
   void handleLine(const std::string & line);
   void handleGetAsset(const QJsonObject & msg, bool byFileDataID);
   void handleGetModelTextures(const QJsonObject & msg);
+  static QJsonArray textureArray(const std::vector<UnityAssetAccess::ModelTexture> & textures);
   void queueJson(const QJsonObject & obj);
   void dropClient(const char * why);
 

--- a/Source/wowmodelviewer/animcontrol.cpp
+++ b/Source/wowmodelviewer/animcontrol.cpp
@@ -196,6 +196,7 @@ void AnimControl::UpdateModel(WoWModel *m)
     return;
   PCRList.clear();
   CDIToTexGp.clear();
+  singleSkinOverrides.clear();
   // Clear skin/texture data from previous model - if there is any.
   if (g_selModel)
   {
@@ -1403,9 +1404,61 @@ void AnimControl::OnLoop(wxCommandEvent &)
   } 
 }
 
+int AnimControl::skinCount()
+{
+  return (skinList && skinList->IsShown()) ? (int)skinList->GetCount() : 0;
+}
+
+wxString AnimControl::skinName(int index)
+{
+  if (!skinList || index < 0 || index >= (int)skinList->GetCount())
+    return wxEmptyString;
+  return skinList->GetString((unsigned int)index);
+}
+
+bool AnimControl::selectedSkinTextures(std::vector<std::pair<int, int> > & out)
+{
+  out.clear();
+  if (!skinList || !skinList->IsShown())
+    return false;
+
+  // Whatever whole skin is selected, if any. A per-slot pick clears this selection, which is why
+  // the overrides below can still answer on their own.
+  std::map<int, int> byType;
+  const int sel = skinList->GetSelection();
+  if (sel >= 0)
+  {
+    TextureGroup * grp = static_cast<TextureGroup *>(skinList->GetClientData((unsigned int)sel));
+    if (grp)
+    {
+      for (size_t i = 0; i < grp->count && i < TextureGroup::num; i++)
+      {
+        GameFile * tex = grp->tex[i];
+        if (!tex)
+          continue;
+        const int fdid = (int)tex->fileDataId();
+        if (fdid > 0)
+          byType[grp->base + (int)i] = fdid;
+      }
+    }
+  }
+
+  // ... with anything picked slot-by-slot applied over it, exactly as the model sees it.
+  for (std::map<int, int>::const_iterator it = singleSkinOverrides.begin();
+       it != singleSkinOverrides.end(); ++it)
+    byType[it->first] = it->second;
+
+  for (std::map<int, int>::const_iterator it = byType.begin(); it != byType.end(); ++it)
+    out.push_back(std::make_pair(it->first, it->second));
+  return !out.empty();
+}
+
 void AnimControl::SetSkin(int num)
 {
   std::vector<wxString> currTextures(3);
+
+  // Choosing a whole skin replaces anything picked slot-by-slot before it.
+  singleSkinOverrides.clear();
 
   if (num == -1)
     num = skinList->GetSelection();  // if we pass -1 to the func, we're redrawing the current skin
@@ -1476,6 +1529,13 @@ void AnimControl::SetSkin(int num)
   skinList->Select(num);
 
   SyncBLPSkinList();
+
+  // The embedded Unity viewport draws the same model from the same data, so it has to follow
+  // the same selection. This is the one funnel every skin change goes through -- the default
+  // chosen on model load, the dropdown, and SetSkinByDisplayID -- so hooking it here covers
+  // all three. No-op when the Unity pane was never opened.
+  if (g_modelViewer)
+    g_modelViewer->SendCurrentSkinToUnity();
 }
 
 void AnimControl::SetSingleSkin(int num, int texnum)
@@ -1501,6 +1561,14 @@ void AnimControl::SetSingleSkin(int num, int texnum)
   GameFile * tex = grp->tex[0];
   LOG_INFO << "SETSINGLESKIN skin = " << tex->fullname();
   g_selModel->updateTextureList(tex, base);
+
+  // Same reasoning as SetSkin: the Unity viewport draws the same model and has to follow the
+  // same textures. Recorded as well as pushed, because the caller clears the main selector's
+  // selection right after this -- so this map is the only remaining record of what is on screen.
+  if (tex && (int)tex->fileDataId() > 0)
+    singleSkinOverrides[base] = (int)tex->fileDataId();
+  if (g_modelViewer)
+    g_modelViewer->SendCurrentSkinToUnity();
 }
 
 int AnimControl::AddSkin(TextureGroup grp)

--- a/Source/wowmodelviewer/animcontrol.h
+++ b/Source/wowmodelviewer/animcontrol.h
@@ -152,6 +152,20 @@ public:
   void OnLoop(wxCommandEvent &event); 
   glm::vec4 fromARGB(int color);
   void SetSkinByDisplayID(int cdi);
+
+  // The skin the selector is showing right now, as (texture type, texture FileDataID) pairs --
+  // the textures the viewport is ACTUALLY drawing. The database can only say what a model's
+  // DEFAULT skin is; which of its variations is on screen is a UI fact, and this is where it
+  // lives. Texture type is the WoW TEXTURE_* slot the texture feeds (TEXTURE_GAMEOBJECT1 = 11
+  // for the first creature skin), i.e. TextureGroup::base + i, matching what SetSkin hands to
+  // WoWModel::updateTextureList. False (and out empty) when no skin list is active or nothing
+  // is selected -- e.g. a character model, or a creature with no skins at all.
+  bool selectedSkinTextures(std::vector<std::pair<int, int> > & out);
+
+  // Entries in the skin selector, and one entry's label -- diagnostics only (the -unityipctest
+  // run walks the list to prove every selection reaches the embedded renderer).
+  int skinCount();
+  wxString skinName(int index);
   int AddSkin(TextureGroup grp);
   void SetSkin(int num);
   void ActivateBLPSkinList();
@@ -166,6 +180,12 @@ public:
   QString modelFolder;
   bool modelFolderChanged, BLPListFilled;
   std::map<int, TextureGroup> CDIToTexGp;
+
+  // Textures picked one slot at a time from the "all skins in folder" lists, as
+  // texture type -> FileDataID. These sit ON TOP of whatever the main skin selector chose (and
+  // SetSingleSkin's own caller clears that selection), so the displayed skin is the selector's
+  // answer with these applied over it. Cleared when the model changes or a whole skin is picked.
+  std::map<int, int> singleSkinOverrides;
   std::vector<particleColorReplacements> PCRList; 
   int selectedAnim;
   int selectedAnim2;

--- a/Source/wowmodelviewer/app.cpp
+++ b/Source/wowmodelviewer/app.cpp
@@ -26,6 +26,7 @@
 #include "util.h"
 #include "WoWDatabase.h"
 #include "WoWFolder.h"
+#include "animcontrol.h"
 #include "WoWModel.h"
 
 #include "logger/Logger.h"
@@ -296,14 +297,55 @@ static void doHeadlessUnityIpcTest(ModelViewer * frame)
       for (size_t ti = 0; ti < modelTextures.size(); ti++)
       {
         const UnityAssetAccess::Result tex = UnityAssetAccess::readByFileDataID(modelTextures[ti].fileDataID);
-        LOG_INFO << "[unityipc-test]   texture[" << (int)modelTextures[ti].index << "] fileDataID="
-                 << modelTextures[ti].fileDataID << "ok=" << (tex.ok ? 1 : 0)
-                 << "bytes=" << tex.data.size() << "path=" << tex.path;
+        LOG_INFO << "[unityipc-test]   texture[" << (int)modelTextures[ti].index << "] type="
+                 << modelTextures[ti].type << "fileDataID=" << modelTextures[ti].fileDataID
+                 << "ok=" << (tex.ok ? 1 : 0) << "bytes=" << tex.data.size() << "path=" << tex.path
+                 << "source=" << UnityAssetAccess::sourceName(modelTextures[ti].source);
       }
+
+      // Selected-skin sync: a creature normally has several skins and the viewport shows ONE of
+      // them. Walk the app's own selector and confirm that what it selects is what gets resolved
+      // for the renderer -- and that each change is pushed to the player.
+      AnimControl * ac = frame->animControl;
+      const int skins = ac ? ac->skinCount() : 0;
+      LOG_INFO << "[unityipc-test] skin-sync check: the selector offers" << skins << "skin(s)";
+      for (int s = 0; s < skins; s++)
+      {
+        ac->SetSkin(s);
+        std::vector<UnityAssetAccess::ModelTexture> sel;
+        QString selError;
+        const bool selOk = UnityAssetAccess::resolveModelTextures(fdid, sel, selError);
+        const int selFdid = (selOk && !sel.empty()) ? sel[0].fileDataID : 0;
+        LOG_INFO << "[unityipc-test]   skin[" << s << "]"
+                 << QString::fromWCharArray(ac->skinName(s).c_str()) << "-> fileDataID="
+                 << selFdid << "type=" << ((selOk && !sel.empty()) ? sel[0].type : 0)
+                 << "source=" << ((selOk && !sel.empty())
+                                  ? UnityAssetAccess::sourceName(sel[0].source) : "none")
+                 << "path=" << (selFdid > 0 ? UnityAssetAccess::readByFileDataID(selFdid).path : QString());
+        // let the push reach the player before selecting the next one
+        for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+      }
+      // Re-select what is already selected. WMV pushes regardless -- it cannot know what the
+      // player is holding -- so this checks the other half of the contract: the player must
+      // recognise the texture it already has and fetch nothing.
+      if (skins > 0)
+      {
+        ac->SetSkin(skins - 1);
+        for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+        LOG_INFO << "[unityipc-test]   re-selected skin[" << (skins - 1)
+                 << "] -- the player should report it unchanged and fetch nothing";
+      }
+      LOG_INFO << "[unityipc-test] skin-sync: skinPushes=" << ipc->stats().skinPushes
+               << "lastSkin=" << ipc->stats().lastSkin;
     }
   }
 
-  const bool pass = st.connections >= 1 && ipc->isUnityReady() && st.requests >= 1 && st.responsesOk >= 1;
+  // A model with a skin selector must have pushed at least one skin; one without simply has
+  // nothing to sync, so the condition only bites when there was something to send.
+  const bool skinsOk = (frame->animControl == NULL) || (frame->animControl->skinCount() == 0) ||
+                       (st.skinPushes >= 1);
+  const bool pass = st.connections >= 1 && ipc->isUnityReady() && st.requests >= 1 &&
+                    st.responsesOk >= 1 && skinsOk;
   LOG_INFO << "[unityipc-test] RESULT:" << (pass ? "PASS" : "FAIL");
 
   // Close the player now (what app shutdown does) and confirm the child process is gone.

--- a/Source/wowmodelviewer/modelviewer.cpp
+++ b/Source/wowmodelviewer/modelviewer.cpp
@@ -1596,6 +1596,20 @@ void ModelViewer::SendCurrentModelToUnity()
   unityRendererHost->ipc()->sendLoadWoWModel(gf->fullname(), gf->fileDataId() > 0 ? gf->fileDataId() : 0);
 }
 
+// The displayed skin changed (dropdown, or the default picked on model load). The Unity viewport
+// renders the same model from the same data, so it has to follow the same selection -- otherwise
+// it shows whatever the database happens to call the model's default while the canvas shows what
+// the user picked. Texture only: the mesh it already built is unchanged.
+void ModelViewer::SendCurrentSkinToUnity()
+{
+  if (!unityRendererHost || !unityRendererHost->ipc() || !unityRendererHost->ipc()->isConnected())
+    return;
+  if (!canvas || !canvas->model() || !canvas->model()->gamefile)
+    return;
+  WoWModel * m = const_cast<WoWModel *>(canvas->model());
+  unityRendererHost->ipc()->sendModelSkin((int)m->gamefile->fileDataId());
+}
+
 // Menu button press events
 void ModelViewer::OnToggleCommand(wxCommandEvent &event)
 {

--- a/Source/wowmodelviewer/modelviewer.h
+++ b/Source/wowmodelviewer/modelviewer.h
@@ -171,6 +171,7 @@ public:
   // FileDataID of the model on the canvas). No-op when no player is connected. Called after
   // every model load and when the player announces unityReady.
   void SendCurrentModelToUnity();
+  void SendCurrentSkinToUnity();
 
   void OnMount(wxCommandEvent &event);
   void OnSave(wxCommandEvent &event);

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
@@ -21,7 +21,8 @@
 //   loadWoWModel  { path, fileDataID, client }
 //   assetResponse { requestId, ok, path, fileDataID, byteLength, sha1, encoding:"base64", data }
 //   assetResponse { requestId, ok:false, error }
-//   modelTextures { requestId, ok, fileDataID, textures:[{ index, fileDataID, source }] }
+//   modelTextures { requestId, ok, fileDataID, textures:[{ index, type, fileDataID, source }] }
+//   modelSkin     { fileDataID, textures:[{ index, type, fileDataID, source }] }   (pushed, no request)
 //
 // getModelTextures exists because a modern M2 does not name its replaceable textures (a
 // creature skin's TXID entry is 0 and its texture array carries no filename) -- the skin comes
@@ -51,6 +52,7 @@ public class WmvIpcClient : MonoBehaviour
     public Action<string, int, string> OnLoadWoWModel;        // (path, fileDataID, client)
     public Action<AssetResponse> OnAssetResponse;
     public Action<ModelTexturesResponse> OnModelTextures;
+    public Action<ModelTexturesResponse> OnModelSkin;          // pushed when the displayed skin changes
     public Action<string> OnStatus;                            // human-readable connection/state text
 
     public bool Connected { get { return connected; } }
@@ -73,8 +75,23 @@ public class WmvIpcClient : MonoBehaviour
     public class ModelTextureRef
     {
         public int index;
+
+        /// <summary>
+        /// The WoW texture TYPE this feeds -- 11, 12, 13 for the three creature skin slots. NOT a
+        /// position: a model's texture-variation order and its M2 texture-slot order need not
+        /// agree, so the renderer matches this against the type each M2 texture declares. 0 when
+        /// the host did not say, in which case index is used as a fallback.
+        /// </summary>
+        public int type;
+
         public int fileDataID;
-        public string source = "";   // "database" (authoritative) or "convention" (legacy fallback)
+
+        /// <summary>
+        /// "selection" -- the skin the WMV viewport is showing right now;
+        /// "database"  -- the model's default skin from CreatureDisplayInfo;
+        /// "convention"-- a listfile naming guess for a model no creature display references.
+        /// </summary>
+        public string source = "";
     }
 
     public class ModelTexturesResponse
@@ -89,6 +106,7 @@ public class WmvIpcClient : MonoBehaviour
     [Serializable] class MsgTexture
     {
         public int index;
+        public int type;
         public int fileDataID;
         public string source;
     }
@@ -204,6 +222,27 @@ public class WmvIpcClient : MonoBehaviour
         }
     }
 
+    static ModelTexturesResponse ReadTextures(Msg msg)
+    {
+        var r = new ModelTexturesResponse
+        {
+            requestId = msg.requestId, ok = msg.ok, fileDataID = msg.fileDataID, error = msg.error,
+        };
+        if (msg.textures != null)
+        {
+            r.textures = new ModelTextureRef[msg.textures.Length];
+            for (int i = 0; i < msg.textures.Length; i++)
+                r.textures[i] = new ModelTextureRef
+                {
+                    index = msg.textures[i].index,
+                    type = msg.textures[i].type,
+                    fileDataID = msg.textures[i].fileDataID,
+                    source = msg.textures[i].source ?? "",
+                };
+        }
+        return r;
+    }
+
     void Dispatch(Msg msg)
     {
         switch (msg.type)
@@ -213,25 +252,14 @@ public class WmvIpcClient : MonoBehaviour
                 break;
 
             case "modelTextures":
-            {
-                var r = new ModelTexturesResponse
-                {
-                    requestId = msg.requestId, ok = msg.ok, fileDataID = msg.fileDataID, error = msg.error,
-                };
-                if (msg.textures != null)
-                {
-                    r.textures = new ModelTextureRef[msg.textures.Length];
-                    for (int i = 0; i < msg.textures.Length; i++)
-                        r.textures[i] = new ModelTextureRef
-                        {
-                            index = msg.textures[i].index,
-                            fileDataID = msg.textures[i].fileDataID,
-                            source = msg.textures[i].source ?? "",
-                        };
-                }
-                OnModelTextures?.Invoke(r);
+                OnModelTextures?.Invoke(ReadTextures(msg));
                 break;
-            }
+
+            // Unsolicited: the skin on display in WMV changed. Same payload as a modelTextures
+            // reply, minus the requestId -- nothing asked for it.
+            case "modelSkin":
+                OnModelSkin?.Invoke(ReadTextures(msg));
+                break;
 
             case "assetResponse":
             {

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -38,6 +38,24 @@ public class WmvMain : MonoBehaviour
     WmvRuntimeModel current;          // the model on screen (disposed when replaced)
     LoadJob job;                      // in-flight load, if any
 
+    // Kept after a successful load so the SKIN can change without reloading anything. A creature
+    // normally has several skins -- chicken2 has seven -- and WMV lets the user pick among them;
+    // when they do, only the textures behind the existing materials need re-uploading.
+    M2ParsedModel currentModel;
+    string currentName = "WoWModel";
+    int currentFileDataID;
+    readonly Dictionary<int, BlpImage> currentTextures = new Dictionary<int, BlpImage>();
+    readonly Dictionary<int, int> currentTextureIds = new Dictionary<int, int>();   // slot -> FileDataID
+    SkinJob skinJob;                  // in-flight skin change, if any
+
+    /// <summary>Textures still on their way for a skin change. Requests are keyed to the M2
+    /// texture slot they will land in.</summary>
+    class SkinJob
+    {
+        public readonly Dictionary<string, int> Pending = new Dictionary<string, int>();
+        public int Applied;
+    }
+
     /// <summary>State for one in-flight model load.</summary>
     class LoadJob
     {
@@ -100,6 +118,7 @@ public class WmvMain : MonoBehaviour
         ipc.OnLoadWoWModel = HandleLoadWoWModel;
         ipc.OnAssetResponse = HandleAssetResponse;
         ipc.OnModelTextures = HandleModelTextures;
+        ipc.OnModelSkin = HandleModelSkin;
     }
 
     // ---------------------------------------------------------------- load pipeline
@@ -122,6 +141,13 @@ public class WmvMain : MonoBehaviour
 
     void HandleAssetResponse(WmvIpcClient.AssetResponse r)
     {
+        // A skin change is answered by the same assetResponse messages as a load, so claim ours
+        // before the load path sees them.
+        if (skinJob != null && skinJob.Pending.ContainsKey(r.requestId))
+        {
+            OnSkinTextureBytes(r);
+            return;
+        }
         if (job == null)
             return;
 
@@ -188,7 +214,11 @@ public class WmvMain : MonoBehaviour
         for (int i = 0; i < job.Model.Textures.Length; i++)
         {
             var t = job.Model.Textures[i];
-            if (t.FileDataID > 0) direct.Add(new KeyValuePair<int, int>(i, t.FileDataID));
+            if (t.FileDataID > 0)
+            {
+                direct.Add(new KeyValuePair<int, int>(i, t.FileDataID));
+                currentTextureIds[i] = t.FileDataID;   // the M2 named this one itself
+            }
             else if (t.IsReplaceable) needsHost = true;
         }
 
@@ -219,9 +249,14 @@ public class WmvMain : MonoBehaviour
         foreach (var t in r.textures)
         {
             if (t.fileDataID <= 0) continue;
-            job.TexturesExpected++;
-            job.PendingTextures[ipc.RequestAssetByFileDataID(t.fileDataID)] = t.index;
-            Debug.Log("WMV: texture slot " + t.index + " -> fileDataID " + t.fileDataID + " (" + t.source + ")");
+            foreach (int slot in SlotsForTexture(job.Model, t))
+            {
+                job.TexturesExpected++;
+                job.PendingTextures[ipc.RequestAssetByFileDataID(t.fileDataID)] = slot;
+                currentTextureIds[slot] = t.fileDataID;
+                Debug.Log("WMV: texture slot " + slot + " (type " + t.type + ") -> fileDataID " +
+                          t.fileDataID + " (" + t.source + ")");
+            }
         }
         if (job.TexturesExpected == 0)
             BuildIfReady();
@@ -271,6 +306,15 @@ public class WmvMain : MonoBehaviour
             current = built;
             if (placeholder != null) placeholder.SetActive(false);
 
+            // Keep what a later skin change needs: the parsed model (to map a texture type onto
+            // slots) and the decoded textures (so untouched slots are not re-fetched).
+            currentModel = job.Model;
+            currentName = string.IsNullOrEmpty(job.Model.Name) ? "WoWModel" : job.Model.Name;
+            currentFileDataID = job.FileDataID;
+            currentTextures.Clear();
+            foreach (var kv in job.Textures) currentTextures[kv.Key] = kv.Value;
+            skinJob = null;
+
             orbit.Frame(built.Bounds);
 
             status.Set("Loaded " + job.Path);
@@ -287,6 +331,111 @@ public class WmvMain : MonoBehaviour
         }
         catch (WowParseException e) { Fail("mesh creation failed: " + e.Message); }
         finally { job = null; }
+    }
+
+    /// <summary>
+    /// WMV's displayed skin changed. Fetch whatever textures that actually changes and re-bind
+    /// them onto the materials already on screen -- the mesh is unaffected by which image its
+    /// materials sample.
+    /// </summary>
+    void HandleModelSkin(WmvIpcClient.ModelTexturesResponse r)
+    {
+        if (current == null || currentModel == null)
+            return;                                     // nothing built yet; the load will pick it up
+        if (r.fileDataID != 0 && currentFileDataID != 0 && r.fileDataID != currentFileDataID)
+            return;                                     // about a different model
+        if (!r.ok || r.textures.Length == 0)
+            return;
+
+        var wanted = new Dictionary<int, int>();         // slot -> FileDataID
+        foreach (var t in r.textures)
+        {
+            if (t.fileDataID <= 0) continue;
+            foreach (int slot in SlotsForTexture(currentModel, t))
+                wanted[slot] = t.fileDataID;
+        }
+
+        var fetch = new List<KeyValuePair<int, int>>();
+        foreach (var kv in wanted)
+        {
+            int have;
+            if (currentTextureIds.TryGetValue(kv.Key, out have) && have == kv.Value &&
+                currentTextures.ContainsKey(kv.Key))
+                continue;                                // this slot already holds that texture
+            fetch.Add(kv);
+        }
+
+        if (fetch.Count == 0)
+        {
+            status.Set("Skin unchanged");
+            return;
+        }
+
+        skinJob = new SkinJob();
+        foreach (var kv in fetch)
+        {
+            skinJob.Pending[ipc.RequestAssetByFileDataID(kv.Value)] = kv.Key;
+            currentTextureIds[kv.Key] = kv.Value;
+            Debug.Log("WMV: skin change -> slot " + kv.Key + " becomes fileDataID " + kv.Value);
+        }
+        status.Set("Skin changed (" + fetch.Count + " texture(s))");
+    }
+
+    void OnSkinTextureBytes(WmvIpcClient.AssetResponse r)
+    {
+        int slot = skinJob.Pending[r.requestId];
+        skinJob.Pending.Remove(r.requestId);
+
+        if (!r.ok)
+        {
+            status.Set("Skin texture request failed: " + r.error);
+        }
+        else
+        {
+            try
+            {
+                currentTextures[slot] = BlpDecoder.Decode(r.data);
+                skinJob.Applied++;
+                Debug.Log("WMV: skin texture slot " + slot + ": " + currentTextures[slot].Width + "x" +
+                          currentTextures[slot].Height + " " + currentTextures[slot].Encoding);
+            }
+            catch (WowParseException e)
+            {
+                status.Set("Skin texture decode failed: " + e.Message);   // keep the old texture
+            }
+        }
+
+        if (skinJob.Pending.Count > 0)
+            return;
+
+        if (skinJob.Applied > 0)
+        {
+            WmvModelBuilder.RebindTextures(current, currentTextures, currentName,
+                                           s => Debug.Log("WMV: " + s));
+            status.Set("Skin applied (" + skinJob.Applied + " texture(s), mesh unchanged)");
+        }
+        skinJob = null;
+    }
+
+    /// <summary>
+    /// Which M2 texture slots a resolved texture feeds. The host names a texture TYPE (11, 12, 13
+    /// for the three creature skin slots) rather than a position, because a model's
+    /// texture-variation order and its M2 texture-slot order need not agree. Falls back to the
+    /// positional index when the host did not say -- an older host, or a texture with no type.
+    /// </summary>
+    static List<int> SlotsForTexture(M2ParsedModel model, WmvIpcClient.ModelTextureRef t)
+    {
+        var slots = new List<int>();
+        if (model != null && t.type > 0)
+        {
+            for (int i = 0; i < model.Textures.Length; i++)
+                if ((int)model.Textures[i].Type == t.type)
+                    slots.Add(i);
+        }
+        if (slots.Count == 0 && t.index >= 0 &&
+            (model == null || t.index < model.Textures.Length))
+            slots.Add(t.index);
+        return slots;
     }
 
     void Fail(string reason)

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -12,12 +12,25 @@ using System.Collections.Generic;
 using UnityEngine;
 using Wmv.Wow;
 
+/// <summary>
+/// Which textures one material was built from. Kept so the skin can be changed later without
+/// rebuilding the mesh: the WMV viewport lets the user pick among a creature's skins (chicken2
+/// has seven), and when they do, only these bindings need re-uploading.
+/// </summary>
+public struct WmvMaterialBinding
+{
+    public int BaseSlot;    // M2 texture slot behind the main texture, -1 when untextured
+    public int EnvSlot;     // M2 texture slot bound as the combiner's second unit, -1 when unused
+    public bool DropAlpha;  // was the base texture's alpha discarded on upload? (see CreateTexture)
+}
+
 public class WmvRuntimeModel
 {
     public GameObject Root;
     public Mesh Mesh;
     public Material[] Materials = new Material[0];
     public Texture2D[] Textures = new Texture2D[0];
+    public WmvMaterialBinding[] Bindings = new WmvMaterialBinding[0];
     public Bounds Bounds;
     public int VertexCount, TriangleCount, SubmeshCount;
 
@@ -152,6 +165,7 @@ public static class WmvModelBuilder
 
         // ---- one submesh per batch ----------------------------------------------------
         var materials = new List<Material>();
+        var bindings = new List<WmvMaterialBinding>();
         var textures = new List<Texture2D>();
         // Keyed by slot AND by whether the alpha channel was discarded, because the same slot
         // can feed an opaque batch (alpha thrown away) and a blended one (alpha kept).
@@ -253,6 +267,10 @@ public static class WmvModelBuilder
                                                  : "")));
             }
 
+            bindings.Add(new WmvMaterialBinding
+            {
+                BaseSlot = textureSlot, EnvSlot = envSlot, DropAlpha = dropAlpha,
+            });
             materials.Add(CreateMaterial(mat, mode, tex, envTex,
                                          objectName + "_mat" + materials.Count, log));
         }
@@ -275,12 +293,70 @@ public static class WmvModelBuilder
         result.Root = go;
         result.Mesh = mesh;
         result.Materials = materials.ToArray();
+        result.Bindings = bindings.ToArray();
         result.Textures = textures.ToArray();
         result.Bounds = mesh.bounds;
         result.VertexCount = n;
         result.TriangleCount = totalTriangles;
         result.SubmeshCount = triangleSets.Count;
         return result;
+    }
+
+    /// <summary>
+    /// Re-upload the textures of an already-built model and hand them to the materials it already
+    /// has. The mesh, the GameObject and the materials themselves survive: a skin change in WMV
+    /// swaps which image a material samples, nothing about the geometry.
+    ///
+    /// decodedTextures is the model's CURRENT texture set keyed by M2 slot -- the caller replaces
+    /// the entries the new skin changed and leaves the rest alone, so slots the skin does not
+    /// touch (an environment map named by the M2 itself, say) are simply re-uploaded unchanged.
+    /// </summary>
+    public static void RebindTextures(WmvRuntimeModel runtime, Dictionary<int, BlpImage> decodedTextures,
+                                      string objectName, Action<string> log)
+    {
+        if (runtime == null || runtime.Materials.Length == 0)
+            return;
+        if (runtime.Bindings.Length != runtime.Materials.Length)
+        {
+            if (log != null)
+                log("rebind: this model was built without texture bindings -- nothing to re-bind");
+            return;
+        }
+
+        var fresh = new List<Texture2D>();
+        var cache = new Dictionary<int, Texture2D>();
+
+        for (int i = 0; i < runtime.Materials.Length; i++)
+        {
+            Material m = runtime.Materials[i];
+            if (m == null)
+                continue;
+            WmvMaterialBinding b = runtime.Bindings[i];
+
+            Texture2D tex = GetTexture(decodedTextures, cache, fresh, b.BaseSlot, b.DropAlpha, false, objectName);
+            if (tex != null && !Debug_.MatColors)
+                m.mainTexture = tex;
+
+            Texture2D envTex = GetTexture(decodedTextures, cache, fresh, b.EnvSlot, true, true, objectName);
+            if (m.HasProperty(CombinerModeProperty))
+            {
+                bool on = envTex != null && !Debug_.MatColors;
+                if (on) m.SetTexture(SecondTexProperty, envTex);
+                m.SetFloat(CombinerModeProperty, on ? PixelShaderOpaqueMod2xNaAlpha : 0);
+            }
+
+            if (log != null)
+                log(string.Format("rebind: material '{0}' <- slot {1} (alpha {2}){3}",
+                                  m.name, b.BaseSlot, b.DropAlpha ? "forced to 255" : "kept (combiner mask)",
+                                  b.EnvSlot >= 0 ? ", env slot " + b.EnvSlot : ""));
+        }
+
+        // Only now destroy the old uploads: a material that ended up keeping its texture would
+        // otherwise be left pointing at a destroyed one.
+        foreach (var old in runtime.Textures)
+            if (old != null && !fresh.Contains(old))
+                UnityEngine.Object.Destroy(old);
+        runtime.Textures = fresh.ToArray();
     }
 
     /// <summary>M2 pixel shader 12, "Combiners_Opaque_Mod2xNA_Alpha" -- the one combiner this

--- a/Tools/UnityRendererProject/README.md
+++ b/Tools/UnityRendererProject/README.md
@@ -150,8 +150,8 @@ UV routing, the full runtime material state, and the shader that was chosen.
 | File | Role |
 |---|---|
 | `WmvMain.cs` | Bootstrap (camera rig, light, placeholder, status overlay) and the load pipeline: on `loadWoWModel` it fetches the .m2, parses it, fetches the .skin profile named by SFID, resolves and fetches textures, builds the mesh and frames the camera. |
-| `WmvIpcClient.cs` | IPC client (protocol v1): connects back to the WMV server given by `-wmvPort`, sends `unityReady`, receives `loadWoWModel`, sends `getAsset` / `getAssetByFileDataID` / `getModelTextures`, decodes + hash-checks `assetResponse`. |
-| `WmvModelBuilder.cs` | Parsed model + skin + decoded textures -> Unity `Mesh` (one submesh per WoW batch), `Material` and `Texture2D`; owns and disposes those runtime resources so repeated loads do not leak. |
+| `WmvIpcClient.cs` | IPC client (protocol v1): connects back to the WMV server given by `-wmvPort`, sends `unityReady`, receives `loadWoWModel` and `modelSkin`, sends `getAsset` / `getAssetByFileDataID` / `getModelTextures`, decodes + hash-checks `assetResponse`. |
+| `WmvModelBuilder.cs` | Parsed model + skin + decoded textures -> Unity `Mesh` (one submesh per WoW batch), `Material` and `Texture2D`; owns and disposes those runtime resources so repeated loads do not leak. `RebindTextures` re-uploads the textures behind the materials it already made, for when WMV's selected skin changes. |
 | `Wow/M2Parser.cs` | Chunked M2 (MD21/MD20 v272): header, vertices, textures, materials, lookups, SFID/TXID. |
 | `Wow/M2SkinParser.cs` | .skin profile: vertex lookup, triangles, submeshes, batches, and the two-level index resolution into model vertices. |
 | `Wow/BlpDecoder.cs` | BLP2 -> RGBA32 in memory (palettized, DXT1/3/5, raw BGRA). |

--- a/Tools/UnityRendererProject/TestStub/fake_unity_renderer.c
+++ b/Tools/UnityRendererProject/TestStub/fake_unity_renderer.c
@@ -253,6 +253,16 @@ static void handle_line(const char * line)
       status("Model textures: %s", err);
     }
   }
+  else if (strcmp(type, "modelSkin") == 0)
+  {
+    /* Pushed, not asked for: the skin on display in WMV changed. The real player re-uploads the
+     * textures and keeps its mesh; the stub only has to prove the message arrives and carries the
+     * selection, which is what the -unityipctest run checks. */
+    long long fdid = 0;
+    json_get_int(line, "fileDataID", &fdid);
+    logf("recv: modelSkin for %lld -> %.400s", fdid, line);
+    status("Skin changed");
+  }
   else if (strcmp(type, "assetResponse") == 0)
   {
     int ok = 0;

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -112,14 +112,26 @@ viewport uses). Player side: `Tools/UnityRendererProject/Assets/Scripts/WmvIpcCl
 ```
 
 `getModelTextures` answers with `modelTextures { requestId, ok, fileDataID, textures:[{ index,
-fileDataID, source }] }`. It exists because a modern M2 does **not** name its replaceable
+type, fileDataID, source }] }`. It exists because a modern M2 does **not** name its replaceable
 textures: a creature skin's TXID entry is 0 and its texture array carries no filename, because
 the actual skin comes from the client database.
 
-- **`source: "database"` -- the normal, authoritative route.** WMV resolves the skin from
-  `CreatureDisplayInfo` joined to `CreatureModelData` on the model's FileDataID: the same
-  relation the legacy viewer's own skin list uses. This is the path any current creature takes,
-  and the path the primary validation target `creature/chicken2/chicken2.m2` exercises.
+`type` is the WoW texture **type** the texture feeds -- 11, 12, 13 for the three creature skin
+slots -- not a position. A model's texture-variation order and its M2 texture-slot order need not
+agree, so the renderer matches this against the type each M2 texture declares.
+
+`source` says where the answer came from, in the order WMV tries them:
+
+- **`source: "selection"` -- what the viewport is actually showing.** A creature normally has
+  several skins (`chicken2` offers seven, plus a folder texture), and the database can only say
+  which is the *default*. Which one is on screen is a UI fact, so WMV answers from its own skin
+  selector -- the same `TextureGroup` the OpenGL viewport hands to `WoWModel::updateTextureList`.
+  Without this the two viewports disagree the moment the user touches the dropdown, or whenever
+  "Random Skins" picks something other than the first display.
+- **`source: "database"` -- the model's default skin.** `CreatureDisplayInfo` joined to
+  `CreatureModelData` on the model's FileDataID: the same relation the viewer's own skin list is
+  built from. Used when there is no selection to read -- a model with no skin list, or a request
+  about a model that is not the displayed one.
 - **`source: "convention"` -- a labelled fallback, not a substitute.** A handful of legacy
   assets are still shipped in CASC but referenced by no creature display at all (for example
   `creature/chicken/chicken.m2`, superseded by `chicken2`), so the database has nothing to say
@@ -137,6 +149,8 @@ The response carries metadata only; bytes are still fetched with `getAssetByFile
 { "type": "assetResponse", "requestId": "abc123", "ok": true, "path": "creature/chicken/chicken.m2",
   "fileDataID": 123200, "byteLength": 101840, "sha1": "1dc88a19...", "encoding": "base64", "data": "TUQyMb..." }
 { "type": "assetResponse", "requestId": "abc123", "ok": false, "error": "not found" }
+{ "type": "modelSkin", "ok": true, "fileDataID": 1521037,
+  "textures": [ { "index": 0, "type": 11, "fileDataID": 1521061, "source": "selection" } ] }
 ```
 
 Semantics:
@@ -144,6 +158,17 @@ Semantics:
 - `unityReady` is answered by a `loadWoWModel` for whatever is on the canvas (and every later
   model load pushes a new one). `client` is `"active"` -- the player never chooses a client;
   WMV's active client/profile is the only data source.
+- `modelSkin` is **pushed, not requested**: the skin on display changed. Same payload as a
+  `modelTextures` reply, built by the same resolver, so the push and the pull cannot disagree.
+  The player re-uploads only the textures that actually changed and keeps the mesh it built --
+  a skin change alters which image a material samples, nothing about the geometry. It is sent
+  from `AnimControl::SetSkin`, the single funnel every skin change goes through (the dropdown,
+  the default chosen on model load, and NPC import), plus `SetSingleSkin` for the per-slot
+  folder-texture lists.
+  *Known limitation:* a display variant can also toggle **geosets**
+  (`CreatureDisplayInfoGeosetData`). The Unity viewport swaps textures only, so on a variant that
+  changes geometry the two viewports will still differ in what is drawn -- geosets are not part
+  of this static-M2 milestone.
 - `getAsset` / `getAssetByFileDataID` return the **raw, whole file** exactly as stored in the
   active client (modern `.m2` bytes start with their `MD21` chunk header, etc.). Paths are
   normalised (lower-case, forward slashes). By-FileDataID works for CASC clients; a legacy


### PR DESCRIPTION
A creature normally has several skins -- chicken2 offers seven -- and the embedded renderer was resolving whichever one the database happened to list first. So the Unity viewport could show a white chicken while the OpenGL viewport, one pane away, showed the spotted one the user had picked from the dropdown (or the one the "Random Skins" option had rolled at load).

Which skin is on screen is a UI fact, not a database fact. The database can only say what a model's DEFAULT is; AnimControl's skin selector is the only place that knows what was chosen. So UnityAssetAccess::resolveModelTextures now asks the selector first and falls back to the database only when there is no selection to read -- a model with no skin list, or a question about a model that is not the displayed one. The request shape is unchanged; only the answer improves, and it is labelled source:"selection" so a default is never mistaken for a choice.

Following the selection afterwards needs a push, because nothing pulls when a dropdown changes. AnimControl::SetSkin is the single funnel every skin change goes through -- the dropdown, the default chosen on model load, and NPC import -- so the notification hangs there, and sends a modelSkin message built by the same resolver the pull uses. Push and reply therefore cannot disagree.

Also hooked: SetSingleSkin, the per-slot "all skins in folder" lists. Those apply a texture directly and then clear the main selector's selection, which would have left the renderer not merely stale but WRONG -- a later question would have been answered with the database default. The picked textures are now remembered per texture type and reported over whatever whole skin is selected, exactly as the model sees them.

Texture metadata gained a "type" field: the WoW texture TYPE a texture feeds (11, 12, 13 for the three creature skin slots) rather than a bare position. A model's texture-variation order and its M2 texture-slot order need not agree, so the renderer matches the type against what each M2 texture declares. The old positional index is still sent and is still the fallback.

Unity side: the player keeps the parsed model and its decoded textures after a load, so a skin change re-uploads only the textures that actually changed and re-binds them onto the materials already on screen. The mesh, the GameObject and the materials survive -- a skin change alters which image a material samples, nothing about the geometry. Re-picking the skin already displayed fetches nothing.

Verified against retail data with creature/chicken2/chicken2.m2. The selector offers eight entries and every one of them round-trips: CHICKEN2_BLACK, _BROWN, _BROWNHEAD, _DIRTY, _LIGHTBROWN, _SPOTTED, _WHITE and the folder texture armorreflect5 each resolve to their own FileDataID with source=selection, reach the player, and are re-bound with the mesh untouched (778 triangles, 1 submesh, before and after). The load-time answer follows the random default rather than the database's first row. The hidden-batch gate and the two-texture environment combiner both survive a skin swap.

Not addressed, and stated rather than hidden: a display variant can also toggle geosets (CreatureDisplayInfoGeosetData). The Unity viewport swaps textures only, so on a variant that changes geometry the two viewports still differ in what is drawn. Geosets are not part of this static-M2 milestone.

Still runtime-only: every byte arrives over IPC and nothing is written to disk.