### PR TITLE
Expand Unity static M2 material coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Embedded Unity renderer: materials now follow the model instead of an approximation of it.**
+  The renderer drew almost everything opaque with a single texture, which is right for a chicken
+  and wrong for most of the bestiary. Measured over a spread of 300 retail creature models (1424
+  draw batches): 26.6% of batches ask for a blend mode that was being ignored -- additive glows,
+  alpha-blended wings, modulated shadows, all rendered as solid geometry -- and 33.4% declare a
+  second texture unit whose contribution was dropped. Both now come from the same tables the
+  OpenGL viewport uses. Every M2 blend mode is applied; the alpha test keys at 128/255, where the
+  legacy combiner keys it; depth write comes from the material's own flag and nothing else (the
+  viewport decides it outside its blend switch, so a blended pass whose flag is clear still writes
+  depth); and the texture combiners a static pose can reproduce -- the products of the two units,
+  the two alpha-masked forms and the decal -- are drawn with unit 1 sampled from whichever source
+  the material's vertex shader names, either stored UV set or a generated environment sphere map.
+  Combiner coverage over that sample goes from 66.6% of batches to 99.8%; the three that remain
+  are logged by name and drawn from unit 0 alone, as all of them were before. Ported case by case
+  from the viewport's own GLSL rather than from the combiner names, which matters: several
+  combiners differ from a simpler one only in a specular lobe the viewport weights at zero by
+  default, so reproducing the default collapses them onto the simpler case. All of it is driven by
+  uniforms on one shader variant, because a player build strips shader variants as readily as it
+  strips whole shaders.
+
+### Added
 - **Embedded Unity renderer: it now shows the right geometry, not just the right texture.** A
   creature display variant can differ from another by which geosets it switches on rather than by
   its skin -- `creature/horse3/horse3.m2` has three dropdown entries sharing one texture that

--- a/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
@@ -14,15 +14,10 @@
 // built-in light uniforms). The key light below is fixed in world space so the model shades the
 // same way in every pipeline.
 //
-// The render state is exposed as properties, which is the point: WmvModelBuilder sets _SrcBlend,
-// _DstBlend, _ZWrite, _Cull and _Cutoff explicitly, and here those calls actually take effect.
-//
-// SECOND TEXTURE UNIT. An M2 material can combine several textures, and which arithmetic it uses
-// is selected by the material's shader id rather than described in the file. _CombinerMode carries
-// the resolved combiner id (the same numbering the legacy OpenGL viewport's GLSL combiner uses);
-// 0 means "single texture", which is the default and the behaviour of every material this shader
-// does not have a case for. It is a plain float uniform, not a shader keyword, so no extra shader
-// variants exist for a player build to strip.
+// EVERYTHING IS UNIFORM-DRIVEN, never a shader keyword: the blend state, the combiner, where the
+// second texture unit takes its coordinates, and how the output alpha is built. A player build
+// strips shader VARIANTS as readily as it strips whole shaders, so a keyword per material feature
+// would be a way to lose them all. One variant, a handful of floats.
 
 Shader "WMV/Opaque Textured"
 {
@@ -30,7 +25,21 @@ Shader "WMV/Opaque Textured"
     {
         _MainTex ("Texture", 2D) = "white" {}
         _SecondTex ("Second texture (M2 unit 1)", 2D) = "black" {}
-        _CombinerMode ("Combiner id (0 = single texture)", Float) = 0
+
+        // 0 = single texture;      1 = unit0 * unit1;          2 = unit0 * unit1 * 2;
+        // 3 = mix(u0*u1, u0, u0.a); 4 = mix(u0, u1, u1.a);      12 = mix(u0*u1*2, u0, u0.a).
+        // Which M2 pixel shader maps to which lives in WmvModelBuilder.PlanCombiner, next to the
+        // reasoning; the shader only needs the arithmetic.
+        _CombinerMode ("Combiner", Float) = 0
+        // Where unit 1 samples: 0 = uv set 0, 1 = uv set 1, 2 = environment sphere map.
+        _Unit1UV ("Unit 1 UV source", Float) = 2
+        // How the M2 combiner builds its "discard alpha": 0 = 1, 1 = unit0.a, 2 = unit1.a,
+        // 3 = unit0.a * unit1.a, 4 = unit0.a + unit1.a. Scaled by _AlphaScale (the x2 combiners).
+        _AlphaMode ("Alpha source", Float) = 0
+        _AlphaScale ("Alpha scale", Float) = 1
+        // 1 when the blend mode ignores that alpha entirely (opaque and alpha-key both output 1).
+        _OpaqueAlpha ("Force opaque alpha", Float) = 1
+
         _Color ("Tint", Color) = (1,1,1,1)
         _Cutoff ("Alpha cutoff", Range(0,1)) = 0.5
         [Enum(UnityEngine.Rendering.CullMode)] _Cull ("Cull", Float) = 2      // Back
@@ -62,6 +71,7 @@ Shader "WMV/Opaque Textured"
                 float4 vertex : POSITION;
                 float3 normal : NORMAL;
                 float2 uv     : TEXCOORD0;
+                float2 uv2    : TEXCOORD1;
             };
 
             struct v2f
@@ -70,12 +80,13 @@ Shader "WMV/Opaque Textured"
                 float2 uv     : TEXCOORD0;
                 float3 normal : TEXCOORD1;
                 float2 env    : TEXCOORD2;
+                float2 uv1    : TEXCOORD3;
             };
 
             sampler2D _MainTex;
             float4 _MainTex_ST;
             sampler2D _SecondTex;
-            float _CombinerMode;
+            float _CombinerMode, _Unit1UV, _AlphaMode, _AlphaScale, _OpaqueAlpha;
             fixed4 _Color;
             fixed _Cutoff;
 
@@ -84,6 +95,7 @@ Shader "WMV/Opaque Textured"
                 v2f o;
                 o.pos = UnityObjectToClipPos(v.vertex);
                 o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                o.uv1 = v.uv2;
                 o.normal = UnityObjectToWorldNormal(v.normal);
 
                 // ENVIRONMENT UNIT. The M2 vertex shader for a combiner material names where each
@@ -105,21 +117,40 @@ Shader "WMV/Opaque Textured"
             fixed4 frag (v2f i) : SV_Target
             {
                 fixed4 t1 = tex2D(_MainTex, i.uv);
-                fixed4 c = t1 * _Color;
-                #ifdef _ALPHATEST_ON
-                    clip(c.a - _Cutoff);
-                #endif
 
-                // Combiner 12, "Combiners_Opaque_Mod2xNA_Alpha". The BASE texture's alpha is the
-                // mask that decides where the second unit is folded in at 2x -- it is not
-                // transparency. On a creature skin that mask is white almost everywhere and dark
-                // only on small features (chicken2 uses it for the eye pupil), so the second unit
-                // shows up exactly where the model wants a reflective highlight.
-                if (_CombinerMode > 11.5 && _CombinerMode < 12.5)
-                {
-                    fixed3 t2 = tex2D(_SecondTex, i.env).rgb;
-                    c.rgb = lerp(t1.rgb * t2 * 2.0, t1.rgb, t1.a) * _Color.rgb;
-                }
+                // Unit 1's coordinates, per the material's vertex shader name.
+                float2 uv1 = (_Unit1UV < 0.5) ? i.uv : ((_Unit1UV < 1.5) ? i.uv1 : i.env);
+                fixed4 t2 = tex2D(_SecondTex, uv1);
+
+                // COLOUR. The M2 combiners this milestone implements are all products of the two
+                // units, except pixel shader 12, whose second unit is masked by the FIRST unit's
+                // alpha (that channel is a reflection mask on a creature skin, not transparency).
+                fixed3 rgb = t1.rgb;
+                if (_CombinerMode > 11.5)                       // 12
+                    rgb = lerp(t1.rgb * t2.rgb * 2.0, t1.rgb, t1.a);
+                else if (_CombinerMode > 3.5)                   // 4: decal
+                    rgb = lerp(t1.rgb, t2.rgb, t2.a);
+                else if (_CombinerMode > 2.5)                   // 3: masked modulate
+                    rgb = lerp(t1.rgb * t2.rgb, t1.rgb, t1.a);
+                else if (_CombinerMode > 1.5)                   // 2: unit0 * unit1 * 2
+                    rgb = t1.rgb * t2.rgb * 2.0;
+                else if (_CombinerMode > 0.5)                   // 1: unit0 * unit1
+                    rgb = t1.rgb * t2.rgb;
+                fixed4 c = fixed4(rgb * _Color.rgb, 1.0);
+
+                // ALPHA. The combiner builds a "discard alpha" the blend mode then either uses as
+                // the output opacity or only tests against. Opaque and alpha-key output 1 and the
+                // key discards below the cutoff; every other mode outputs it.
+                fixed a = 1.0;
+                if (_AlphaMode > 3.5)      a = t1.a + t2.a;
+                else if (_AlphaMode > 2.5) a = t1.a * t2.a;
+                else if (_AlphaMode > 1.5) a = t2.a;
+                else if (_AlphaMode > 0.5) a = t1.a;
+                a = saturate(a * _AlphaScale);
+
+                #ifdef _ALPHATEST_ON
+                    clip(a - _Cutoff);
+                #endif
 
                 // Fixed key light + ambient. Engine light data is unavailable across pipelines,
                 // so this is a viewer light, not the scene's -- it only has to read as shape.
@@ -127,8 +158,7 @@ Shader "WMV/Opaque Textured"
                 half ndl = saturate(dot(n, normalize(half3(0.35, 0.80, -0.50))));
                 c.rgb *= 0.45h + 0.75h * ndl;
 
-                // Opaque output: the alpha channel of a WoW skin is not transparency.
-                c.a = 1.0h;
+                c.a = (_OpaqueAlpha > 0.5) ? 1.0 : a;
                 return c;
             }
             ENDCG

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -19,9 +19,11 @@ using Wmv.Wow;
 /// </summary>
 public struct WmvMaterialBinding
 {
-    public int BaseSlot;    // M2 texture slot behind the main texture, -1 when untextured
-    public int EnvSlot;     // M2 texture slot bound as the combiner's second unit, -1 when unused
-    public bool DropAlpha;  // was the base texture's alpha discarded on upload? (see CreateTexture)
+    public int BaseSlot;         // M2 texture slot behind the main texture, -1 when untextured
+    public int EnvSlot;          // M2 texture slot bound as the combiner's second unit, -1 unused
+    public bool DropAlpha;       // was the base texture's alpha discarded on upload?
+    public bool Unit1DropAlpha;  // ... and the second unit's
+    public bool Unit1Clamp;      // the second unit is sphere-mapped, so it must not wrap
 }
 
 public class WmvRuntimeModel
@@ -159,6 +161,7 @@ public static class WmvModelBuilder
         var positions = new Vector3[n];
         var normals = new Vector3[n];
         var uvs = new Vector2[n];
+        var uvs2 = new Vector2[n];
         for (int i = 0; i < n; i++)
         {
             float x, y, z;
@@ -170,6 +173,9 @@ public static class WmvModelBuilder
             WowCoordinateConverter.ConvertTexCoord(model.Vertices[i].TexCoord0, out u, out v);
             if (Debug_.FlipV) v = 1f - v;
             uvs[i] = new Vector2(u, v);
+            WowCoordinateConverter.ConvertTexCoord(model.Vertices[i].TexCoord1, out u, out v);
+            if (Debug_.FlipV) v = 1f - v;
+            uvs2[i] = new Vector2(u, v);
         }
 
         if (log != null && model.Vertices.Length > 0)
@@ -190,6 +196,9 @@ public static class WmvModelBuilder
         mesh.vertices = positions;
         mesh.normals = normals;
         mesh.uv = uvs;
+        // An M2 carries two UV sets, and a combiner unit routed to "T2" reads the second. Cheap to
+        // upload and meaningless to the units that do not use it.
+        mesh.uv2 = uvs2;
 
         // ---- one submesh per batch ----------------------------------------------------
         var materials = new List<Material>();
@@ -256,30 +265,37 @@ public static class WmvModelBuilder
                 hiddenByGeoset++;
 
             // How this material combines its texture units, resolved exactly as the legacy
-            // renderer does. This milestone implements one combiner; the rest are logged and
-            // drawn from unit 0 alone, which is what happened to every one of them before.
+            // renderer does, then reduced to what this renderer can draw of it.
             var shader = M2ShaderTable.Resolve(batch.TextureCount, batch.ShaderId);
-            bool wantsCombiner = batch.TextureCount >= 2 &&
-                                 shader.PixelShader == PixelShaderOpaqueMod2xNaAlpha &&
-                                 shader.UvSource[1] == M2UvSource.Environment &&
-                                 mode == M2BlendMode.Opaque && !Debug_.ForceSolid;
-            bool useCombiner = wantsCombiner && combinerAvailable;
+            CombinerPlan plan = PlanCombiner(shader.PixelShader);
+            M2UvSource unit1Uv = batch.TextureCount >= 2 ? shader.UvSource[1] : M2UvSource.TexCoord1;
+
+            // Unit 1 is bound when the combiner reads it AND the model actually declares it. A
+            // shader that cannot run a combiner at all (a pipeline Lit shader) gets neither.
+            bool useUnit1 = plan.NeedsUnit1 && batch.TextureCount >= 2 &&
+                            combinerAvailable && !Debug_.ForceSolid;
 
             int textureSlot = ResolveTextureSlot(model, batch, 0);
-            int envSlot = useCombiner ? ResolveTextureSlot(model, batch, 1) : -1;
+            int unit1Slot = useUnit1 ? ResolveTextureSlot(model, batch, 1) : -1;
 
-            // The base texture's ALPHA is the combiner's mask -- pixel shader 12 folds unit 1 in
-            // where alpha is low -- so it must survive when the combiner runs. Discarding it is
-            // otherwise still the right call for an opaque material: nothing downstream should be
-            // able to read a channel WoW does not treat as transparency.
-            bool dropAlpha = Debug_.ForceSolid || (mode == M2BlendMode.Opaque && !useCombiner);
+            // The base texture's ALPHA is not transparency on an opaque material -- on a creature
+            // skin it is a reflection mask -- so it is discarded on upload UNLESS something
+            // actually reads it: a combiner that masks with it, or a blend mode that outputs it.
+            bool alphaIsRead = useUnit1 ||
+                               plan.AlphaMode == 1 || plan.AlphaMode == 3 || plan.AlphaMode == 4 ||
+                               mode != M2BlendMode.Opaque;
+            bool dropAlpha = Debug_.ForceSolid || !alphaIsRead;
 
             Texture2D tex = GetTexture(decodedTextures, textureCache, textures, textureSlot,
                                        dropAlpha, false, objectName);
-            // Unit 1's own alpha is unused by the combiner; it is sampled by generated sphere-map
-            // coordinates, so it must not wrap.
-            Texture2D envTex = GetTexture(decodedTextures, textureCache, textures, envSlot,
-                                          true, true, objectName);
+            // An environment unit is sampled by generated sphere-map coordinates, which must not
+            // wrap; a unit fed by a stored UV set is a normal repeating texture. Its own alpha is
+            // kept whenever the combiner reads it.
+            bool unit1Env = unit1Uv == M2UvSource.Environment;
+            bool unit1DropAlpha = !(plan.AlphaMode == 2 || plan.AlphaMode == 3 || plan.AlphaMode == 4 ||
+                                    plan.Mode == 4);
+            Texture2D unit1Tex = GetTexture(decodedTextures, textureCache, textures, unit1Slot,
+                                            unit1DropAlpha, unit1Env, objectName);
 
             if (log != null)
             {
@@ -289,25 +305,29 @@ public static class WmvModelBuilder
                                   (M2BlendMode)mat.BlendMode, mat.Flags, mat.TwoSided,
                                   mat.DepthWriteDisabled, textureSlot,
                                   tex == null ? " (no texture)" : "",
-                                  dropAlpha ? "forced to 255" : "kept (combiner mask)"));
-                log(string.Format("batch: shaderId 0x{0:X4} -> {1} / {2} (combiner {3}), {4} texture unit(s), " +
-                                  "unit 1 uv {5}{6}",
+                                  dropAlpha ? "forced to 255" : "kept (something reads it)"));
+                log(string.Format("batch: shaderId 0x{0:X4} -> {1} / {2} (pixel shader {3}), {4} unit(s), " +
+                                  "unit 1 uv {5} -> combiner {6}, alpha mode {7}x{8}{9}",
                                   batch.ShaderId, shader.PixelShaderName, shader.VertexShaderName,
                                   shader.PixelShader, batch.TextureCount,
-                                  batch.TextureCount >= 2 ? shader.UvSource[1].ToString() : "n/a",
-                                  useCombiner ? " -> env slot " + envSlot + " bound"
-                                              : (batch.TextureCount >= 2
-                                                 ? (wantsCombiner
-                                                    ? " -- the resolved shader cannot run the combiner, unit 1 dropped"
-                                                    : " -- this combiner is not implemented yet, unit 1 dropped")
-                                                 : "")));
+                                  batch.TextureCount >= 2 ? unit1Uv.ToString() : "n/a",
+                                  plan.Mode, plan.AlphaMode, plan.AlphaScale,
+                                  useUnit1 ? ", unit 1 slot " + unit1Slot + " bound"
+                                           : (plan.NeedsUnit1 && batch.TextureCount >= 2
+                                              ? ", unit 1 NOT bound (the resolved shader cannot combine)"
+                                              : "")));
+                if (!plan.Known)
+                    log(string.Format("material: pixel shader {0} ({1}) is not implemented -- drawing " +
+                                      "unit 0 alone with its own alpha",
+                                      shader.PixelShader, shader.PixelShaderName));
             }
 
             bindings.Add(new WmvMaterialBinding
             {
-                BaseSlot = textureSlot, EnvSlot = envSlot, DropAlpha = dropAlpha,
+                BaseSlot = textureSlot, EnvSlot = unit1Slot, DropAlpha = dropAlpha,
+                Unit1DropAlpha = unit1DropAlpha, Unit1Clamp = unit1Env,
             });
-            materials.Add(CreateMaterial(mat, mode, tex, envTex,
+            materials.Add(CreateMaterial(mat, mode, plan, unit1Uv, tex, unit1Tex,
                                          objectName + "_mat" + materials.Count, log));
         }
 
@@ -443,12 +463,14 @@ public static class WmvModelBuilder
             if (tex != null && !Debug_.MatColors)
                 m.mainTexture = tex;
 
-            Texture2D envTex = GetTexture(decodedTextures, cache, fresh, b.EnvSlot, true, true, objectName);
-            if (m.HasProperty(CombinerModeProperty))
+            // Unit 1 keeps whatever combiner the material was built with; only the image behind
+            // it is re-uploaded. Re-deriving the plan here would risk the two paths drifting.
+            if (b.EnvSlot >= 0 && m.HasProperty(CombinerModeProperty))
             {
-                bool on = envTex != null && !Debug_.MatColors;
-                if (on) m.SetTexture(SecondTexProperty, envTex);
-                m.SetFloat(CombinerModeProperty, on ? PixelShaderOpaqueMod2xNaAlpha : 0);
+                Texture2D unit1 = GetTexture(decodedTextures, cache, fresh, b.EnvSlot,
+                                             b.Unit1DropAlpha, b.Unit1Clamp, objectName);
+                if (unit1 != null && !Debug_.MatColors)
+                    m.SetTexture(SecondTexProperty, unit1);
             }
 
             if (log != null)
@@ -465,9 +487,208 @@ public static class WmvModelBuilder
         runtime.Textures = fresh.ToArray();
     }
 
-    /// <summary>M2 pixel shader 12, "Combiners_Opaque_Mod2xNA_Alpha" -- the one combiner this
-    /// milestone implements. See WmvOpaque.shader.</summary>
-    const int PixelShaderOpaqueMod2xNaAlpha = 12;
+    /// <summary>
+    /// How much of one M2 combiner this renderer can draw. The shader takes the arithmetic as a
+    /// few floats rather than a keyword per case, so widening coverage is a table entry here.
+    /// </summary>
+    struct CombinerPlan
+    {
+        public int Mode;          // _CombinerMode: 0 single, 1 u0*u1, 2 u0*u1*2, 3/4 masked/decal, 12 ps12
+        public int AlphaMode;     // _AlphaMode: 0 one, 1 u0.a, 2 u1.a, 3 u0.a*u1.a, 4 u0.a+u1.a
+        public float AlphaScale;
+        public bool NeedsUnit1;   // the second texture is sampled, for colour or for alpha
+        public bool Known;        // false: not implemented -- drawn from unit 0 alone, and logged
+    }
+
+    static CombinerPlan Plan(int mode, int alphaMode, float scale, bool unit1)
+    {
+        CombinerPlan p;
+        p.Mode = mode; p.AlphaMode = alphaMode; p.AlphaScale = scale;
+        p.NeedsUnit1 = unit1; p.Known = true;
+        return p;
+    }
+
+    /// <summary>
+    /// What one M2 pixel shader reduces to here. Ported case by case from the legacy viewport's
+    /// own GLSL combiner (ModelRenderPass.cpp), not from the shader NAMES -- "Combiners_Mod_Mod2x"
+    /// says nothing until you read that it is unit0 * unit1 * 2 with a discard of u0.a * u1.a * 2.
+    ///
+    /// One thing makes the table much shorter than it looks: several combiners differ from a
+    /// simpler one only in a SPECULAR lobe, and the legacy viewport multiplies that lobe by a
+    /// weight that is ZERO unless an opt-in environment variable is set. Reproducing its default
+    /// means dropping the lobe too, which collapses those cases onto plain single-texture colour
+    /// (8, 10, 13, 14, 16, 20, 23) or onto pixel shader 12 (15).
+    /// </summary>
+    static CombinerPlan PlanCombiner(int pixelShader)
+    {
+        switch (pixelShader)
+        {
+            // colour from unit 0 alone
+            case 0:  return Plan(0, 0, 1f, false);   // Combiners_Opaque
+            case 1:  return Plan(0, 1, 1f, false);   // Combiners_Mod
+            case 13: return Plan(0, 0, 1f, false);   // Opaque_AddAlpha        (lobe dropped)
+            case 14: return Plan(0, 0, 1f, false);   // Opaque_AddAlpha_Alpha  (lobe dropped)
+            case 20: return Plan(0, 0, 1f, false);   // Opaque_AddAlpha_Wgt    (lobe dropped)
+            case 10: return Plan(0, 1, 1f, false);   // Mod_AddNA              (lobe dropped)
+            case 16: return Plan(0, 1, 1f, false);   // Mod_AddAlpha           (lobe dropped)
+            case 23: return Plan(0, 1, 1f, false);   // Mod_AddAlpha_Wgt       (lobe dropped)
+            case 33: return Plan(0, 1, 1f, false);   // Mod_Depth
+
+            // the alpha, but not the colour, needs unit 1
+            case 8:  return Plan(0, 4, 1f, true);    // Mod_Add                (lobe dropped)
+            case 21: return Plan(0, 4, 1f, true);    // Mod_Add_Alpha          (lobe dropped)
+
+            // products of the two units
+            case 5:  return Plan(1, 0, 1f, true);    // Opaque_Opaque
+            case 2:  return Plan(1, 2, 1f, true);    // Opaque_Mod
+            case 6:  return Plan(1, 3, 1f, true);    // Mod_Mod
+            case 36: return Plan(1, 3, 1f, true);    // Mod_Mod_Depth
+            case 11: return Plan(1, 1, 1f, true);    // Mod_Opaque
+            case 4:  return Plan(2, 0, 1f, true);    // Opaque_Mod2xNA
+            case 3:  return Plan(2, 2, 2f, true);    // Opaque_Mod2x
+            case 7:  return Plan(2, 3, 2f, true);    // Mod_Mod2x
+            case 9:  return Plan(2, 1, 1f, true);    // Mod_Mod2xNA
+
+            // masked by unit 0's own alpha -- on a creature skin that channel is a reflection
+            // mask, not transparency
+            case 12: return Plan(12, 0, 1f, true);   // Opaque_Mod2xNA_Alpha
+            case 15: return Plan(12, 0, 1f, true);   // ..._Add: third unit only fed the lobe
+            case 22: return Plan(3, 0, 1f, true);    // Opaque_ModNA_Alpha
+            case 29: return Plan(4, 0, 1f, true);    // Opaque_Alpha (decal)
+
+            default:
+            {
+                // Not implemented: draw unit 0 with its own alpha, which is what every one of
+                // these did before any combiner existed, and say so once per material.
+                CombinerPlan p = Plan(0, 1, 1f, false);
+                p.Known = false;
+                return p;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The GL state one M2 blend mode produces, read off the legacy viewport's own switch
+    /// (ModelRenderPass::init). Mode 0 sets a blend function but never enables blending, and mode
+    /// 1 sets One/Zero with an alpha test -- both are opaque, which is why they were already right
+    /// before this. The rest were being drawn opaque too, which they are not: an additive glow
+    /// rendered opaque is a solid box where a wisp of light belongs.
+    ///
+    /// opaqueAlpha follows the combiner's own final-opacity rule: only modes 0 and 1 ignore the
+    /// alpha the combiner built (they output mesh opacity, 1 for a static pose); every other mode
+    /// outputs it.
+    /// </summary>
+    static void ApplyBlendMode(Material m, M2BlendMode mode, bool depthWriteDisabled,
+                               float cutoff, out string described)
+    {
+        var src = UnityEngine.Rendering.BlendMode.One;
+        var dst = UnityEngine.Rendering.BlendMode.Zero;
+        int queue = (int)UnityEngine.Rendering.RenderQueue.Geometry;
+        string renderType = "Opaque";
+        bool alphaTest = false, opaqueAlpha = true;
+
+        switch (mode)
+        {
+            case M2BlendMode.Opaque:                                       // One/Zero, no blending
+                described = "opaque";
+                break;
+
+            case M2BlendMode.AlphaKey:                                     // One/Zero + alpha test
+                alphaTest = m.HasProperty("_Cutoff") || m.HasProperty("_AlphaCutoff");
+                if (alphaTest)
+                {
+                    queue = (int)UnityEngine.Rendering.RenderQueue.AlphaTest;
+                    renderType = "TransparentCutout";
+                }
+                described = alphaTest ? "alpha clip (cutoff " + cutoff.ToString("0.###") + ")"
+                                      : "opaque (the shader exposes no alpha cutoff)";
+                break;
+
+            case M2BlendMode.Alpha:                                        // SrcAlpha/OneMinusSrcAlpha
+                src = UnityEngine.Rendering.BlendMode.SrcAlpha;
+                dst = UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha;
+                opaqueAlpha = false;
+                queue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                renderType = "Transparent";
+                described = "alpha blend";
+                break;
+
+            case M2BlendMode.NoAlphaAdd:                                     // One/One
+                src = UnityEngine.Rendering.BlendMode.One;
+                dst = UnityEngine.Rendering.BlendMode.One;
+                opaqueAlpha = false;
+                queue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                renderType = "Transparent";
+                described = "additive";
+                break;
+
+            case M2BlendMode.Add:                                // SrcAlpha/One
+                src = UnityEngine.Rendering.BlendMode.SrcAlpha;
+                dst = UnityEngine.Rendering.BlendMode.One;
+                opaqueAlpha = false;
+                queue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                renderType = "Transparent";
+                described = "additive (alpha-weighted)";
+                break;
+
+            case M2BlendMode.Mod:                                     // DstColor/Zero
+                src = UnityEngine.Rendering.BlendMode.DstColor;
+                dst = UnityEngine.Rendering.BlendMode.Zero;
+                opaqueAlpha = false;
+                queue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                renderType = "Transparent";
+                described = "modulate";
+                break;
+
+            case M2BlendMode.Mod2x:                                   // DstColor/SrcColor
+                src = UnityEngine.Rendering.BlendMode.DstColor;
+                dst = UnityEngine.Rendering.BlendMode.SrcColor;
+                opaqueAlpha = false;
+                queue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                renderType = "Transparent";
+                described = "modulate 2x";
+                break;
+
+            default:                                                       // mode 7: One/OneMinusSrcAlpha
+                src = UnityEngine.Rendering.BlendMode.One;
+                dst = UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha;
+                opaqueAlpha = false;
+                queue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                renderType = "Transparent";
+                described = "premultiplied blend";
+                break;
+        }
+
+        // Depth write is the model's own flag and NOTHING else. The legacy viewport sets it from
+        // one unconditional test outside its blend switch, so a blended pass whose flag is clear
+        // still writes depth. Inferring "this mode blends, therefore no depth write" would look
+        // reasonable and diverge on every such pass.
+        bool zwrite = !depthWriteDisabled;
+
+        if (m.HasProperty("_Mode")) m.SetFloat("_Mode", alphaTest ? 1f : 0f);
+        if (m.HasProperty("_Surface")) m.SetFloat("_Surface", opaqueAlpha ? 0f : 1f);
+        if (m.HasProperty("_Blend")) m.SetFloat("_Blend", 0f);
+        if (m.HasProperty("_AlphaClip")) m.SetFloat("_AlphaClip", alphaTest ? 1f : 0f);
+        if (m.HasProperty("_SrcBlend")) m.SetInt("_SrcBlend", (int)src);
+        if (m.HasProperty("_DstBlend")) m.SetInt("_DstBlend", (int)dst);
+        if (m.HasProperty("_ZWrite")) m.SetInt("_ZWrite", zwrite ? 1 : 0);
+        if (m.HasProperty("_OpaqueAlpha")) m.SetFloat("_OpaqueAlpha", opaqueAlpha ? 1f : 0f);
+        if (m.HasProperty("_Cutoff")) m.SetFloat("_Cutoff", cutoff);
+        if (m.HasProperty("_AlphaCutoff")) m.SetFloat("_AlphaCutoff", cutoff);
+
+        m.DisableKeyword("_ALPHATEST_ON");
+        m.DisableKeyword("_ALPHABLEND_ON");
+        m.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+        m.DisableKeyword("_SURFACE_TYPE_TRANSPARENT");
+        if (alphaTest) m.EnableKeyword("_ALPHATEST_ON");
+        if (!opaqueAlpha) m.EnableKeyword("_SURFACE_TYPE_TRANSPARENT");
+
+        m.SetOverrideTag("RenderType", renderType);
+        m.renderQueue = queue;
+
+        if (depthWriteDisabled)
+            described += ", no depth write (model flag)";
+    }
 
     /// <summary>
     /// Resolve one TEXTURE UNIT of a batch to an M2 texture slot.
@@ -651,10 +872,12 @@ public static class WmvModelBuilder
     ///     FindRenderShader. A shader that bakes its blending into the pass ignores every
     ///     property written here without complaining.
     ///
-    /// This is deliberately not a full WoW material system; see the blend-mode note below.
+    /// This is deliberately not a full WoW material system; see ApplyBlendMode and PlanCombiner
+    /// for exactly how much of one it is.
     /// </summary>
-    static Material CreateMaterial(M2MaterialDef def, M2BlendMode mode, Texture2D tex,
-                                   Texture2D envTex, string name, Action<string> log)
+    static Material CreateMaterial(M2MaterialDef def, M2BlendMode mode, CombinerPlan plan,
+                                   M2UvSource unit1Uv, Texture2D tex, Texture2D unit1Tex,
+                                   string name, Action<string> log)
     {
         var shader = FindRenderShader(log);
         // Material(null) throws; Unity's error shader is always present and at least draws
@@ -667,43 +890,23 @@ public static class WmvModelBuilder
         if (m.HasProperty("_Glossiness")) m.SetFloat("_Glossiness", 0f);      // Built-in
         else if (m.HasProperty("_Smoothness")) m.SetFloat("_Smoothness", 0f); // URP/HDRP
 
-        // Second texture unit. The property only exists on the renderer's own shader, so on every
-        // other shader this is a no-op and the material stays exactly as it was.
+        // The combiner properties exist only on the renderer's own shader. On a pipeline Lit
+        // shader every one of these is a no-op and the material keeps its single texture, which
+        // is the honest outcome: that shader cannot run an M2 combiner.
+        bool combining = plan.NeedsUnit1 && unit1Tex != null && !Debug_.MatColors &&
+                         m.HasProperty(CombinerModeProperty);
         if (m.HasProperty(CombinerModeProperty))
         {
-            bool on = envTex != null && !Debug_.MatColors;
-            if (on) m.SetTexture(SecondTexProperty, envTex);
-            m.SetFloat(CombinerModeProperty, on ? PixelShaderOpaqueMod2xNaAlpha : 0);
+            if (combining) m.SetTexture(SecondTexProperty, unit1Tex);
+            m.SetFloat(CombinerModeProperty, combining ? plan.Mode : 0);
+            m.SetFloat("_AlphaMode", combining ? plan.AlphaMode : (plan.AlphaMode == 1 ? 1 : 0));
+            m.SetFloat("_AlphaScale", combining ? plan.AlphaScale : 1f);
+            m.SetFloat("_Unit1UV", (float)(int)unit1Uv);
         }
 
         string treatedAs;
-        switch (mode)
-        {
-            case M2BlendMode.Opaque:
-                SetOpaque(m);
-                treatedAs = "opaque";
-                break;
-
-            // Alpha-key is a cutout in WoW. Plain Alpha is genuinely blended, but for a static
-            // V1 creature a clip is the safer reading: it keeps depth writes and solid geometry
-            // instead of risking a see-through model, and looks right for the hair/feather/eye
-            // decals creatures actually use it for. Real blending is left for the material pass.
-            case M2BlendMode.AlphaKey:
-            case M2BlendMode.Alpha:
-                treatedAs = SetAlphaClip(m, 0.5f) ? "alpha clip (cutoff 0.5)"
-                                                  : "opaque (shader has no alpha-clip property)";
-                if (mode == M2BlendMode.Alpha && log != null)
-                    log("material: blend mode Alpha is drawn as an alpha clip in this milestone");
-                break;
-
-            default:
-                SetOpaque(m);
-                treatedAs = "opaque (blend mode not implemented)";
-                if (log != null)
-                    log(string.Format("material: blend mode {0} is not implemented yet -- drawing it opaque",
-                                      def.BlendMode));
-                break;
-        }
+        // The legacy combiner keys at 128/255, not at a rounded half.
+        ApplyBlendMode(m, mode, def.DepthWriteDisabled, 128f / 255f, out treatedAs);
 
         // Only the model's own flag may disable culling; nothing here turns it off globally.
         if (m.HasProperty("_Cull"))
@@ -720,44 +923,6 @@ public static class WmvModelBuilder
 
         LogMaterialState(m, def, mode, treatedAs, log);
         return m;
-    }
-
-    /// <summary>Opaque, depth-writing, geometry queue -- stated explicitly across pipelines.</summary>
-    static void SetOpaque(Material m)
-    {
-        if (m.HasProperty("_Mode")) m.SetFloat("_Mode", 0f);        // Built-in Standard
-        if (m.HasProperty("_Surface")) m.SetFloat("_Surface", 0f);  // URP/HDRP: 0 = opaque
-        if (m.HasProperty("_Blend")) m.SetFloat("_Blend", 0f);
-        if (m.HasProperty("_AlphaClip")) m.SetFloat("_AlphaClip", 0f);
-        if (m.HasProperty("_SrcBlend")) m.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
-        if (m.HasProperty("_DstBlend")) m.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-        if (m.HasProperty("_ZWrite")) m.SetInt("_ZWrite", 1);
-        m.DisableKeyword("_ALPHATEST_ON");
-        m.DisableKeyword("_ALPHABLEND_ON");
-        m.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-        m.DisableKeyword("_SURFACE_TYPE_TRANSPARENT");
-        m.SetOverrideTag("RenderType", "Opaque");
-        m.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Geometry;
-    }
-
-    /// <summary>
-    /// Alpha-tested cutout: still opaque as far as depth and sorting are concerned. Returns false
-    /// when the shader exposes no cutoff at all, in which case the material is left fully opaque
-    /// -- for this milestone a solid surface beats a see-through one.
-    /// </summary>
-    static bool SetAlphaClip(Material m, float cutoff)
-    {
-        SetOpaque(m);                                                // depth/blend state first
-        if (!m.HasProperty("_Cutoff") && !m.HasProperty("_AlphaCutoff"))
-            return false;
-        if (m.HasProperty("_Mode")) m.SetFloat("_Mode", 1f);         // Built-in Standard: cutout
-        if (m.HasProperty("_AlphaClip")) m.SetFloat("_AlphaClip", 1f); // URP
-        if (m.HasProperty("_Cutoff")) m.SetFloat("_Cutoff", cutoff);
-        if (m.HasProperty("_AlphaCutoff")) m.SetFloat("_AlphaCutoff", cutoff); // HDRP
-        m.EnableKeyword("_ALPHATEST_ON");
-        m.SetOverrideTag("RenderType", "TransparentCutout");
-        m.renderQueue = (int)UnityEngine.Rendering.RenderQueue.AlphaTest;
-        return true;
     }
 
     /// <summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -56,7 +56,10 @@ namespace Wmv.Wow
         public bool Unlit { get { return (Flags & 0x01) != 0; } }
         public bool NoFog { get { return (Flags & 0x02) != 0; } }
         public bool TwoSided { get { return (Flags & 0x04) != 0; } }
-        public bool DepthTestDisabled { get { return (Flags & 0x08) != 0; } }
+        /// <summary>Bit 0x08 is BILLBOARD in the legacy viewport, not a depth-test flag: it only
+        /// feeds that renderer's environment-mapping decision, and nothing there ever disables the
+        /// depth test. Kept for completeness, deliberately unused.</summary>
+        public bool Billboard { get { return (Flags & 0x08) != 0; } }
         public bool DepthWriteDisabled { get { return (Flags & 0x10) != 0; } }
     }
 

--- a/Tools/UnityRendererProject/README.md
+++ b/Tools/UnityRendererProject/README.md
@@ -87,7 +87,9 @@ Three consequences worth knowing:
   shader is chosen so that setting it actually does something.
 - Transparency follows the **WoW blend mode only**, never the presence of an alpha channel in
   the texture. Creature skins have one regardless: chicken2's is DXT5 with ~97% of its texels
-  below 255. On an opaque material that channel is **discarded at upload** rather than trusted.
+  below 255. That channel is **discarded at upload** unless something actually reads it — a
+  combiner that masks or keys with it, or a blend mode that outputs it — rather than trusted
+  because it happens to be there.
 - Every material load logs its real runtime state — chosen shader, render queue, `RenderType`,
   `_SrcBlend`/`_DstBlend`/`_ZWrite`/`_Cull`/`_Mode`/`_Surface`/`_AlphaClip` (or `n/a` where the
   shader does not expose them), enabled keywords, and the WoW blend/two-sided/depth-write flags
@@ -95,8 +97,8 @@ Three consequences worth knowing:
 
 ## Texture units, combiners and hidden geometry
 
-Three things about an M2 material are easy to miss, and missing any of them looks like a texturing
-bug rather than a missing feature:
+These are the parts of an M2 material that are easy to miss, and missing any of them looks like a
+texturing bug rather than a missing feature:
 
 **A batch can load more than one texture.** It declares how many (`textureCount`) and where its run
 starts in the texture-combo table (`textureComboIndex`); unit *k* is entry `textureComboIndex + k`.
@@ -115,11 +117,52 @@ rgb = lerp(unit0.rgb * unit1.rgb * 2, unit0.rgb, unit0.a)
 
 so the **base texture's alpha channel is the reflection mask**, not transparency. On chicken2's skin
 that mask is white everywhere except the eye pupil, which is exactly where the model wants a
-reflective highlight. Only this one combiner is implemented; any other is logged by name and drawn
-from unit 0 alone, which is what happened to all of them before. The combiner needs the renderer's
-own `WmvOpaque` shader — a pipeline Lit shader has one texture slot and no idea what a sphere-mapped
-second unit is — so on those the second unit is dropped and the log says so. `-wmvOwnShader` forces
-the renderer's own shader if you want to see it.
+reflective highlight.
+
+`WmvModelBuilder.PlanCombiner` reduces each M2 pixel shader to what this renderer can draw of it,
+ported case by case from the legacy viewport's own GLSL rather than from the combiner *names* —
+`Combiners_Mod_Mod2x` says nothing until you read that it is `unit0 * unit1 * 2` keyed on
+`unit0.a * unit1.a * 2`. What comes out is a handful of floats on one shader variant, never a
+keyword per case: a player build strips shader *variants* as readily as whole shaders, so a keyword
+per material feature would be a way to lose them all.
+
+| Combiner | Arithmetic | Pixel shaders |
+|---|---|---|
+| 0 | `unit0` alone | 0, 1, 10, 13, 14, 16, 20, 23, 33 |
+| 1 | `unit0 * unit1` | 2, 5, 6, 11, 36 |
+| 2 | `unit0 * unit1 * 2` | 3, 4, 7, 9 |
+| 3 | `lerp(unit0 * unit1, unit0, unit0.a)` | 22 |
+| 4 | `lerp(unit0, unit1, unit1.a)` — a decal | 29 |
+| 12 | `lerp(unit0 * unit1 * 2, unit0, unit0.a)` | 12, 15 |
+
+One thing makes that table much shorter than the shader list looks: several combiners differ from a
+simpler one only in a **specular lobe**, and the legacy viewport multiplies that lobe by a weight
+that is **zero** unless an opt-in environment variable is set. Reproducing its default means
+dropping the lobe too, which collapses those cases onto plain single-texture colour (8, 10, 13, 14,
+16, 20, 23) or onto combiner 12 (15). Pixel shaders 8 and 21 still bind unit 1 anyway — their
+*alpha* reads it even though their colour does not.
+
+Anything outside the table is logged by name once per material and drawn from unit 0 alone, which is
+what happened to all of them before. A combiner also needs the renderer's own `WmvOpaque` shader —
+a pipeline Lit shader has one texture slot and no idea what a sphere-mapped second unit is — so on
+those the second unit is dropped and the log says so. `-wmvOwnShader` forces the renderer's own
+shader if you want to see it.
+
+**Where unit 1 samples is the vertex shader's business, not the material's.** The same table names
+it per unit: `T1`/`T2` are the mesh's two stored UV sets, `Env` is a sphere map generated from the
+view-space normal. Over a spread of 300 retail creature models (1424 batches), 30.6% of batches
+route unit 1 to `Env` and 21.9% to the second UV set, so reading either one as "the first UV set"
+is wrong most of the time.
+
+**The blend mode is not a suggestion either.** `ApplyBlendMode` sets `_SrcBlend`/`_DstBlend`/
+`_ZWrite`/`_Cutoff` from the same switch the legacy viewport uses (`ModelRenderPass::init`), and two
+of its readings are counter-intuitive. Mode 0 sets a blend function but never enables blending, and
+mode 1 is `One`/`Zero` with an alpha test — both are opaque, which is why they were already right
+before any of this. Depth write comes from the material's own `0x10` flag and **nothing else**: the
+viewport sets it from one unconditional test *outside* that switch, so a blended pass whose flag is
+clear still writes depth. "This mode blends, therefore no depth write" reads perfectly reasonably
+and diverges on every such pass. The alpha test keys at `128/255`, the value the combiner actually
+compares against, not a rounded half.
 
 **A model hides geometry by keying an animation track to zero, not by leaving it out.** An eye
 overlay, a glow, a blink. The OpenGL viewport refuses to draw a batch whose colour entry resolves to
@@ -164,7 +207,7 @@ UV routing, the full runtime material state, and the shader that was chosen.
 | `Wow/BlpDecoder.cs` | BLP2 -> RGBA32 in memory (palettized, DXT1/3/5, raw BGRA). |
 | `Wow/M2ShaderTable.cs` | Shader id + texture count -> combiner name/id and per-unit UV routing. Pure data, no rendering; the same table the OpenGL viewport resolves. |
 | `Wow/WowCoordinateConverter.cs` | The single WoW -> Unity axis/winding/UV conversion. |
-| `Assets/Resources/WmvOpaque.shader` | The renderer's own opaque textured shader, kept under `Resources/` so a player build cannot strip it. Exposes `_SrcBlend`/`_DstBlend`/`_ZWrite`/`_Cull`/`_Cutoff` as real properties, and carries the second texture unit + M2 combiner 12. |
+| `Assets/Resources/WmvOpaque.shader` | The renderer's own textured shader, kept under `Resources/` so a player build cannot strip it. One variant, everything uniform-driven: `_SrcBlend`/`_DstBlend`/`_ZWrite`/`_Cull`/`_Cutoff` as real properties, plus `_CombinerMode`, `_Unit1UV`, `_AlphaMode`/`_AlphaScale` and `_OpaqueAlpha` for the second texture unit and the M2 combiners. |
 | `Wow/ByteCursor.cs` | Bounds-checked little-endian reader shared by the parsers. |
 | `WmvOrbitCamera.cs` | Orbit / pan / zoom controls plus bounds-driven framing of a loaded model. |
 

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -222,8 +222,17 @@ in-process, and shuts the player down. Result lines carry the `[unityipc-test]` 
 - Runtime BLP decoding for the formats the creature pipeline uses: palettized (alpha 0/1/4/8),
   DXT1 / DXT3 / DXT5 and raw BGRA, decoded straight from the received bytes into an in-memory
   texture. Anything else is reported by name instead of being decoded into garbage.
-- Basic materials: opaque, alpha-key and alpha blending, two-sided when the model asks for it.
-  Blend modes beyond that log a diagnostic and draw opaque.
+- Static materials taken from the model's own render state rather than approximated: every M2
+  blend mode (opaque, alpha key, alpha blend, both additive forms, modulate, modulate 2x and
+  premultiplied), the alpha test keyed where the legacy combiner keys it, depth write from the
+  material's own flag alone, and two-sided when the model asks for it. Over a spread of 300
+  retail creature models, 26.6% of draw batches ask for a blend mode that was previously drawn
+  opaque -- an additive glow rendered opaque is a solid box where a wisp of light belongs.
+- The M2 texture combiners a static pose can reproduce: the products of the two units, the two
+  alpha-masked forms and the decal, with unit 1 sampled from whichever source the material's
+  vertex shader names (either stored UV set, or a generated environment sphere map). That covers
+  1421 of 1424 batches in the same sample; the remaining three are logged by name and drawn from
+  unit 0 alone.
 - Model textures the M2 does not name (replaceable creature skins) are resolved by WMV from
   the client database and handed to the player as FileDataIDs (`getModelTextures`), labelled
   `database` or -- for orphaned legacy assets only -- `convention`.
@@ -232,8 +241,9 @@ in-process, and shuts the player down. Result lines carry the `[unityipc-test]` 
 **Not yet implemented**
 
 - Skeletal animation (bone data is parsed and preserved, but nothing is animated or skinned).
-- The full WoW material system (shader/combiner effects, texture animation, environment
-  mapping, colour/transparency tracks).
+- The rest of the WoW material system: texture animation, colour and transparency tracks beyond
+  the rest-pose visibility gate, the specular lobes the legacy viewport leaves unweighted by
+  default, and the few combiners that mix more than two contributing units.
 - Particles and ribbons.
 - The character / equipment pipeline (customization, attachments, geoset rules).
 - Maps, terrain, WMOs, fog.


### PR DESCRIPTION
The Unity renderer drew almost everything opaque with a single texture, which is right for a chicken and wrong for most of the bestiary. Measured over a spread of 300 retail creature models (1424 draw batches): 26.6% of batches ask for a blend mode that was being ignored, and 33.4% declare a second texture unit whose contribution was dropped.

Both now come from the same tables the OpenGL viewport uses, read off its own switch and its own GLSL rather than inferred from the format's names:

  * every M2 blend mode is applied, not just opaque and a clip. Mode 0 sets a blend function but never enables blending and mode 1 is One/Zero with an alpha test, so both really are opaque; the other six are not.
  * the alpha test keys at 128/255, the value the legacy combiner compares against, not a rounded half.
  * depth write comes from the material's own 0x10 flag and nothing else. The viewport decides it in one unconditional test outside its blend switch, so a blended pass whose flag is clear still writes depth -- "this mode blends, therefore no depth write" reads reasonably and diverges on every such pass.
  * the texture combiners a static pose can reproduce (the products of the two units, the two alpha-masked forms and the decal) are drawn with unit 1 sampled from whichever source the material's vertex shader names: either stored UV set, or a generated environment sphere map. Several combiners differ from a simpler one only in a specular lobe the viewport weights at zero by default, so reproducing that default collapses them onto the simpler case -- which is most of why the table is short.

Combiner coverage over that sample goes from 66.6% of batches to 99.8%; the three that remain are logged by name and drawn from unit 0 alone, as all of them were before. Bit 0x08 was labelled DepthTestDisabled and is actually BILLBOARD, so it is renamed and left unused.

All of it is driven by uniforms on one shader variant. A player build strips shader variants as readily as whole shaders, so a keyword per material feature would be a way to lose them all.

Validated with -unityipctest against the real Unity player: chicken2 unchanged (778 triangles, one submesh, combiner 12, hidden eye batch still skipped), horse3 geoset sync unchanged, selected-skin sync unchanged, and five new material cases (mininaxx, wrathofazshara, shaboss_doubt, overfiend, valkier) covering additive, alpha-blended, alpha-keyed and modulated passes -- all PASS, no exceptions, no unimplemented combiners. 74/74 parser tests pass, the player scripts type-check under all four input-backend configurations, and the OpenGL viewport is untouched.