### PR TITLE
Add Unity M2 skinning foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Embedded Unity renderer: models are now skinned to their own skeleton.** The renderer drew
+  every M2 as a rigid mesh; the bone indices and weights each vertex carries were parsed and then
+  ignored. The rig is now rebuilt as Unity transforms, the influences and bind poses are handed to
+  a SkinnedMeshRenderer, and the mesh is deformed by that rig. **No animation is played yet** --
+  every bone sits in its rest pose, and that is the point: the milestone's contract is that a
+  skinned model at rest is indistinguishable from the static one it replaces. It holds because of
+  how the format is built. The legacy viewport composes a bone as
+  T(pivot) * T(translation) * R(rotation) * S(scale) * T(-pivot), composed with its parent's, and
+  with every track at rest that collapses to the identity -- so the positions stored in the file
+  already are the rest pose, and the bind pose only has to reproduce the identity. Each bone is
+  placed at its pivot with no rotation, which is also exactly the arrangement animation needs:
+  adding the translation track to that rest offset and setting the rotation and scale from their
+  tracks reproduces the viewport's expression term for term. Measured with the new `-wmvSkinCheck`
+  switch, which bakes the skinned result and compares it against the file's own positions, the
+  largest deviation across seven validation models (rigs of 29 to 236 bones, 2 to 15 deep) is
+  3.8e-6 units, and three of the seven are exactly zero. Two details of the data are easy to get
+  wrong and are handled explicitly: the per-vertex bone indices are DIRECT indices into the bone
+  array rather than indices through the .skin's lookup table, and a rig is a forest -- valkier has
+  27 root bones out of 149 -- with out-of-range, self-referential and cyclic parents all
+  normalised to roots at parse time. A model whose bones live in a separate skeleton file (the
+  SKID chunk) is still drawn as a static mesh and logs why; over a spread of 300 retail creature
+  models, 299 keep their bones in the .m2 itself. `-wmvNoSkin` forces the old static path for an
+  A/B, and every debug switch can now also be set through the `WMV_DEBUG` environment variable,
+  which is the only way to reach them in the embedded viewport since WMV builds the player's
+  command line itself.
+
+### Added
 - **Embedded Unity renderer: materials now follow the model instead of an approximation of it.**
   The renderer drew almost everything opaque with a single texture, which is right for a chicken
   and wrong for most of the bestiary. Measured over a spread of 300 retail creature models (1424

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -42,6 +42,16 @@ public class WmvRuntimeModel
     /// and no material is rebuilt.</summary>
     public int[][] SubmeshTriangles = new int[0][];
 
+    /// <summary>
+    /// The bone transforms behind the SkinnedMeshRenderer, in the model's own bone order, or an
+    /// empty array when this model is drawn unskinned. They are children of Root, so Dispose
+    /// takes them with it.
+    /// </summary>
+    public Transform[] Bones = new Transform[0];
+
+    /// <summary>True when the model is drawn through a SkinnedMeshRenderer.</summary>
+    public bool Skinned;
+
     /// <summary>The geoset numbers currently switched on, or null when the host has not said.</summary>
     public HashSet<int> Geosets;
     public Bounds Bounds;
@@ -56,6 +66,7 @@ public class WmvRuntimeModel
         foreach (var t in Textures) if (t != null) UnityEngine.Object.Destroy(t);
         Root = null;
         Mesh = null;
+        Bones = new Transform[0];
         Materials = new Material[0];
         Textures = new Texture2D[0];
     }
@@ -64,9 +75,15 @@ public class WmvRuntimeModel
 public static class WmvModelBuilder
 {
     /// <summary>
-    /// Diagnostic switches, read from the player command line. They exist to isolate a visual
-    /// fault without rebuilding: run the player (or let WMV launch it) with the flag and the
-    /// rendering changes accordingly.
+    /// Diagnostic switches. They exist to isolate a visual fault without rebuilding: pass the
+    /// flag and the rendering changes accordingly.
+    ///
+    /// Each is read from the player's own command line AND from the WMV_DEBUG environment
+    /// variable (space-separated, same spellings). The environment matters because WMV builds the
+    /// player's command line itself when it launches it into the viewport pane -- without it these
+    /// switches would only reach a player started by hand, which is not the case anyone wants to
+    /// diagnose. A child process inherits the environment, so setting WMV_DEBUG for WMV sets it
+    /// for the player.
     ///
     ///   -wmvFlipV        invert the V texture coordinate (isolates a UV-orientation fault)
     ///   -wmvForceOpaque  force every material opaque, ignoring the WoW blend mode
@@ -83,17 +100,29 @@ public static class WmvModelBuilder
     ///   -wmvOwnShader    resolve the renderer's own WmvOpaque shader before any pipeline
     ///                    shader. The pipeline's Lit shaders cannot run the M2 combiner, so this
     ///                    is how to see the second texture unit in a build where they exist.
+    ///   -wmvNoSkin       build every model as a static mesh, as before skinning existed. The
+    ///                    A/B for "did the skinned path change what I see?".
+    ///   -wmvSkinCheck    after building a skinned model, bake the skinned result and report the
+    ///                    largest distance between a baked vertex and the position the file gave
+    ///                    it. At rest that distance is the whole claim of this milestone, so it
+    ///                    is worth being able to measure rather than assert.
     /// </summary>
     public static class Debug_
     {
         static bool parsed;
         static bool flipV, forceOpaque, forceSolid, matColors, showHidden, ownShader;
+        static bool noSkin, skinCheck;
 
         static void Parse()
         {
             if (parsed) return;
             parsed = true;
-            foreach (var a in System.Environment.GetCommandLineArgs())
+            var args = new List<string>(System.Environment.GetCommandLineArgs());
+            string fromEnv = System.Environment.GetEnvironmentVariable("WMV_DEBUG");
+            if (!string.IsNullOrEmpty(fromEnv))
+                args.AddRange(fromEnv.Split(new[] { ' ', '\t', ',', ';' },
+                                            StringSplitOptions.RemoveEmptyEntries));
+            foreach (var a in args)
             {
                 if (a == "-wmvFlipV") flipV = true;
                 else if (a == "-wmvForceOpaque") forceOpaque = true;
@@ -101,11 +130,15 @@ public static class WmvModelBuilder
                 else if (a == "-wmvMatColors") matColors = true;
                 else if (a == "-wmvShowHidden") showHidden = true;
                 else if (a == "-wmvOwnShader") ownShader = true;
+                else if (a == "-wmvNoSkin") noSkin = true;
+                else if (a == "-wmvSkinCheck") skinCheck = true;
             }
-            if (flipV || forceOpaque || forceSolid || matColors || showHidden || ownShader)
+            if (flipV || forceOpaque || forceSolid || matColors || showHidden || ownShader ||
+                noSkin || skinCheck)
                 Debug.Log("WMV debug switches: flipV=" + flipV + " forceOpaque=" + forceOpaque +
                           " forceSolid=" + forceSolid + " matColors=" + matColors +
-                          " showHidden=" + showHidden + " ownShader=" + ownShader);
+                          " showHidden=" + showHidden + " ownShader=" + ownShader +
+                          " noSkin=" + noSkin + " skinCheck=" + skinCheck);
         }
 
         public static bool FlipV { get { Parse(); return flipV; } }
@@ -114,6 +147,8 @@ public static class WmvModelBuilder
         public static bool MatColors { get { Parse(); return matColors; } }
         public static bool ShowHidden { get { Parse(); return showHidden; } }
         public static bool OwnShader { get { Parse(); return ownShader; } }
+        public static bool NoSkin { get { Parse(); return noSkin; } }
+        public static bool SkinCheck { get { Parse(); return skinCheck; } }
     }
 
     static readonly Color[] DebugColors =
@@ -140,6 +175,177 @@ public static class WmvModelBuilder
         if (geosets == null || submeshId == 0)
             return true;
         return geosets.Contains(submeshId);
+    }
+
+    /// <summary>An upper bound on the rig this renderer will build, purely so a corrupt bone
+    /// count cannot make the player allocate a GameObject per garbage entry. Real creature rigs
+    /// are two orders of magnitude below it.</summary>
+    const int MaxBones = 2048;
+
+    /// <summary>Whether this model can be skinned, and if not, why not -- in words meant for the
+    /// log, because an unexplained fallback to a static mesh is indistinguishable from a bug.</summary>
+    struct SkinPlan
+    {
+        public bool CanSkin;
+        public string Reason;
+    }
+
+    /// <summary>
+    /// Decide whether to build a skinned mesh for this model.
+    ///
+    /// The bar is deliberately high: the milestone's contract is that a skinned model in its rest
+    /// pose is INDISTINGUISHABLE from the static one, so anything that would make the two diverge
+    /// is a reason to stay static and say so rather than to approximate.
+    /// </summary>
+    static SkinPlan PlanSkinning(M2ParsedModel model)
+    {
+        SkinPlan p;
+        p.CanSkin = false;
+        if (Debug_.NoSkin)
+        {
+            p.Reason = "-wmvNoSkin was passed";
+            return p;
+        }
+        if (model.SkeletonFileDataID != 0)
+        {
+            // The bones are in a .skel named by the SKID chunk (and possibly in ITS parent, via
+            // SKPD). Fetching that is another asset round-trip and another chunked format; over a
+            // spread of 300 retail creature models exactly one needed it, so this milestone draws
+            // those unskinned rather than guessing at the header's unused bone array.
+            p.Reason = "its bones live in a separate skeleton file (SKID " +
+                       model.SkeletonFileDataID + "), which this milestone does not fetch";
+            return p;
+        }
+        if (model.Bones.Length == 0)
+        {
+            p.Reason = model.BoneCount > 0
+                ? "its " + model.BoneCount + " bone(s) could not be read"
+                : "it declares no bones";
+            return p;
+        }
+        if (model.Bones.Length > MaxBones)
+        {
+            p.Reason = "it declares " + model.Bones.Length + " bones, past the " + MaxBones +
+                       " this renderer will build";
+            return p;
+        }
+        p.CanSkin = true;
+        p.Reason = null;
+        return p;
+    }
+
+    /// <summary>
+    /// Build the Unity skeleton for a model, in the M2's own bone order.
+    ///
+    /// THE WHOLE THING RESTS ON ONE PROPERTY OF THE FORMAT. The legacy viewport composes a bone's
+    /// matrix as
+    ///
+    ///     local = T(pivot) * T(translation) * R(rotation) * S(scale) * T(-pivot)
+    ///     world = parent.world * local
+    ///
+    /// (Bone::calcMatrix), and it skins a vertex as the weighted sum of world * position over its
+    /// four influences. With every track at rest that local matrix collapses to the IDENTITY, so
+    /// the positions stored in the file ARE the rest pose. A bind pose therefore only has to
+    /// reproduce the identity -- which is why this places each bone at its pivot with no rotation
+    /// and no scale, and takes the bind poses from those same transforms.
+    ///
+    /// It is also exactly the arrangement animation needs later. Unity composes a bone as
+    /// parent.world * T(localPosition) * R(localRotation) * S(localScale); putting the rest
+    /// localPosition at (pivot - parentPivot) means that adding the M2's translation track to it,
+    /// and setting the rotation and scale from their tracks, reproduces the expression above term
+    /// for term -- the pivot translations telescope through the parent chain.
+    /// </summary>
+    static Transform[] BuildSkeleton(M2ParsedModel model, Transform root, out Transform rootBone)
+    {
+        int nb = model.Bones.Length;
+        var pivots = new Vector3[nb];
+        for (int i = 0; i < nb; i++)
+        {
+            float x, y, z;
+            WowCoordinateConverter.ConvertPosition(model.Bones[i].Pivot, out x, out y, out z);
+            pivots[i] = new Vector3(x, y, z);
+        }
+
+        var bones = new Transform[nb];
+        for (int i = 0; i < nb; i++)
+            bones[i] = new GameObject("bone" + i).transform;
+
+        // Parent first, place second: a bone's local offset is its pivot relative to its parent's,
+        // and because every rest rotation is the identity that offset does not depend on the order
+        // the transforms are visited in.
+        rootBone = null;
+        for (int i = 0; i < nb; i++)
+        {
+            int parent = model.Bones[i].Parent;
+            bones[i].SetParent(parent >= 0 ? bones[parent] : root, false);
+            if (parent < 0 && rootBone == null)
+                rootBone = bones[i];
+        }
+        for (int i = 0; i < nb; i++)
+        {
+            int parent = model.Bones[i].Parent;
+            bones[i].localPosition = parent >= 0 ? pivots[i] - pivots[parent] : pivots[i];
+            bones[i].localRotation = Quaternion.identity;
+            bones[i].localScale = Vector3.one;
+        }
+        if (rootBone == null)
+            rootBone = root;
+        return bones;
+    }
+
+    /// <summary>
+    /// Per-vertex influences, converted from the M2's four (bone index, weight/255) pairs. The
+    /// indices are direct indices into the bone array -- there is no lookup table in between,
+    /// which is worth stating because the .skin format has one for a different purpose.
+    ///
+    /// Two corrections are applied, and both exist to keep the rest pose identical to the static
+    /// mesh. An influence pointing past the end of the bone array is dropped -- the legacy
+    /// viewport drops it too -- but the remaining weights are then renormalised rather than left
+    /// short, because a vertex whose weights no longer sum to one is dragged toward the origin.
+    /// A vertex left with no influence at all is bound to bone 0 at full weight, which at rest is
+    /// the identity and so leaves it exactly where the file put it.
+    /// </summary>
+    static BoneWeight[] BuildBoneWeights(M2ParsedModel model, int boneCount,
+                                         out int droppedInfluences, out int unweightedVertices)
+    {
+        droppedInfluences = 0;
+        unweightedVertices = 0;
+        int n = model.Vertices.Length;
+        var weights = new BoneWeight[n];
+        var idx = new int[4];
+        var w = new float[4];
+
+        for (int i = 0; i < n; i++)
+        {
+            M2Vertex v = model.Vertices[i];
+            idx[0] = v.BoneIndex0; idx[1] = v.BoneIndex1; idx[2] = v.BoneIndex2; idx[3] = v.BoneIndex3;
+            w[0] = v.BoneWeight0; w[1] = v.BoneWeight1; w[2] = v.BoneWeight2; w[3] = v.BoneWeight3;
+
+            float sum = 0f;
+            for (int k = 0; k < 4; k++)
+            {
+                if (w[k] <= 0f) { w[k] = 0f; idx[k] = 0; continue; }
+                if (idx[k] >= boneCount) { droppedInfluences++; w[k] = 0f; idx[k] = 0; continue; }
+                sum += w[k];
+            }
+
+            var bw = new BoneWeight();
+            if (sum <= 0f)
+            {
+                unweightedVertices++;
+                bw.boneIndex0 = 0;
+                bw.weight0 = 1f;
+            }
+            else
+            {
+                bw.boneIndex0 = idx[0]; bw.weight0 = w[0] / sum;
+                bw.boneIndex1 = idx[1]; bw.weight1 = w[1] / sum;
+                bw.boneIndex2 = idx[2]; bw.weight2 = w[2] / sum;
+                bw.boneIndex3 = idx[3]; bw.weight3 = w[3] / sum;
+            }
+            weights[i] = bw;
+        }
+        return weights;
     }
 
     public static WmvRuntimeModel Build(M2ParsedModel model, M2ParsedSkin skin,
@@ -348,12 +554,69 @@ public static class WmvModelBuilder
                               hiddenByGeoset, triangleSets.Count, GeosetList(geosets)));
 
         // ---- scene object -------------------------------------------------------------
+        // Skinned when the model carries a rig this renderer can reproduce, static otherwise. The
+        // two paths share everything above: the same vertices, the same submesh-per-batch split,
+        // the same materials. Only how the mesh reaches the scene differs, and in the rest pose
+        // the result is the same geometry -- see BuildSkeleton for why that is exact rather than
+        // approximate.
         var go = new GameObject(objectName);
-        go.AddComponent<MeshFilter>().sharedMesh = mesh;
-        var renderer = go.AddComponent<MeshRenderer>();
-        renderer.sharedMaterials = materials.ToArray();
+        SkinPlan skinPlan = PlanSkinning(model);
+        var boneTransforms = new Transform[0];
+
+        if (skinPlan.CanSkin)
+        {
+            Transform rootBone;
+            boneTransforms = BuildSkeleton(model, go.transform, out rootBone);
+
+            int dropped, unweighted;
+            mesh.boneWeights = BuildBoneWeights(model, boneTransforms.Length, out dropped, out unweighted);
+
+            // The canonical bind pose: the matrix that takes a vertex from the renderer's space
+            // into the bone's. Taken from the transforms just built rather than from the pivots
+            // again, so the two can never disagree about where a bone is.
+            var bindPoses = new Matrix4x4[boneTransforms.Length];
+            for (int i = 0; i < boneTransforms.Length; i++)
+                bindPoses[i] = boneTransforms[i].worldToLocalMatrix * go.transform.localToWorldMatrix;
+            mesh.bindposes = bindPoses;
+
+            var smr = go.AddComponent<SkinnedMeshRenderer>();
+            smr.sharedMesh = mesh;
+            smr.bones = boneTransforms;
+            smr.rootBone = rootBone;
+            smr.sharedMaterials = materials.ToArray();
+            // A skinned renderer culls against localBounds, not against the mesh's own bounds, and
+            // an unset one is a zero-size box at the origin -- the model would flicker out the
+            // moment the camera moved. Bounds of the whole model, as above, so switching a geoset
+            // variant does not resize it.
+            smr.localBounds = mesh.bounds;
+            smr.updateWhenOffscreen = false;
+
+            if (log != null)
+            {
+                log(string.Format("skin: {0} bone(s), {1} root(s), max depth {2}; " +
+                                  "bind pose = rest pose (every bone at its pivot, no rotation)",
+                                  boneTransforms.Length, CountRoots(model), MaxDepth(model)));
+                if (dropped > 0 || unweighted > 0)
+                    log(string.Format("skin: {0} influence(s) pointed past the bone array and were " +
+                                      "dropped; {1} vertex/vertices were left with none and are bound " +
+                                      "to bone 0 (identity at rest)", dropped, unweighted));
+            }
+
+            if (Debug_.SkinCheck)
+                ReportSkinDeviation(smr, positions, log);
+        }
+        else
+        {
+            go.AddComponent<MeshFilter>().sharedMesh = mesh;
+            var renderer = go.AddComponent<MeshRenderer>();
+            renderer.sharedMaterials = materials.ToArray();
+            if (log != null)
+                log("skin: drawn as a static mesh -- " + skinPlan.Reason);
+        }
 
         result.Root = go;
+        result.Bones = boneTransforms;
+        result.Skinned = skinPlan.CanSkin;
         result.Mesh = mesh;
         result.Materials = materials.ToArray();
         result.Bindings = bindings.ToArray();
@@ -366,6 +629,72 @@ public static class WmvModelBuilder
         result.TriangleCount = totalTriangles;
         result.SubmeshCount = triangleSets.Count;
         return result;
+    }
+
+    /// <summary>
+    /// Bake the skinned mesh and report how far its vertices moved from where the file put them.
+    ///
+    /// This is the milestone's contract expressed as a number. The skinned and the static path
+    /// share their vertex array, so if the bind poses and the bone placement agree the baked
+    /// result is the input, and the largest deviation is float noise. A large one would mean the
+    /// rig is being applied rather than cancelled -- which is exactly the failure that is hard to
+    /// see by eye on a model you have not memorised.
+    /// </summary>
+    static void ReportSkinDeviation(SkinnedMeshRenderer smr, Vector3[] positions, Action<string> log)
+    {
+        if (log == null || smr == null)
+            return;
+        var baked = new Mesh();
+        try
+        {
+            smr.BakeMesh(baked, true);
+            Vector3[] after = baked.vertices;
+            if (after.Length != positions.Length)
+            {
+                log(string.Format("skin check: baked {0} vertices, expected {1}", after.Length, positions.Length));
+                return;
+            }
+            float worst = 0f;
+            int worstAt = -1;
+            for (int i = 0; i < after.Length; i++)
+            {
+                float dx = after[i].x - positions[i].x;
+                float dy = after[i].y - positions[i].y;
+                float dz = after[i].z - positions[i].z;
+                float dist = Mathf.Sqrt(dx * dx + dy * dy + dz * dz);
+                if (dist > worst) { worst = dist; worstAt = i; }
+            }
+            log(string.Format("skin check: {0} vertices baked from the rest pose; largest deviation " +
+                              "{1:E3} units at vertex {2}", after.Length, worst, worstAt));
+        }
+        finally
+        {
+            UnityEngine.Object.Destroy(baked);
+        }
+    }
+
+    /// <summary>How many bones have no parent. Diagnostic only: an M2 rig is a forest, not a
+    /// tree, and a creature routinely has a dozen roots.</summary>
+    static int CountRoots(M2ParsedModel model)
+    {
+        int roots = 0;
+        for (int i = 0; i < model.Bones.Length; i++)
+            if (model.Bones[i].Parent < 0) roots++;
+        return roots;
+    }
+
+    /// <summary>Deepest parent chain in the rig. Diagnostic only; the walk is bounded by the bone
+    /// count so a cycle in malformed data cannot hang the load.</summary>
+    static int MaxDepth(M2ParsedModel model)
+    {
+        int deepest = 0;
+        for (int i = 0; i < model.Bones.Length; i++)
+        {
+            int d = 0, p = model.Bones[i].Parent, guard = 0;
+            while (p >= 0 && guard++ < model.Bones.Length) { d++; p = model.Bones[p].Parent; }
+            if (d > deepest) deepest = d;
+        }
+        return deepest;
     }
 
     static readonly int[] EmptyTriangles = new int[0];

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -26,8 +26,34 @@ namespace Wmv.Wow
         public WowVec3 Normal;
         public WowVec2 TexCoord0;
         public WowVec2 TexCoord1;
-        public byte BoneWeight0, BoneWeight1, BoneWeight2, BoneWeight3;   // preserved, unused in the static milestone
+        /// <summary>Four influences, weight/255. The indices are DIRECT indices into the
+        /// model's bone array -- not through any lookup table. See M2BoneDef.</summary>
+        public byte BoneWeight0, BoneWeight1, BoneWeight2, BoneWeight3;
         public byte BoneIndex0, BoneIndex1, BoneIndex2, BoneIndex3;
+    }
+
+    /// <summary>
+    /// One M2 bone, reduced to what a bind pose needs: where it sits, and whose child it is.
+    ///
+    /// The animation tracks are deliberately NOT parsed here. The reason is the shape of the
+    /// format: a bone's matrix is built as T(pivot) * T(translation) * R(rotation) * S(scale) *
+    /// T(-pivot) and then composed with its parent's, so with every track left at rest the matrix
+    /// is the IDENTITY -- and the vertex positions in the file are already in that pose. The bind
+    /// pose therefore needs the pivot and the parent, nothing else, and animation is a later
+    /// milestone that fills in the three tracks around the same pivot.
+    /// </summary>
+    public struct M2BoneDef
+    {
+        public int KeyBoneId;        // index into the key-bone lookup, -1 when this is not one
+        public uint Flags;
+        public short Parent;         // -1 for a root bone
+        public ushort SubmeshId;
+        public WowVec3 Pivot;        // model space, the point this bone rotates about
+
+        /// <summary>Bit 0x08. A billboarded bone is re-oriented towards the viewer every frame by
+        /// the legacy viewport; at rest it is an ordinary bone, which is all this milestone
+        /// needs.</summary>
+        public bool Billboard { get { return (Flags & 0x08) != 0; } }
     }
 
     /// <summary>
@@ -132,7 +158,24 @@ namespace Wmv.Wow
         public int SkinProfileCount;
         public int[] SkinFileDataIDs = new int[0];       // SFID chunk
         public int[] TextureFileDataIDs = new int[0];    // TXID chunk (0 where replaceable)
+
+        /// <summary>
+        /// The model's bones. Empty when the model declares none, and ALSO empty when the bones
+        /// live in a separate skeleton file -- see SkeletonFileDataID.
+        /// </summary>
+        public M2BoneDef[] Bones = new M2BoneDef[0];
+
+        /// <summary>Number of bones the header declares. Equal to Bones.Length whenever the bones
+        /// are in the .m2 itself.</summary>
         public int BoneCount;
+
+        /// <summary>
+        /// The SKID chunk: the FileDataID of a separate skeleton (.skel) file. Non-zero means the
+        /// bone array in the header is not the one the renderer must use -- the real one lives in
+        /// that file's SKB1 chunk (or, when it carries an SKPD, in its parent skeleton's). This
+        /// milestone does not fetch it; a model that has one is drawn unskinned and says so.
+        /// </summary>
+        public int SkeletonFileDataID;
 
         /// <summary>Model-space bounds of the vertex positions (WoW axes).</summary>
         public WowVec3 BoundsMin, BoundsMax;

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
@@ -13,8 +13,8 @@
 //   A modern .m2 is a sequence of {char magic[4]; uint32 size; byte payload[size]} chunks. The
 //   model itself lives in the MD21 chunk and *every offset inside it is relative to the start
 //   of that chunk's payload*, not to the start of the file. Sibling chunks carry the
-//   FileDataIDs of related assets: SFID (skin profiles), TXID (textures), SKID/AFID/BFID/PFID
-//   (additional file-reference chunks -- not used in this milestone).
+//   FileDataIDs of related assets: SFID (skin profiles), TXID (textures) and SKID (a separate
+//   skeleton file). AFID/BFID/PFID are further file-reference chunks this milestone does not use.
 //
 // The MD20 header layout below matches the one WMV's own loader uses (Source/games/wow/
 // modelheaders.h): count/offset pairs, with nViews being a lone uint32 because view (LOD) data
@@ -31,6 +31,12 @@ namespace Wmv.Wow
         public const int VertexStride = 48;
         const int TextureStride = 16;
         const int MaterialStride = 4;
+
+        // One M2 bone on disk: keyBoneId(4) flags(4) parent(2) submeshId(2) boneNameCRC(4),
+        // three animation tracks of 20 bytes each, then the pivot (12). 88 bytes in total, and
+        // the pivot -- the only part a bind pose needs -- sits at the end of it.
+        const int BoneStride = 88;
+        const int OfsBonePivot = 76;
 
         // MD20 header offsets (relative to the MD21 payload)
         const int OfsName = 0x08;
@@ -68,6 +74,8 @@ namespace Wmv.Wow
 
                 model.SkinFileDataIDs = ReadIdChunk(file, chunks, "SFID");
                 model.TextureFileDataIDs = ReadIdChunk(file, chunks, "TXID");
+                int[] skeleton = ReadIdChunk(file, chunks, "SKID");
+                model.SkeletonFileDataID = skeleton.Length > 0 ? skeleton[0] : 0;
             }
 
             // Work on the MD21 payload as its own address space -- offsets inside are relative
@@ -95,7 +103,16 @@ namespace Wmv.Wow
             model.GlobalFlags = c.ReadUInt32();
 
             c.Seek(OfsBones);
-            model.BoneCount = c.ReadArray().Count;
+            M2Array bones = c.ReadArray();
+            model.BoneCount = bones.Count;
+            // A skeleton file overrides the header's bone array wholesale, so reading that array
+            // anyway would hand the renderer a rig the vertices are not indexed against. Leave
+            // Bones empty and let the caller decide what to do about it.
+            if (model.SkeletonFileDataID == 0)
+            {
+                c.RequireArray(bones, BoneStride, "bones");
+                model.Bones = ReadBones(c, bones);
+            }
 
             c.Seek(OfsNumSkinProfiles);
             model.SkinProfileCount = (int)c.ReadUInt32();
@@ -331,6 +348,42 @@ namespace Wmv.Wow
                 model.BoundsMax = new WowVec3(maxX, maxY, maxZ);
             }
             return verts;
+        }
+
+        /// <summary>
+        /// Read the bone array. Only the hierarchy and the pivots are taken: those are what a
+        /// bind pose is made of, and the three animation tracks each bone carries belong to a
+        /// later milestone. A parent index outside the array is normalised to "root" here rather
+        /// than left to blow up downstream -- the legacy viewport sanitises the same field for the
+        /// same reason, since a bad parent otherwise recurses off the end of its bone vector.
+        /// </summary>
+        static M2BoneDef[] ReadBones(ByteCursor c, M2Array arr)
+        {
+            var bones = new M2BoneDef[arr.Count];
+            for (int i = 0; i < arr.Count; i++)
+            {
+                c.Seek(arr.Offset + i * BoneStride);
+                bones[i].KeyBoneId = c.ReadInt32();
+                bones[i].Flags = c.ReadUInt32();
+                short parent = c.ReadInt16();
+                bones[i].Parent = (parent >= 0 && parent < arr.Count && parent != i) ? parent : (short)-1;
+                bones[i].SubmeshId = c.ReadUInt16();
+                c.Seek(arr.Offset + i * BoneStride + OfsBonePivot);
+                bones[i].Pivot = new WowVec3(c.ReadSingle(), c.ReadSingle(), c.ReadSingle());
+            }
+
+            // A parent chain that loops is a forest no more, and a renderer asked to parent one
+            // transform inside its own descendants throws. Any bone whose chain does not reach a
+            // root within the length of the array is part of a cycle, so it becomes a root.
+            for (int i = 0; i < bones.Length; i++)
+            {
+                int p = bones[i].Parent, steps = 0;
+                while (p >= 0 && steps++ <= bones.Length)
+                    p = bones[p].Parent;
+                if (steps > bones.Length)
+                    bones[i].Parent = -1;
+            }
+            return bones;
         }
 
         static M2TextureDef[] ReadTextures(ByteCursor c, M2Array arr, M2ParsedModel model)

--- a/Tools/UnityRendererProject/README.md
+++ b/Tools/UnityRendererProject/README.md
@@ -178,9 +178,71 @@ has three dropdown entries sharing one texture that differ only in whether geose
 on -- a long mane and tail, or a cropped one. WMV sends the set; switching between variants swaps
 which submeshes hand the mesh their triangles, so nothing is re-uploaded and no material is rebuilt.
 
+## Skinning and the bind pose
+
+A model is drawn through a `SkinnedMeshRenderer` when it carries a rig this renderer can
+reproduce. No animation track is evaluated yet: every bone sits in its rest pose, and the point of
+the milestone is that this is **indistinguishable from the static mesh it replaces**.
+
+That is not a hope, it is a property of the format. The legacy viewport composes a bone as
+
+```
+local = T(pivot) * T(translation) * R(rotation) * S(scale) * T(-pivot)
+world = parent.world * local
+```
+
+(`Bone::calcMatrix`) and skins a vertex as the weighted sum of `world * position` over its four
+influences. With every track at rest that local matrix collapses to the **identity** — so the
+positions stored in the file already *are* the rest pose, and a bind pose only has to reproduce
+the identity. Each Unity bone is therefore placed at its pivot with no rotation and no scale, and
+the bind poses are read back off those same transforms:
+
+```
+bone.localPosition = pivot - parentPivot
+bindposes[i]       = bones[i].worldToLocalMatrix * renderer.localToWorldMatrix
+```
+
+The same arrangement is what animation will need. Unity composes a bone as
+`parent.world * T(localPosition) * R(localRotation) * S(localScale)`, so adding the M2's
+translation track to that rest `localPosition` and setting the rotation and scale from their
+tracks reproduces the expression above term for term — the pivot translations telescope through
+the parent chain. Nothing here will need re-deriving to make the model move.
+
+Four things about the data are worth stating, because getting any of them wrong stays invisible
+until the model deforms:
+
+**The per-vertex bone indices are direct indices into the bone array.** There is no lookup table
+in between. The `.skin` format does carry one, for its own batching purposes, and reading the
+vertex indices through it produces a rig that looks plausible and skins the wrong vertices.
+
+**Weights are `uint8`/255 and are renormalised here.** An influence pointing past the end of the
+bone array is dropped, as the legacy viewport drops it — but the remaining weights are then
+rescaled to sum to one rather than left short, because a vertex whose weights no longer sum to one
+is dragged toward the origin. A vertex left with no influence at all is bound to bone 0 at full
+weight, which at rest is the identity and so leaves it exactly where the file put it. Across the
+validation models neither correction fired: every weight set summed to 255 and every index was in
+range.
+
+**A rig is a forest, not a tree.** A creature routinely has a dozen bones with no parent —
+`creature/valkier` has 27 of 149 — so there is no single root to hang everything from. Parent
+indices are sanitised at parse time: out of range, self-referential, or part of a cycle all become
+roots, because a cycle is both an infinite parent walk and a transform Unity refuses to parent
+inside its own descendants.
+
+**Where the bones live.** Almost always in the `.m2` itself. A model can instead name a separate
+skeleton file through its `SKID` chunk, and that skeleton can defer again to a parent through
+`SKPD`; over a spread of 300 retail creature models, 299 kept their bones in the `.m2` and one
+used an `SKPD` parent. This milestone does not fetch skeleton files, so a model that names one is
+drawn as a static mesh and the log says exactly that — as it does for any other model the plan
+refuses. Reading the header's bone array anyway would be worse than not skinning: the vertices are
+not indexed against it.
+
 ## Debug switches
 
-Pass these on the player command line to isolate a visual fault without rebuilding:
+Pass these on the player command line to isolate a visual fault without rebuilding. They are also
+read from the **`WMV_DEBUG`** environment variable (space-separated, same spellings), which is how
+to reach them in the embedded viewport — WMV builds the player's command line itself, and a child
+process inherits the environment:
 
 | Flag | Effect |
 |---|---|
@@ -190,10 +252,13 @@ Pass these on the player command line to isolate a visual fault without rebuildi
 | `-wmvMatColors` | replace textures with a flat per-material colour — separates a batch/material assignment fault from a texture fault |
 | `-wmvShowHidden` | draw the batches the model hides at rest — shows *what* is hidden, and usually what it was covering |
 | `-wmvOwnShader` | resolve the renderer's own `WmvOpaque` shader ahead of any pipeline shader — the only one that can run an M2 combiner |
+| `-wmvNoSkin` | build every model as a static mesh, as before skinning existed — the A/B for "did the skinned path change what I see?" |
+| `-wmvSkinCheck` | bake the skinned result and report the largest distance between a baked vertex and the position the file gave it. At rest that distance is the milestone's whole claim, so it is measurable rather than asserted |
 
 Each model load also logs its UV sample, per-batch material/blend/texture-slot mapping, the alpha
 treatment per texture, which batches are hidden at rest and why, the resolved combiner and per-unit
-UV routing, the full runtime material state, and the shader that was chosen.
+UV routing, the full runtime material state, the shader that was chosen, and the rig it was skinned
+to (or why it was not).
 
 ## Scripts
 

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -67,22 +67,37 @@ namespace Wmv.Wow.Tests
             for (int i = 0; i < 4; i++) b[o + i] = (byte)m[i];
         }
 
-        /// <summary>Minimal but structurally valid MD20 payload with `vertexCount` vertices.</summary>
-        static byte[] BuildM2Payload(int vertexCount, int textureCount = 1, uint textureType = 11)
+        /// <summary>One bone on disk, laid out the way the format does it.</summary>
+        const int BoneStride = 88;
+
+        static void PutBone(byte[] b, int o, short parent, float px, float py, float pz, uint flags = 0)
+        {
+            PutU32(b, o + 0, unchecked((uint)-1));   // keyBoneId
+            PutU32(b, o + 4, flags);
+            PutU16(b, o + 8, unchecked((ushort)parent));
+            PutU16(b, o + 10, 0);                    // submeshId
+            PutF32(b, o + 76, px); PutF32(b, o + 80, py); PutF32(b, o + 84, pz);
+        }
+
+        /// <summary>Minimal but structurally valid MD20 payload with `vertexCount` vertices, and
+        /// optionally a bone array.</summary>
+        static byte[] BuildM2Payload(int vertexCount, int textureCount = 1, uint textureType = 11,
+                                     int boneCount = 0)
         {
             const int headerSize = 0x100;
             int vertsOffset = headerSize;
             int texOffset = vertsOffset + vertexCount * 48;
             int matOffset = texOffset + textureCount * 16;
             int lookupOffset = matOffset + 4;
-            int total = lookupOffset + 2;
+            int boneOffset = lookupOffset + 2;
+            int total = boneOffset + boneCount * BoneStride;
 
             var b = new byte[total];
             PutMagic(b, 0, "MD20");
             PutU32(b, 0x04, 272);
             PutU32(b, 0x08, 0); PutU32(b, 0x0C, 0);            // name
             PutU32(b, 0x10, 0);                                 // globalFlags
-            PutU32(b, 0x2C, 1); PutU32(b, 0x30, 0);             // bones (count only matters)
+            PutU32(b, 0x2C, (uint)boneCount); PutU32(b, 0x30, (uint)boneOffset);
             PutU32(b, 0x3C, (uint)vertexCount); PutU32(b, 0x40, (uint)vertsOffset);
             PutU32(b, 0x44, 1);                                 // numSkinProfiles
             PutU32(b, 0x50, (uint)textureCount); PutU32(b, 0x54, (uint)texOffset);
@@ -109,13 +124,19 @@ namespace Wmv.Wow.Tests
             PutU16(b, matOffset, 0);        // material flags
             PutU16(b, matOffset + 2, 1);    // blend mode: alpha key
             PutU16(b, lookupOffset, 0);     // textureLookup[0] -> slot 0
+
+            // A small chain: bone 0 at the origin, each later one a child of the one before it,
+            // one unit further along WoW's +X (forward).
+            for (int i = 0; i < boneCount; i++)
+                PutBone(b, boneOffset + i * BoneStride, (short)(i - 1), i, 0f, 0f);
             return b;
         }
 
-        static byte[] WrapChunked(byte[] md20Payload, int[] sfid, int[] txid)
+        static byte[] WrapChunked(byte[] md20Payload, int[] sfid, int[] txid, int skid = 0)
         {
             int total = 8 + md20Payload.Length + (sfid != null ? 8 + sfid.Length * 4 : 0)
-                                               + (txid != null ? 8 + txid.Length * 4 : 0);
+                                               + (txid != null ? 8 + txid.Length * 4 : 0)
+                                               + (skid != 0 ? 12 : 0);
             var b = new byte[total];
             int o = 0;
             PutMagic(b, o, "MD21"); PutU32(b, o + 4, (uint)md20Payload.Length); o += 8;
@@ -129,6 +150,11 @@ namespace Wmv.Wow.Tests
             {
                 PutMagic(b, o, "TXID"); PutU32(b, o + 4, (uint)(txid.Length * 4)); o += 8;
                 foreach (int id in txid) { PutU32(b, o, (uint)id); o += 4; }
+            }
+            if (skid != 0)
+            {
+                PutMagic(b, o, "SKID"); PutU32(b, o + 4, 4); o += 8;
+                PutU32(b, o, (uint)skid); o += 4;
             }
             return b;
         }
@@ -220,6 +246,8 @@ namespace Wmv.Wow.Tests
             ShaderTableTests();
             log.Add("Visibility tracks");
             VisibilityTests();
+            log.Add("Bones");
+            BoneTests();
 
             log.Add(failures == 0 ? "ALL TESTS PASSED" : (failures + " TEST(S) FAILED"));
             if (output != null)
@@ -272,6 +300,72 @@ namespace Wmv.Wow.Tests
             var badChunk = WrapChunked(BuildM2Payload(1), null, null);
             PutU32(badChunk, 4, (uint)(badChunk.Length * 4));
             Throws<WowParseException>(() => M2Parser.Parse(badChunk), "M2: oversized chunk rejected");
+        }
+
+        static void BoneTests()
+        {
+            M2ParsedModel m = M2Parser.Parse(BuildM2Payload(3, boneCount: 4));
+            Check(m.BoneCount == 4 && m.Bones.Length == 4, "bones: count read");
+            Check(m.Bones[0].Parent == -1, "bones: first bone is a root");
+            Check(m.Bones[1].Parent == 0 && m.Bones[3].Parent == 2, "bones: parent chain read");
+            Near(m.Bones[2].Pivot.X, 2f, "bones: pivot read");
+            Check(m.SkeletonFileDataID == 0, "bones: no SKID means no skeleton file");
+
+            // A parent index outside the array cannot be followed; it becomes a root rather than
+            // a read off the end of the array.
+            var badParent = BuildM2Payload(3, boneCount: 3);
+            PutU16(badParent, 0x100 + 3 * 48 + 16 + 4 + 2 + BoneStride + 8, 99);
+            M2ParsedModel bp = M2Parser.Parse(badParent);
+            Check(bp.Bones[1].Parent == -1, "bones: out-of-range parent becomes a root");
+
+            // Same for a bone that claims to be its own parent.
+            var selfParent = BuildM2Payload(3, boneCount: 3);
+            PutU16(selfParent, 0x100 + 3 * 48 + 16 + 4 + 2 + BoneStride + 8, 1);
+            Check(M2Parser.Parse(selfParent).Bones[1].Parent == -1, "bones: self-parent becomes a root");
+
+            // ... and for a cycle, which would otherwise be an infinite parent walk and a
+            // renderer asked to parent a transform inside its own descendants.
+            var cycle = BuildM2Payload(3, boneCount: 3);
+            int boneBase = 0x100 + 3 * 48 + 16 + 4 + 2;
+            PutU16(cycle, boneBase + 8, 2);                 // 0 -> 2 -> 1 -> 0
+            PutU16(cycle, boneBase + BoneStride + 8, 0);
+            PutU16(cycle, boneBase + 2 * BoneStride + 8, 1);
+            M2ParsedModel cy = M2Parser.Parse(cycle);
+            // The guarantee is not that every bone in the loop becomes a root -- it is that no
+            // parent chain runs forever, which is what the renderer and the depth walk need.
+            bool allChainsTerminate = true;
+            for (int i = 0; i < cy.Bones.Length; i++)
+            {
+                int p = cy.Bones[i].Parent, steps = 0;
+                while (p >= 0 && steps++ <= cy.Bones.Length) p = cy.Bones[p].Parent;
+                if (p >= 0) allChainsTerminate = false;
+            }
+            Check(allChainsTerminate, "bones: parent cycle broken");
+
+            // A model whose bones live in a skeleton file must not hand back the header's array:
+            // the vertices are not indexed against it.
+            byte[] skid = WrapChunked(BuildM2Payload(3, boneCount: 4), null, null, 1234567);
+            M2ParsedModel sk = M2Parser.Parse(skid);
+            Check(sk.SkeletonFileDataID == 1234567, "bones: SKID chunk read");
+            Check(sk.BoneCount == 4 && sk.Bones.Length == 0, "bones: SKID suppresses the header bone array");
+
+            // The per-vertex influences are direct indices, kept verbatim.
+            var weighted = BuildM2Payload(2, boneCount: 4);
+            int v1 = 0x100 + 48;
+            weighted[v1 + 12] = 200; weighted[v1 + 13] = 55;   // weights
+            weighted[v1 + 16] = 3; weighted[v1 + 17] = 1;      // indices
+            M2ParsedModel wm = M2Parser.Parse(weighted);
+            Check(wm.Vertices[1].BoneWeight0 == 200 && wm.Vertices[1].BoneWeight1 == 55,
+                  "bones: vertex weights read");
+            Check(wm.Vertices[1].BoneIndex0 == 3 && wm.Vertices[1].BoneIndex1 == 1,
+                  "bones: vertex bone indices read");
+
+            // A bone array that runs past the end of the payload is a parse error, not a read
+            // into whatever follows it.
+            var truncatedBones = BuildM2Payload(3, boneCount: 2);
+            PutU32(truncatedBones, 0x2C, 64);
+            Throws<WowParseException>(() => M2Parser.Parse(truncatedBones),
+                                      "bones: truncated bone array rejected");
         }
 
         static void SkinTests()

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -236,11 +236,22 @@ in-process, and shuts the player down. Result lines carry the `[unityipc-test]` 
 - Model textures the M2 does not name (replaceable creature skins) are resolved by WMV from
   the client database and handed to the player as FileDataIDs (`getModelTextures`), labelled
   `database` or -- for orphaned legacy assets only -- `convention`.
+- Skinned rendering in the rest pose: the model's bone hierarchy is rebuilt as Unity transforms,
+  the per-vertex influences and bind poses are handed to a SkinnedMeshRenderer, and the mesh is
+  deformed by that rig instead of being drawn rigid. No animation track is evaluated yet, so
+  every bone sits at rest -- and because an M2's stored vertex positions ARE that rest pose, the
+  result is the static mesh it replaces to within float noise (largest measured deviation across
+  the validation models: 3.8e-6 units). Models whose bones live in a separate skeleton file are
+  still drawn static, and say so.
 - Bounds-driven camera framing, so a loaded model is visible immediately.
 
 **Not yet implemented**
 
-- Skeletal animation (bone data is parsed and preserved, but nothing is animated or skinned).
+- Animation playback. The rig is built and the mesh is skinned to it, but no animation track is
+  read, so nothing moves; sequences, interpolation, timing and an idle loop are the next step.
+- Bones from a separate skeleton file (the SKID chunk, and the SKPD parent it can defer to).
+  Over a spread of 300 retail creature models, 299 keep their bones in the .m2 itself and one
+  does not; that one is drawn unskinned.
 - The rest of the WoW material system: texture animation, colour and transparency tracks beyond
   the rest-pose visibility gate, the specular lobes the legacy viewport leaves unweighted by
   default, and the few combiners that mix more than two contributing units.


### PR DESCRIPTION
The Unity renderer drew every M2 as a rigid mesh. The bone indices and weights each vertex carries were parsed and then ignored. The rig is now rebuilt as Unity transforms, the influences and bind poses are handed to a SkinnedMeshRenderer, and the mesh is deformed by that rig.

No animation is played yet -- every bone sits in its rest pose, and that is the point. The milestone's contract is that a skinned model at rest is indistinguishable from the static one it replaces, and it holds because of how the format is built. The legacy viewport composes a bone as

    local = T(pivot) * T(translation) * R(rotation) * S(scale) * T(-pivot)
    world = parent.world * local

(Bone::calcMatrix) and skins a vertex as the weighted sum of world * position over its four influences. With every track at rest that local matrix collapses to the identity, so the positions stored in the file already ARE the rest pose and a bind pose only has to reproduce the identity. Each bone is therefore placed at its pivot with no rotation and no scale, and the bind poses are read back off those same transforms.

That is also exactly the arrangement animation will need. Unity composes a bone as parent.world * T(localPosition) * R(localRotation) * S(localScale), so adding the M2's translation track to the rest localPosition and setting the rotation and scale from their tracks reproduces the expression above term for term -- the pivot translations telescope through the parent chain. Nothing here will need re-deriving to make the model move.

Two details of the data are easy to get wrong and are handled explicitly:

  * the per-vertex bone indices are DIRECT indices into the bone array, not indices through the .skin's lookup table. Reading them through it produces a rig that looks plausible and skins the wrong vertices.
  * a rig is a forest, not a tree. valkier has 27 root bones out of 149. Out-of-range, self-referential and cyclic parents all become roots at parse time, since a cycle is both an infinite parent walk and a transform Unity refuses to parent inside its own descendants.

Weights are renormalised after any out-of-range influence is dropped, rather than left short as the legacy viewport leaves them, because a vertex whose weights no longer sum to one is dragged toward the origin; a vertex left with no influence is bound to bone 0, which at rest is the identity. Neither correction fired on any validation model.

A model whose bones live in a separate skeleton file (the SKID chunk, and the SKPD parent it can defer to) is drawn as a static mesh and logs why. Fetching skeleton files is another asset round-trip and another chunked format; over a spread of 300 retail creature models, 299 keep their bones in the .m2 itself and one does not.

New: -wmvSkinCheck bakes the skinned result and reports the largest distance between a baked vertex and the position the file gave it, so the claim above is measured rather than asserted; -wmvNoSkin forces the old static path for an A/B. Every debug switch is now also read from the WMV_DEBUG environment variable, which is the only way to reach them in the embedded viewport -- WMV builds the player's command line itself.

Validated with -unityipctest against the real Unity player on eight models (rigs of 29 to 236 bones, 2 to 15 deep, 7 to 27 roots): all PASS, no exceptions. Largest rest-pose deviation 3.8e-6 units, three models exactly zero. chicken2 is unchanged (778 triangles, one submesh, hidden eye batch still skipped, combiner 12 still applied), horse3's geoset variants still switch (1504/2253/2442/2515), skin sync, the hidden-batch gate and the material coverage are untouched, and creature/orcskeleton exercises the skeleton-file fallback. 87/87 parser tests pass, the player scripts type-check under all four input-backend configurations, and the branch contains no C++ at all, so the OpenGL viewport is untouched.