### PR TITLE
Fix retail creature display texture lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **Creature display lookup read the wrong columns on retail.** `AnimControl::UpdateCreatureModel`
+  builds one of three queries depending on the client generation, but read the display id and the
+  particle colour at fixed positions that only match the two OLDER layouts. The modern query
+  selects a fourth texture variation the others do not, so on current retail the display id was
+  actually `ParticleColorID` and the particle colour was actually
+  `TextureVariationFileDataID4` -- both off by one. Consequences, all measured against retail
+  12.1: the display-id -> skin map collapsed to a single entry keyed 0 for 97.8% of creature
+  displays, so NPC and Armory import (`SetSkinByDisplayID`) could never find the skin a display
+  names and silently left the model on whatever was already selected; per-display geoset data was
+  fetched with a particle-colour id, so 16% of creature displays never received the geosets that
+  define them (and 48 rows received another display's); and creature particle-colour replacement
+  never ran at all, because the id it needed was never read. The column positions are now derived
+  beside the query that defines them, so the three layouts cannot drift apart again.
+  Two visible consequences worth expecting: `creature/chicken2/chicken2.m2` now maps all 41 of its
+  displays instead of 1, and creatures whose displays differ only by geoset now offer those
+  variants in the skin dropdown -- 433 of 2965 creature models gain entries, 2526 are unchanged.
+
 ### Added
 - **Embedded Unity renderer: it now shows the skin you picked.** A creature normally has several
   skins -- `chicken2` offers seven -- and the renderer was resolving whichever one the database

--- a/Source/wowmodelviewer/animcontrol.cpp
+++ b/Source/wowmodelviewer/animcontrol.cpp
@@ -512,6 +512,19 @@ bool AnimControl::UpdateCreatureModel(WoWModel *m)
 
   QString query;
 
+  // Where the non-texture values sit in each result row. The three queries below do NOT
+  // share a column layout -- the modern one selects a fourth texture variation the older two
+  // do not -- so the positions are derived here, beside the SELECT that defines them, and
+  // never assumed further down. Reading them at fixed positions is what made the modern
+  // branch take ParticleColorID for the display id and TextureVariationFileDataID4 for the
+  // particle colour.
+  //
+  // The first TextureGroup::num columns are always the texture variations in every branch,
+  // which is why the texture loop below can stay positional.
+  int colParticleColor = 3;
+  int colDisplayId = 4;
+  int colGeosetData = -1;   // only Legion packs the geoset data into the row itself
+
   if (GAMEDIRECTORY.version().contains("7.3"))
   { 
     query = QString("SELECT TextureVariationFileDataID1, TextureVariationFileDataID2, TextureVariationFileDataID3, ParticleColorID, "
@@ -520,6 +533,7 @@ bool AnimControl::UpdateCreatureModel(WoWModel *m)
                     "ON CreatureDisplayInfo.ModelID = CreatureModelData.ID "
                     "WHERE CreatureModelData.FileDataID = %1")
                     .arg( m->gamefile->fileDataId());
+    colGeosetData = 5;
   } 
   else if (GAMEDIRECTORY.version().contains("8.3") || GAMEDIRECTORY.version().contains("9.2"))
   {
@@ -538,6 +552,8 @@ bool AnimControl::UpdateCreatureModel(WoWModel *m)
                       "ON CreatureDisplayInfo.ModelID = CreatureModelData.ID "
                       "WHERE CreatureModelData.FileDataID = %1")
                       .arg(m->gamefile->fileDataId());
+      colParticleColor = 4;
+      colDisplayId = 5;
   }
 
   sqlResult r = GAMEDATABASE.sqlQuery(query);
@@ -546,6 +562,18 @@ bool AnimControl::UpdateCreatureModel(WoWModel *m)
   {
     for(size_t i = 0 ; i < r.values.size() ; i++)
     {
+      // A row shorter than the SELECT promised would otherwise be read past its end. Bound the
+      // LAST column any branch reads -- on Legion the geoset column sits past the display id, so
+      // checking the display id alone would leave that read unguarded.
+      const int colMax = std::max(colDisplayId, std::max(colParticleColor, colGeosetData));
+      if (r.values[i].size() <= (size_t)colMax)
+      {
+        LOG_ERROR << "CreatureDisplayInfo row" << (uint)i << "has only"
+                  << (uint)r.values[i].size() << "columns; expected at least" << (colMax + 1)
+                  << "-- skipping it";
+        continue;
+      }
+
       TextureGroup grp;
       int count = 0;
       for (size_t skin = 0; skin < TextureGroup::num; skin++)
@@ -558,7 +586,7 @@ bool AnimControl::UpdateCreatureModel(WoWModel *m)
           count++;
         }
       }
-      int cdi = r.values[i][4].toInt();
+      int cdi = r.values[i][colDisplayId].toInt();
       grp.base = TEXTURE_GAMEOBJECT1;
       grp.definedTexture = true;
       grp.count = count;
@@ -566,14 +594,14 @@ bool AnimControl::UpdateCreatureModel(WoWModel *m)
       // Configure geosets that are switched on only for certain displayIDs.
       // This is handled differently in BfA (has its own table) compared
       // to Legion (compressed into a single integer in CreatureDisplayInfo) :
-      if (GAMEDIRECTORY.version().contains("7.3"))
+      if (colGeosetData >= 0)
       {
         // Geoset data is compressed into a single integer.
         // The position of the hex digit (from right) represents
         // the group number, and the value of the four bits at
         // that position represents the geoset. So 0x00200000
         // means geoset 2 of group 600, therefore 602.
-        int cgd = r.values[i][5].toInt();
+        int cgd = r.values[i][colGeosetData].toInt();
         for (int I = 0; I < 8; I++)
         {
           int geotype = 100 * (I + 1);
@@ -601,7 +629,7 @@ bool AnimControl::UpdateCreatureModel(WoWModel *m)
         }
       }
 
-      int pci = r.values[i][3].toInt(); // particleColorIndex, for replacing particle color
+      int pci = r.values[i][colParticleColor].toInt(); // particleColorIndex, for replacing particle color
       if (pci)
       {
         grp.particleColInd = pci;
@@ -1402,6 +1430,27 @@ void AnimControl::OnLoop(wxCommandEvent &)
     }
     g_selModel->animManager->Play();
   } 
+}
+
+void AnimControl::displayIdSkinIndices(std::vector<std::pair<int, int> > & out)
+{
+  out.clear();
+  const int count = skinList ? (int)skinList->GetCount() : 0;
+  for (std::map<int, TextureGroup>::const_iterator it = CDIToTexGp.begin();
+       it != CDIToTexGp.end(); ++it)
+  {
+    int index = -1;
+    for (int i = 0; i < count; i++)
+    {
+      TextureGroup * grp = static_cast<TextureGroup *>(skinList->GetClientData((unsigned int)i));
+      if (grp && it->second == *grp)
+      {
+        index = i;
+        break;
+      }
+    }
+    out.push_back(std::make_pair(it->first, index));
+  }
 }
 
 int AnimControl::skinCount()

--- a/Source/wowmodelviewer/animcontrol.h
+++ b/Source/wowmodelviewer/animcontrol.h
@@ -166,6 +166,11 @@ public:
   // run walks the list to prove every selection reaches the embedded renderer).
   int skinCount();
   wxString skinName(int index);
+
+  // Every creature display id this model's skins were built from, paired with the selector entry
+  // it resolves to (-1 when it resolves to none). Matched exactly the way SetSkinByDisplayID
+  // matches, so it reports what that call would actually do. Diagnostics only.
+  void displayIdSkinIndices(std::vector<std::pair<int, int> > & out);
   int AddSkin(TextureGroup grp);
   void SetSkin(int num);
   void ActivateBLPSkinList();

--- a/Source/wowmodelviewer/app.cpp
+++ b/Source/wowmodelviewer/app.cpp
@@ -335,6 +335,36 @@ static void doHeadlessUnityIpcTest(ModelViewer * frame)
         LOG_INFO << "[unityipc-test]   re-selected skin[" << (skins - 1)
                  << "] -- the player should report it unchanged and fetch nothing";
       }
+      // Display-id lookup: NPC and Armory import select a skin by CreatureDisplayInfo id
+      // (SetSkinByDisplayID), not by list position, so the map that translates one into the
+      // other has to be keyed on real display ids. Report what it holds, then round-trip one
+      // id through it and check the skin that comes out is the one that id names.
+      if (ac)
+      {
+        std::vector<std::pair<int, int> > displayMap;
+        ac->displayIdSkinIndices(displayMap);
+        LOG_INFO << "[unityipc-test] display-map check:" << (int)displayMap.size()
+                 << "display id(s) known to the skin selector";
+        for (size_t di = 0; di < displayMap.size() && di < 5; di++)
+          LOG_INFO << "[unityipc-test]   display" << displayMap[di].first << "-> skin["
+                   << displayMap[di].second << "]"
+                   << QString::fromWCharArray(ac->skinName(displayMap[di].second).c_str());
+
+        if (!displayMap.empty())
+        {
+          const int probeId = displayMap[0].first;
+          ac->SetSkinByDisplayID(probeId);
+          std::vector<UnityAssetAccess::ModelTexture> after;
+          QString afterError;
+          const bool afterOk = UnityAssetAccess::resolveModelTextures(fdid, after, afterError);
+          const int afterFdid = (afterOk && !after.empty()) ? after[0].fileDataID : 0;
+          LOG_INFO << "[unityipc-test]   SetSkinByDisplayID(" << probeId << ") -> skin["
+                   << displayMap[0].second << "] texture" << afterFdid
+                   << (afterFdid > 0 ? UnityAssetAccess::readByFileDataID(afterFdid).path : QString());
+          for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+        }
+      }
+
       LOG_INFO << "[unityipc-test] skin-sync: skinPushes=" << ipc->stats().skinPushes
                << "lastSkin=" << ipc->stats().lastSkin;
     }


### PR DESCRIPTION
UpdateCreatureModel builds one of three queries depending on the client generation, then read two values out of the result at positions that are only correct for the two OLDER layouts:

    7.3        TVF1 TVF2 TVF3 ParticleColorID CreatureDisplayInfo.ID GeosetData
    8.3 / 9.2  TVF1 TVF2 TVF3 ParticleColorID CreatureDisplayInfo.ID
    modern     TVF1 TVF2 TVF3 TVF4 ParticleColorID CreatureDisplayInfo.ID
                                   ^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^
    read as                        display id      (never read)
    read as    particle colour  <- TVF4

The modern query selects a fourth texture variation the older two do not, so everything after the textures sits one column further along. Current retail takes that branch (12.1.0.69404 matches none of the version substrings), and has been reading ParticleColorID as the display id and TextureVariationFileDataID4 as the particle colour ever since the column was added. A blanket shift would have been wrong: the older two branches were already correct.

Measured against retail 12.1, three things were broken by it.

  The display-id -> texture-group map was keyed on ParticleColorID, which is 0
  for 97.8% of creature displays. Every display of a model therefore collapsed
  onto key 0, holding whichever row happened to be processed last. chicken2
  ended up with ONE entry for its 41 displays. SetSkinByDisplayID -- how NPC
  and Armory import ask for a specific look -- could never match a real display
  id, logged "not associated with this model", and left the model on whatever
  skin was already selected.

  Per-display geoset data was fetched with WHERE CreatureDisplayInfoID = <a
  particle colour id>. 16% of creature displays carry geoset data that
  therefore never reached the model, and 48 rows accidentally matched an
  unrelated display's geosets.

  Creature particle-colour replacement never ran, because the id it needs was
  never read. Where TVF4 happened to be set the code instead asked the
  ParticleColor table for a FileDataID -- ids run to 2776, FileDataIDs to
  seven digits, so it always missed and quietly did nothing.

The positions are now derived where the query is built, in the same if/else that chooses it, so a layout and its offsets can no longer drift apart. That also becomes the single source of truth for whether the row carries the packed geoset integer at all, replacing a second version-string test further down. A row shorter than its SELECT promised is skipped with a logged reason rather than read past its end -- bounded on the last column any branch reads, since on Legion the geoset column sits past the display id.

Verified against retail 12.1 with creature/chicken2/chicken2.m2, before and after, through the -unityipctest diagnostic (which gained a display-map check for it): the map goes from 1 entry keyed 0 to all 41 display ids, and SetSkinByDisplayID(304) now selects CHICKEN2_WHITE / 1521062 -- matching the database row -- where before it was handed 0, returned early and changed nothing. Displays 589, 5369, 16138 and 17034 likewise resolve to the textures their rows name. The skin dropdown for chicken2 is unchanged at 7+1 entries, the Unity selected-skin sync still follows every selection, and the OpenGL viewport is unaffected.

Expect two visible changes elsewhere. Creatures whose displays differ only by geoset now offer those variants separately, because geoset data participates in the dropdown's de-duplication: 433 of 2965 creature models gain entries, 6 lose entries that were never real distinctions, and 2526 are unchanged. And particle-colour replacement now actually applies on the creatures that define it.

Out of scope and deliberately untouched: geoset SYNC to the Unity viewport (it still mirrors textures only), the equivalent lookups in UpdateItemModel (checked -- their 3-column query and its indices already agree), and the version gate's substring matching, which is sound for the current major.minor.patch.build format but would false-match a future version whose own digits spell one of the older ones.