### PR TITLE
Sync Unity creature geoset visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Embedded Unity renderer: it now shows the right geometry, not just the right texture.** A
+  creature display variant can differ from another by which geosets it switches on rather than by
+  its skin -- `creature/horse3/horse3.m2` has three dropdown entries sharing one texture that
+  differ only in geoset 101, 102 or 103, a long mane and tail against a cropped one -- and the
+  Unity viewport drew all of them identically. It now follows the same rule the OpenGL viewport
+  uses: a submesh is drawn when its geoset number is 0, or when the displayed variant names that
+  number. WMV sends the selected set alongside the textures it already sent, so the app stays the
+  only thing that reads the client database; the renderer already knows each submesh's number from
+  the .skin it parsed. Switching variants swaps which submeshes hand the mesh their triangles --
+  the mesh, its vertices, its materials and its textures are all left alone.
+
 ### Fixed
 - **Creature display lookup read the wrong columns on retail.** `AnimControl::UpdateCreatureModel`
   builds one of three queries depending on the client generation, but read the display id and the

--- a/Source/wowmodelviewer/UnityAssetAccess.cpp
+++ b/Source/wowmodelviewer/UnityAssetAccess.cpp
@@ -218,6 +218,19 @@ const char * UnityAssetAccess::sourceName(ModelTexture::Source source)
   }
 }
 
+bool UnityAssetAccess::selectedModelGeosets(int m2FileDataID, std::vector<int> & out)
+{
+  out.clear();
+  if (m2FileDataID <= 0 || !hasActiveClient())
+    return false;
+  if (!g_modelViewer || !g_modelViewer->animControl || !g_selModel || !g_selModel->gamefile)
+    return false;
+  if ((int)g_selModel->gamefile->fileDataId() != m2FileDataID)
+    return false;   // a question about some other model; we only know about the displayed one
+
+  return g_modelViewer->animControl->selectedSkinGeosets(out);
+}
+
 bool UnityAssetAccess::resolveModelTextures(int m2FileDataID, std::vector<ModelTexture> & out, QString & error)
 {
   out.clear();

--- a/Source/wowmodelviewer/UnityAssetAccess.h
+++ b/Source/wowmodelviewer/UnityAssetAccess.h
@@ -71,6 +71,14 @@ public:
   // "database" / "selection" / "convention" -- the wire spelling of ModelTexture::Source.
   static const char * sourceName(ModelTexture::Source source);
 
+  // The geosets the displayed skin switches on, as the numbers the model's own submeshes are
+  // identified by. A creature display can differ from another by GEOMETRY rather than texture,
+  // and the renderer cannot work that out for itself: only the app knows which display is
+  // selected. An empty list with a true return means "this display switches none on", which is
+  // not the same as not knowing -- see WoWModel::setCreatureGeosetData, where a submesh is drawn
+  // when its id is 0 or appears in this set. False when there is no selection to report.
+  static bool selectedModelGeosets(int m2FileDataID, std::vector<int> & out);
+
   // Resolve the texture(s) of a model that the M2 itself does not name.
   //
   // Tries, in order:

--- a/Source/wowmodelviewer/UnityIpcServer.cpp
+++ b/Source/wowmodelviewer/UnityIpcServer.cpp
@@ -292,6 +292,22 @@ QJsonArray UnityIpcServer::textureArray(const std::vector<UnityAssetAccess::Mode
   return arr;
 }
 
+void UnityIpcServer::addGeosets(QJsonObject & msg, int m2FileDataID)
+{
+  std::vector<int> geosets;
+  const bool known = UnityAssetAccess::selectedModelGeosets(m2FileDataID, geosets);
+
+  // "hasGeosets" separates "this display switches none on" (an answer) from "no selection to
+  // report" (not an answer). Without it the renderer could not tell an empty list from silence,
+  // and those mean opposite things: the first hides every non-zero geoset, the second must
+  // change nothing.
+  msg["hasGeosets"] = known;
+  QJsonArray arr;
+  for (size_t i = 0; i < geosets.size(); i++)
+    arr.append(geosets[i]);
+  msg["geosets"] = arr;
+}
+
 void UnityIpcServer::sendModelSkin(int m2FileDataID)
 {
   if (!m_client || !m_unityReady || m2FileDataID <= 0)
@@ -312,6 +328,7 @@ void UnityIpcServer::sendModelSkin(int m2FileDataID)
   msg["ok"] = true;              // same shape as a modelTextures reply, so one reader handles both
   msg["fileDataID"] = m2FileDataID;
   msg["textures"] = textureArray(textures);
+  addGeosets(msg, m2FileDataID);
   m_stats.skinPushes++;
   m_stats.lastSkin = QString("%1 (%2)").arg(textures[0].fileDataID)
                                        .arg(UnityAssetAccess::sourceName(textures[0].source));
@@ -401,6 +418,7 @@ void UnityIpcServer::handleGetModelTextures(const QJsonObject & msg)
   if (ok)
   {
     resp["textures"] = textureArray(textures);
+    addGeosets(resp, fdid);
     m_stats.responsesOk++;
     LOG_INFO << "[unityipc] -> modelTextures" << requestId << "resolved" << (int)textures.size()
              << "texture(s) from" << UnityAssetAccess::sourceName(textures.empty()

--- a/Source/wowmodelviewer/UnityIpcServer.h
+++ b/Source/wowmodelviewer/UnityIpcServer.h
@@ -27,7 +27,8 @@
  *     { "type":"modelTextures", "requestId":"abc125", "ok":true, "fileDataID":123200,
  *       "textures":[ { "index":0, "type":11, "fileDataID":123199, "source":"selection" } ] }
  *     { "type":"modelSkin", "fileDataID":1521037,
- *       "textures":[ { "index":0, "type":11, "fileDataID":1521061, "source":"selection" } ] }
+ *       "textures":[ { "index":0, "type":11, "fileDataID":1521061, "source":"selection" } ],
+ *       "geosets":[ 101 ], "hasGeosets":true }
  *
  * getModelTextures exists because modern M2s do NOT name their replaceable textures (a
  * creature skin's TXID entry is 0 and the texture array carries no filename) -- the skin comes
@@ -129,6 +130,8 @@ private:
   void handleGetAsset(const QJsonObject & msg, bool byFileDataID);
   void handleGetModelTextures(const QJsonObject & msg);
   static QJsonArray textureArray(const std::vector<UnityAssetAccess::ModelTexture> & textures);
+  // Adds "geosets"/"hasGeosets" to a message about one model, when a selection is known.
+  static void addGeosets(QJsonObject & msg, int m2FileDataID);
   void queueJson(const QJsonObject & obj);
   void dropClient(const char * why);
 

--- a/Source/wowmodelviewer/animcontrol.cpp
+++ b/Source/wowmodelviewer/animcontrol.cpp
@@ -1453,6 +1453,26 @@ void AnimControl::displayIdSkinIndices(std::vector<std::pair<int, int> > & out)
   }
 }
 
+bool AnimControl::selectedSkinGeosets(std::vector<int> & out)
+{
+  out.clear();
+  if (!skinList || !skinList->IsShown())
+    return false;
+
+  const int sel = skinList->GetSelection();
+  if (sel < 0)
+    return false;   // a per-slot texture pick clears the selection; it does not change geosets
+
+  TextureGroup * grp = static_cast<TextureGroup *>(skinList->GetClientData((unsigned int)sel));
+  if (!grp)
+    return false;
+
+  for (std::set<GeosetNum>::const_iterator it = grp->creatureGeosetData.begin();
+       it != grp->creatureGeosetData.end(); ++it)
+    out.push_back((int)*it);
+  return true;   // true means "the selection is known", even when it switches nothing on
+}
+
 int AnimControl::skinCount()
 {
   return (skinList && skinList->IsShown()) ? (int)skinList->GetCount() : 0;

--- a/Source/wowmodelviewer/animcontrol.h
+++ b/Source/wowmodelviewer/animcontrol.h
@@ -162,6 +162,13 @@ public:
   // is selected -- e.g. a character model, or a creature with no skins at all.
   bool selectedSkinTextures(std::vector<std::pair<int, int> > & out);
 
+  // The geosets the selected display switches on, as the same numbers the model's submeshes are
+  // identified by (group * 100 + variant). A creature display can differ from another by geometry
+  // rather than texture -- one horse mane instead of another -- and this is what says which.
+  // Empty is meaningful, not "unknown": it means the display switches none on, so only the
+  // submeshes with id 0 are drawn. See WoWModel::setCreatureGeosetData.
+  bool selectedSkinGeosets(std::vector<int> & out);
+
   // Entries in the skin selector, and one entry's label -- diagnostics only (the -unityipctest
   // run walks the list to prove every selection reaches the embedded renderer).
   int skinCount();

--- a/Source/wowmodelviewer/app.cpp
+++ b/Source/wowmodelviewer/app.cpp
@@ -316,12 +316,24 @@ static void doHeadlessUnityIpcTest(ModelViewer * frame)
         QString selError;
         const bool selOk = UnityAssetAccess::resolveModelTextures(fdid, sel, selError);
         const int selFdid = (selOk && !sel.empty()) ? sel[0].fileDataID : 0;
+
+        // Two variants of a creature can differ by GEOMETRY rather than texture, so report the
+        // geoset set alongside the texture -- that is what the renderer has to mirror.
+        std::vector<int> geosets;
+        UnityAssetAccess::selectedModelGeosets(fdid, geosets);
+        QString geoStr;
+        for (size_t gi = 0; gi < geosets.size(); gi++)
+          geoStr += (gi ? "," : "") + QString::number(geosets[gi]);
+        if (geoStr.isEmpty())
+          geoStr = "none";
+
         LOG_INFO << "[unityipc-test]   skin[" << s << "]"
                  << QString::fromWCharArray(ac->skinName(s).c_str()) << "-> fileDataID="
                  << selFdid << "type=" << ((selOk && !sel.empty()) ? sel[0].type : 0)
                  << "source=" << ((selOk && !sel.empty())
                                   ? UnityAssetAccess::sourceName(sel[0].source) : "none")
-                 << "path=" << (selFdid > 0 ? UnityAssetAccess::readByFileDataID(selFdid).path : QString());
+                 << "path=" << (selFdid > 0 ? UnityAssetAccess::readByFileDataID(selFdid).path : QString())
+                 << "geosets=" << geoStr;
         // let the push reach the player before selecting the next one
         for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
       }

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
@@ -22,7 +22,7 @@
 //   assetResponse { requestId, ok, path, fileDataID, byteLength, sha1, encoding:"base64", data }
 //   assetResponse { requestId, ok:false, error }
 //   modelTextures { requestId, ok, fileDataID, textures:[{ index, type, fileDataID, source }] }
-//   modelSkin     { fileDataID, textures:[{ index, type, fileDataID, source }] }   (pushed, no request)
+//   modelSkin     { fileDataID, textures:[...], geosets:[...], hasGeosets }        (pushed, no request)
 //
 // getModelTextures exists because a modern M2 does not name its replaceable textures (a
 // creature skin's TXID entry is 0 and its texture array carries no filename) -- the skin comes
@@ -101,6 +101,15 @@ public class WmvIpcClient : MonoBehaviour
         public int fileDataID;
         public string error;
         public ModelTextureRef[] textures = new ModelTextureRef[0];
+
+        /// <summary>
+        /// The geoset numbers the displayed variant switches on. Only meaningful when
+        /// <see cref="hasGeosets"/> is true -- an empty list then means "this variant switches
+        /// none on", which hides every submesh whose id is not 0. When hasGeosets is false the
+        /// host had no selection to report and geoset visibility must be left alone.
+        /// </summary>
+        public int[] geosets = new int[0];
+        public bool hasGeosets;
     }
 
     [Serializable] class MsgTexture
@@ -114,6 +123,8 @@ public class WmvIpcClient : MonoBehaviour
     [Serializable] class Msg
     {
         public MsgTexture[] textures;
+        public int[] geosets;
+        public bool hasGeosets;
         public string type;
         public string requestId;
         public string path;
@@ -240,6 +251,8 @@ public class WmvIpcClient : MonoBehaviour
                     source = msg.textures[i].source ?? "",
                 };
         }
+        r.hasGeosets = msg.hasGeosets;
+        if (msg.geosets != null) r.geosets = msg.geosets;
         return r;
     }
 

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -48,6 +48,14 @@ public class WmvMain : MonoBehaviour
     readonly Dictionary<int, int> currentTextureIds = new Dictionary<int, int>();   // slot -> FileDataID
     SkinJob skinJob;                  // in-flight skin change, if any
 
+    /// <summary>
+    /// The geoset numbers the displayed creature variant switches on, or null when the host has
+    /// not reported any. Two variants of the same creature can differ by GEOMETRY rather than
+    /// texture -- one horse's mane instead of another -- and this is what decides which submeshes
+    /// are drawn. See WmvModelBuilder.GeosetVisible.
+    /// </summary>
+    HashSet<int> currentGeosets;
+
     /// <summary>Textures still on their way for a skin change. Requests are keyed to the M2
     /// texture slot they will land in.</summary>
     class SkinJob
@@ -237,6 +245,7 @@ public class WmvMain : MonoBehaviour
         if (job == null || r.requestId != job.PendingTextureList)
             return;
         job.PendingTextureList = null;
+        AdoptGeosets(r);
 
         if (!r.ok || r.textures.Length == 0)
         {
@@ -299,7 +308,8 @@ public class WmvMain : MonoBehaviour
             long t0 = job.Clock.ElapsedMilliseconds;
             var built = WmvModelBuilder.Build(job.Model, job.Skin, job.Textures,
                                               string.IsNullOrEmpty(job.Model.Name) ? "WoWModel" : job.Model.Name,
-                                              s => Debug.LogWarning("WMV: " + s));
+                                              s => Debug.LogWarning("WMV: " + s),
+                                              currentGeosets);
             job.BuildMs = job.Clock.ElapsedMilliseconds - t0;
 
             if (current != null) current.Dispose();      // never leak the previous model
@@ -320,6 +330,9 @@ public class WmvMain : MonoBehaviour
             status.Set("Loaded " + job.Path);
             status.Set(string.Format("Vertices {0}  Triangles {1}  Submeshes {2}  Textures {3}",
                                      built.VertexCount, built.TriangleCount, built.SubmeshCount, job.Textures.Count));
+            if (currentGeosets != null)
+                status.Set("Geosets " + (currentGeosets.Count == 0 ? "none" : string.Join(",",
+                           new List<int>(currentGeosets).ConvertAll(x => x.ToString()).ToArray())));
             status.Set(string.Format("Bounds {0} size {1}", built.Bounds.center, built.Bounds.size));
             status.Set(string.Format("Load {0} ms (m2 {1}, skin {2}, tex {3}, parse {4}, build {5})",
                                      job.Clock.ElapsedMilliseconds, job.M2Ms, job.SkinMs, job.TextureMs,
@@ -346,6 +359,16 @@ public class WmvMain : MonoBehaviour
             return;                                     // about a different model
         if (!r.ok || r.textures.Length == 0)
             return;
+
+        // Geometry first: a variant can change which submeshes are drawn as well as which texture
+        // they wear, and the two are independent -- a variant that only swaps geosets has no
+        // texture to fetch and would otherwise be dropped by the no-op check below.
+        if (AdoptGeosets(r))
+        {
+            WmvModelBuilder.ApplyGeosets(current, currentGeosets, s => Debug.Log("WMV: " + s));
+            status.Set(string.Format("Geosets applied ({0} triangles, mesh unchanged)",
+                                     current.TriangleCount));
+        }
 
         var wanted = new Dictionary<int, int>();         // slot -> FileDataID
         foreach (var t in r.textures)
@@ -436,6 +459,34 @@ public class WmvMain : MonoBehaviour
             (model == null || t.index < model.Textures.Length))
             slots.Add(t.index);
         return slots;
+    }
+
+    /// <summary>
+    /// Take the geoset set out of a host message, if it reported one. Returns true when the set
+    /// actually CHANGED, so the caller only touches the mesh when there is something to do.
+    /// A message with hasGeosets false is silence, not an empty answer: the host had no creature
+    /// selection to report, and whatever is on screen stays.
+    /// </summary>
+    bool AdoptGeosets(WmvIpcClient.ModelTexturesResponse r)
+    {
+        if (!r.hasGeosets)
+            return false;
+
+        var next = new HashSet<int>();
+        foreach (int g in r.geosets)
+            next.Add(g);
+
+        if (currentGeosets != null && currentGeosets.Count == next.Count)
+        {
+            bool same = true;
+            foreach (int g in next)
+                if (!currentGeosets.Contains(g)) { same = false; break; }
+            if (same)
+                return false;
+        }
+
+        currentGeosets = next;
+        return true;
     }
 
     void Fail(string reason)

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -31,6 +31,17 @@ public class WmvRuntimeModel
     public Material[] Materials = new Material[0];
     public Texture2D[] Textures = new Texture2D[0];
     public WmvMaterialBinding[] Bindings = new WmvMaterialBinding[0];
+
+    /// <summary>Geoset number of each submesh, parallel to Materials. 0 = always drawn.</summary>
+    public int[] SubmeshGeosets = new int[0];
+
+    /// <summary>Every submesh's triangles, kept so hiding one is a matter of handing the mesh an
+    /// empty list and showing it again is handing back this array -- no geometry is re-uploaded
+    /// and no material is rebuilt.</summary>
+    public int[][] SubmeshTriangles = new int[0][];
+
+    /// <summary>The geoset numbers currently switched on, or null when the host has not said.</summary>
+    public HashSet<int> Geosets;
     public Bounds Bounds;
     public int VertexCount, TriangleCount, SubmeshCount;
 
@@ -113,9 +124,26 @@ public static class WmvModelBuilder
     /// pixels; a slot with no entry renders untextured (white), which is what happens for a
     /// replaceable texture the host could not resolve.
     /// </summary>
+    /// <summary>
+    /// Is this submesh drawn, given the geoset numbers the displayed variant switches on?
+    ///
+    /// This is the legacy viewport's rule, from WoWModel::setCreatureGeosetData: a submesh whose
+    /// geoset number is 0 is always drawn, and every other one is drawn only if the variant names
+    /// it. An EMPTY set is an answer, not a blank -- it hides everything but the id-0 submeshes,
+    /// which is exactly what the viewport does for a display with no geoset data. A null set means
+    /// the host had nothing to say (no creature selection at all), and then nothing is hidden.
+    /// </summary>
+    public static bool GeosetVisible(int submeshId, HashSet<int> geosets)
+    {
+        if (geosets == null || submeshId == 0)
+            return true;
+        return geosets.Contains(submeshId);
+    }
+
     public static WmvRuntimeModel Build(M2ParsedModel model, M2ParsedSkin skin,
                                         Dictionary<int, BlpImage> decodedTextures,
-                                        string objectName, Action<string> log)
+                                        string objectName, Action<string> log,
+                                        HashSet<int> geosets = null)
     {
         if (model == null || skin == null)
             throw new WowParseException("builder: nothing to build");
@@ -171,7 +199,8 @@ public static class WmvModelBuilder
         // can feed an opaque batch (alpha thrown away) and a blended one (alpha kept).
         var textureCache = new Dictionary<int, Texture2D>();
         var triangleSets = new List<int[]>();
-        int totalTriangles = 0;
+        var submeshGeosets = new List<int>();
+        int totalTriangles = 0, hiddenByGeoset = 0;
 
         // Resolve the shader up front: whether it can run the M2 combiner decides how the base
         // texture's alpha has to be treated, which happens before any material is created.
@@ -217,7 +246,14 @@ public static class WmvModelBuilder
             int[] indices = M2SkinParser.BuildTriangles(skin, submesh, n);
             WowCoordinateConverter.FlipWinding(indices);   // handedness change reverses winding
             triangleSets.Add(indices);
-            totalTriangles += indices.Length / 3;
+            submeshGeosets.Add(submesh.Id);
+            // A geoset the variant does not switch on still gets its submesh and material -- only
+            // its triangles are withheld -- so a later variant can switch it back on without
+            // rebuilding anything.
+            if (GeosetVisible(submesh.Id, geosets))
+                totalTriangles += indices.Length / 3;
+            else
+                hiddenByGeoset++;
 
             // How this material combines its texture units, resolved exactly as the legacy
             // renderer does. This milestone implements one combiner; the rest are logged and
@@ -281,8 +317,15 @@ public static class WmvModelBuilder
 
         mesh.subMeshCount = triangleSets.Count;
         for (int i = 0; i < triangleSets.Count; i++)
-            mesh.SetTriangles(triangleSets[i], i, true);
-        mesh.RecalculateBounds();
+            mesh.SetTriangles(GeosetVisible(submeshGeosets[i], geosets) ? triangleSets[i] : EmptyTriangles,
+                              i, false);
+        // Bounds come from the WHOLE model, not from what is currently visible, so switching a
+        // variant does not make the camera jump.
+        mesh.bounds = BoundsOfAll(positions, triangleSets);
+
+        if (log != null && hiddenByGeoset > 0)
+            log(string.Format("geosets: {0} of {1} submesh(es) hidden by the displayed variant [{2}]",
+                              hiddenByGeoset, triangleSets.Count, GeosetList(geosets)));
 
         // ---- scene object -------------------------------------------------------------
         var go = new GameObject(objectName);
@@ -295,11 +338,74 @@ public static class WmvModelBuilder
         result.Materials = materials.ToArray();
         result.Bindings = bindings.ToArray();
         result.Textures = textures.ToArray();
+        result.SubmeshGeosets = submeshGeosets.ToArray();
+        result.SubmeshTriangles = triangleSets.ToArray();
+        result.Geosets = geosets;
         result.Bounds = mesh.bounds;
         result.VertexCount = n;
         result.TriangleCount = totalTriangles;
         result.SubmeshCount = triangleSets.Count;
         return result;
+    }
+
+    static readonly int[] EmptyTriangles = new int[0];
+
+    /// <summary>Bounds over every triangle the model has, visible or not.</summary>
+    static Bounds BoundsOfAll(Vector3[] positions, List<int[]> triangleSets)
+    {
+        bool any = false;
+        Vector3 min = Vector3.zero, max = Vector3.zero;
+        foreach (var tris in triangleSets)
+        {
+            foreach (int i in tris)
+            {
+                Vector3 p = positions[i];
+                if (!any) { min = max = p; any = true; continue; }
+                min = new Vector3(Mathf.Min(min.x, p.x), Mathf.Min(min.y, p.y), Mathf.Min(min.z, p.z));
+                max = new Vector3(Mathf.Max(max.x, p.x), Mathf.Max(max.y, p.y), Mathf.Max(max.z, p.z));
+            }
+        }
+        var b = new Bounds();
+        b.center = (min + max) * 0.5f;
+        b.size = max - min;
+        return b;
+    }
+
+    static string GeosetList(HashSet<int> geosets)
+    {
+        if (geosets == null) return "not reported";
+        if (geosets.Count == 0) return "none";
+        var parts = new List<string>();
+        foreach (int g in geosets) parts.Add(g.ToString());
+        parts.Sort();
+        return string.Join(",", parts.ToArray());
+    }
+
+    /// <summary>
+    /// Switch which geosets the model shows. The mesh, its vertices, its materials and its
+    /// textures are all untouched: a variant change only decides which submeshes hand the mesh
+    /// their triangles. Returns the number of triangles now drawn.
+    /// </summary>
+    public static int ApplyGeosets(WmvRuntimeModel runtime, HashSet<int> geosets, Action<string> log)
+    {
+        if (runtime == null || runtime.Mesh == null ||
+            runtime.SubmeshTriangles.Length != runtime.Mesh.subMeshCount)
+            return 0;
+
+        runtime.Geosets = geosets;
+        int visible = 0, shown = 0, hidden = 0;
+        for (int i = 0; i < runtime.SubmeshTriangles.Length; i++)
+        {
+            bool on = GeosetVisible(runtime.SubmeshGeosets[i], geosets);
+            runtime.Mesh.SetTriangles(on ? runtime.SubmeshTriangles[i] : EmptyTriangles, i, false);
+            if (on) { visible += runtime.SubmeshTriangles[i].Length / 3; shown++; }
+            else hidden++;
+        }
+        runtime.TriangleCount = visible;
+        if (log != null)
+            log(string.Format("geosets [{0}]: {1} submesh(es) shown, {2} hidden, {3} triangles drawn",
+                              GeosetList(geosets), shown, hidden, visible));
+        return visible;
     }
 
     /// <summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -138,6 +138,11 @@ namespace Wmv.Wow
     /// <summary>One renderable section of the skin profile (a "geoset"/submesh).</summary>
     public struct M2Submesh
     {
+        /// <summary>
+        /// The geoset number this submesh belongs to, group * 100 + variant, masked to 15 bits.
+        /// 0 means "always drawn"; anything else is drawn only when the displayed creature variant
+        /// switches that number on. See WmvModelBuilder.GeosetVisible.
+        /// </summary>
         public ushort Id;
         public ushort Level;
         public ushort VertexStart, VertexCount;

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2SkinParser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2SkinParser.cs
@@ -73,7 +73,10 @@ namespace Wmv.Wow
             {
                 c.Seek(submeshes.Offset + i * SubmeshStride);
                 M2Submesh s;
-                s.Id = c.ReadUInt16();
+                // Mask off the high bit: only the low 15 bits are the geoset number, and that
+                // number is what a creature display's geoset set is expressed in. The legacy
+                // viewport masks it the same way, so both renderers compare like with like.
+                s.Id = (ushort)(c.ReadUInt16() & 0x7FFF);
                 s.Level = c.ReadUInt16();
                 s.VertexStart = c.ReadUInt16();
                 s.VertexCount = c.ReadUInt16();

--- a/Tools/UnityRendererProject/README.md
+++ b/Tools/UnityRendererProject/README.md
@@ -128,6 +128,13 @@ ships an 18-triangle eye overlay pointing at a colour entry whose alpha track is
 eye is painted into the skin texture on the head underneath. Drawing that batch anyway covers the
 painted eye with a flat red patch. `-wmvShowHidden` draws them if you want to see what is hidden.
 
+**And a creature variant can change the geometry, not just the texture.** Each submesh carries a
+geoset number (group * 100 + variant, masked to 15 bits); a submesh numbered 0 is always drawn, and
+any other is drawn only when the displayed variant switches that number on. `creature/horse3/horse3.m2`
+has three dropdown entries sharing one texture that differ only in whether geoset 101, 102 or 103 is
+on -- a long mane and tail, or a cropped one. WMV sends the set; switching between variants swaps
+which submeshes hand the mesh their triangles, so nothing is re-uploaded and no material is rebuilt.
+
 ## Debug switches
 
 Pass these on the player command line to isolate a visual fault without rebuilding:

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -136,7 +136,7 @@ namespace Wmv.Wow.Tests
         /// <summary>Skin with `vertexCount` lookup entries and one submesh covering `triangles`.</summary>
         static byte[] BuildSkin(int vertexCount, ushort[] triangles, ushort submeshIndexCount = 0xFFFF,
                                 ushort lookupOverride = 0xFFFF, ushort batchColorIndex = 0xFFFF,
-                                ushort batchTextureCount = 1)
+                                ushort batchTextureCount = 1, ushort submeshId = 0)
         {
             const int headerSize = 0x30;
             int vertOffset = headerSize;
@@ -158,7 +158,7 @@ namespace Wmv.Wow.Tests
             for (int i = 0; i < triangles.Length; i++)
                 PutU16(b, triOffset + i * 2, triangles[i]);
 
-            PutU16(b, subOffset + 0, 0);                     // id
+            PutU16(b, subOffset + 0, submeshId);             // id (geoset number)
             PutU16(b, subOffset + 2, 0);                     // level
             PutU16(b, subOffset + 4, 0);                     // vertexStart
             PutU16(b, subOffset + 6, (ushort)vertexCount);   // vertexCount
@@ -416,6 +416,14 @@ namespace Wmv.Wow.Tests
             Check(skin.Batches[0].ColorIndex == 0 && skin.Batches[0].HasColor,
                   "tracks: batch colour index parsed");
             Check(skin.Batches[0].TextureWeightComboIndex == 0, "tracks: batch weight combo index parsed");
+
+            // The geoset number is the low 15 bits: the legacy viewport masks the same way, and a
+            // creature display's geoset set is expressed in those numbers. Without the mask the
+            // two renderers would compare different values and never agree on what is visible.
+            var masked = M2SkinParser.Parse(BuildSkin(3, new ushort[] { 0, 1, 2 }, submeshId: 0x8065));
+            Check(masked.Submeshes[0].Id == 0x0065, "geoset: submesh id is masked to 15 bits");
+            var unmasked = M2SkinParser.Parse(BuildSkin(3, new ushort[] { 0, 1, 2 }, submeshId: 101));
+            Check(unmasked.Submeshes[0].Id == 101, "geoset: an id below the mask is unchanged");
             Check(skin.Batches[0].TextureCoordComboIndex == 0xFFFF, "tracks: batch coord combo index parsed");
 
             // a batch with no colour entry is never hidden by one

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -150,7 +150,8 @@ The response carries metadata only; bytes are still fetched with `getAssetByFile
   "fileDataID": 123200, "byteLength": 101840, "sha1": "1dc88a19...", "encoding": "base64", "data": "TUQyMb..." }
 { "type": "assetResponse", "requestId": "abc123", "ok": false, "error": "not found" }
 { "type": "modelSkin", "ok": true, "fileDataID": 1521037,
-  "textures": [ { "index": 0, "type": 11, "fileDataID": 1521061, "source": "selection" } ] }
+  "textures": [ { "index": 0, "type": 11, "fileDataID": 1521061, "source": "selection" } ],
+  "geosets": [ 101 ], "hasGeosets": true }
 ```
 
 Semantics:
@@ -165,10 +166,18 @@ Semantics:
   from `AnimControl::SetSkin`, the single funnel every skin change goes through (the dropdown,
   the default chosen on model load, and NPC import), plus `SetSingleSkin` for the per-slot
   folder-texture lists.
-  *Known limitation:* a display variant can also toggle **geosets**
-  (`CreatureDisplayInfoGeosetData`). The Unity viewport swaps textures only, so on a variant that
-  changes geometry the two viewports will still differ in what is drawn -- geosets are not part
-  of this static-M2 milestone.
+- `geosets` / `hasGeosets` ride along with both `modelTextures` and `modelSkin`, because a display
+  variant can differ from another by **geometry** rather than texture. `creature/horse3/horse3.m2`
+  is the worked example: three of its dropdown entries share one texture and differ only in
+  whether geoset 101, 102 or 103 is switched on -- a long mane and tail, or a cropped one.
+  A submesh is drawn when **its geoset number is 0, or the variant switches that number on**,
+  which is the legacy viewport's own rule (`WoWModel::setCreatureGeosetData`: every geoset in
+  `[1, 900)` is shown iff the set names it, and `setLOD` starts them at `display = (id == 0)`).
+  The renderer already knows every submesh's number from the .skin it parsed, so only the SET
+  travels.
+  `hasGeosets` separates two things an empty list cannot: `true` with an empty list means "this
+  variant switches none on" -- which hides every submesh whose number is not 0 -- while `false`
+  means the host had no creature selection to report and geoset visibility must be left alone.
 - `getAsset` / `getAssetByFileDataID` return the **raw, whole file** exactly as stored in the
   active client (modern `.m2` bytes start with their `MD21` chunk header, etc.). Paths are
   normalised (lower-case, forward slashes). By-FileDataID works for CASC clients; a legacy


### PR DESCRIPTION
A creature display variant can differ from another by which geometry it shows, not just by which skin it wears. creature/horse3/horse3.m2 is the worked example: three of its dropdown entries share one texture (horse3_black) and differ only in whether geoset 101, 102 or 103 is switched on -- a long flowing mane and tail against a cropped mane and docked tail. The Unity viewport drew all three identically, because it had no idea geosets existed.

The rule, taken from the legacy viewport rather than invented

  WoWModel::setLOD starts every geoset at  display = (id == 0)  and
  WoWModel::setCreatureGeosetData then shows each one in [1, 900) if and only
  if the selected display names it. Nothing else writes that flag for a
  creature: WoWModel::refresh returns at "if (infos.raceID == -1)" before its
  character default-geoset rule, and the customization and equipment paths are
  reached only from character code. So visibility is a pure function

      drawn(submesh) = (submesh.geosetNumber == 0) || selected.contains(number)

  and a second renderer can reproduce it exactly. That was worth establishing
  before writing any of this, because if anything else had touched the flag the
  two viewports could not have been kept in step.

What travels: only the SET. The renderer already knows every submesh's geoset number from the .skin it parsed, so the app sends the numbers the displayed variant switches on and nothing else -- it stays the only component that reads the client database. "hasGeosets" separates the two things an empty list cannot: true with an empty list means "this variant switches none on", which hides every submesh numbered other than 0, while false means there was no creature selection to report and visibility must be left alone. Both getModelTextures and the pushed modelSkin carry it, built from the same accessor, so they cannot disagree.

The skin parser now masks the geoset number to 15 bits, as the legacy viewport does. Without that the two renderers would be comparing different numbers for the same submesh and could never agree.

Unity keeps every drawable batch as a submesh whether or not it is currently shown, and switches visibility by handing the mesh that submesh's triangles or an empty list. The mesh, its vertices, its materials and its textures are untouched, so changing variant costs an index-buffer write and nothing else -- and a variant that only swaps geosets, with no texture to fetch, still takes effect. Bounds are computed over the whole model rather than what is visible, so switching does not make the camera jump.

Verified against retail 12.1. horse3's submeshes carry geoset numbers {0: 1504 triangles, 101: 1011, 102: 938, 103: 749}; walking its 47 dropdown entries, the renderer reports exactly 2515, 2442 and 2253 triangles for variants 101, 102 and 103 -- the arithmetic the file predicts -- with "mesh unchanged" every time and no reload. creature/babyoctopus/babyoctopus.m2 is the on/off case: 1992 triangles with geoset 101, 1828 without. Rendering both horse3 variants through the committed parsers shows the mane and tail change and nothing else. creature/chicken2/chicken2.m2 is unchanged at 778 triangles and one submesh -- its geosets are all 0, so nothing is hidden -- with its eye-overlay batch still skipped and its two-texture environment combiner still bound; and creature/murloc2/murloc2.m2 confirms the 95.5% of creature models that have no geoset data at all are unaffected, because every one of their submeshes is numbered 0.

Out of scope: geoset groups that a display switches on for reasons other than CreatureDisplayInfoGeosetData (character customization and equipment), which belong to the character pipeline this milestone does not render; and the animation, skinning, particle and map work that remains ahead of it.

Still runtime-only: every byte arrives over IPC and nothing is written to disk.