### PR TITLE
Add Unity M2 idle animation playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Embedded Unity renderer: creatures now play their idle animation.** The rig built by the
+  previous milestone stood perfectly still; it now loops the model's default idle. Which sequence
+  that is turned out to be the first thing worth getting right: it is NOT sequence 0, but the first
+  sequence whose AnimId is "Stand", falling back to sequence 0 only when a model has none -- the
+  rule the OpenGL viewport itself uses. On `creature/chicken2` sequence 0 is a run cycle and the
+  idle is sequence 2; on `creature/valkier` it is sequence 11. Bone tracks are evaluated the way
+  the legacy evaluator does, case for case: fewer than two keys holds the first value, a time past
+  the last key holds the last, and otherwise the containing span is interpolated -- stepped for
+  "none", interpolated for "linear", and *slerped* rather than lerped for rotations. Hermite and
+  Bezier tracks are read as linear (their tangents are not), which no bone track in any validation
+  model uses. **Global sequences are implemented, not skipped**: a track bound to one loops on its
+  own clock independently of what is playing, and keeps its keys at entry 0 -- `creature/valkier`
+  drives 61 of its tracks that way. A global sequence of zero length, which `creature/wrathofazshara`
+  actually ships, holds its first keyframe here rather than returning a default value as the legacy
+  evaluator does; for a scale track that default collapses the bone to a point. Only the sequence
+  being played is parsed, so a 109-sequence boss costs one sequence of keyframes, and only bones
+  that actually move are driven. There is no Animator Controller and no clip: Unity's animation
+  system wants assets authored at build time and a player build strips them, so the animator writes
+  localPosition/localRotation/localScale straight onto the bones -- the same expression the
+  skinning milestone derived, with the tracks filled in instead of left at rest, so the bind poses
+  are untouched and `-wmvNoAnim` returns the model to a rest pose that still measures identical to
+  the static mesh. One rotation subtlety is worth naming: the WoW-to-Unity axis map mirrors, so
+  converting a rotation remaps its axis AND reverses its turn, which is checked against the matrix
+  route in the parser tests rather than trusted. Measured with the new `-wmvAnimCheck`, which
+  samples the idle across its length and bakes the skinned result, vertices move at most 16% of the
+  model's own diagonal on chicken2 and stay bounded on every model tested. Nothing but bones is
+  animated, and a model whose idle keeps its keyframes in a separate .anim file is left still and
+  says so.
+
+### Added
 - **Embedded Unity renderer: models are now skinned to their own skeleton.** The renderer drew
   every M2 as a rigid mesh; the bone indices and weights each vertex carries were parsed and then
   ignored. The rig is now rebuilt as Unity transforms, the influences and bind poses are handed to

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
@@ -1,0 +1,308 @@
+// WmvM2Animator.cs
+//
+// Plays one M2 animation -- the model's default idle -- by writing bone transforms every frame.
+//
+// WHY THERE IS NO ANIMATOR CONTROLLER HERE. Unity's animation system wants clips authored at
+// build time; this renderer receives a model over IPC at runtime and has to be moving a second
+// later. An AnimationClip would have to be built per model, per sequence, from curves this code
+// would have to fill in anyway -- and clips are exactly the kind of asset a player build strips.
+// Writing localPosition/localRotation/localScale straight onto the bone transforms is both less
+// machinery and a closer match to what the legacy viewport does.
+//
+// WHAT IT REPRODUCES. The legacy viewport composes a bone as
+//
+//     local = T(pivot) * T(translation(t)) * R(rotation(t)) * S(scale(t)) * T(-pivot)
+//     world = parent.world * local
+//
+// (Bone::calcMatrix), evaluating each track at a time in milliseconds inside the playing
+// sequence. The skeleton this renderer already builds puts every bone at its pivot with the rest
+// transform localPosition = pivot - parentPivot, and Unity composes a bone as
+// parent.world * T(localPosition) * R(localRotation) * S(localScale). Adding the translation
+// track to that rest offset and setting the rotation and scale from their tracks reproduces the
+// expression above term for term: the pivot translations telescope through the parent chain, and
+// the bind poses are unchanged. A bone with no track for this sequence simply keeps its rest
+// transform, which is what the viewport's "no tracks, matrix stays identity" case amounts to.
+//
+// GLOBAL SEQUENCES. A track can be bound to a global sequence instead of the animation: it then
+// loops over that sequence's own duration on a clock that does not care what is playing. The
+// legacy evaluator reads entry 0 of such a track's keys and takes the time as
+// globalTime % duration; both are reproduced here.
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Wmv.Wow;
+
+/// <summary>
+/// Drives one model's bones from its M2 tracks. Added by WmvModelBuilder to the model root, so it
+/// dies with the model.
+/// </summary>
+public class WmvM2Animator : MonoBehaviour
+{
+    /// <summary>
+    /// The clock global-sequence tracks run on, in milliseconds. Shared by every model, which is
+    /// the point of a global sequence: it is global.
+    /// </summary>
+    public static double GlobalTimeMs;
+
+    /// <summary>One track, with its keys already in Unity space.</summary>
+    struct Track<T>
+    {
+        public M2Interpolation Interpolation;
+        public int GlobalSequence;
+        public uint[] Times;
+        public T[] Values;
+        public bool HasData { get { return Values != null && Values.Length > 0; } }
+    }
+
+    struct AnimatedBone
+    {
+        public Transform Transform;
+        public Vector3 RestLocalPosition;
+        public Track<Vector3> Translation;
+        public Track<Quaternion> Rotation;
+        public Track<Vector3> Scale;
+    }
+
+    AnimatedBone[] bones = new AnimatedBone[0];
+    uint[] globalSequences = new uint[0];
+    float lengthMs = 1f;
+    double timeMs;
+
+    /// <summary>Sequence index and AnimId, for the log and for nothing else.</summary>
+    public int SequenceIndex { get; private set; }
+    public int AnimId { get; private set; }
+    public int AnimatedBoneCount { get { return bones.Length; } }
+    public float LengthMs { get { return lengthMs; } }
+    public int GlobalSequenceTrackCount { get; private set; }
+
+    /// <summary>
+    /// Bind the animator to a model's bones.
+    ///
+    /// Only bones that actually move in this sequence are kept: on a 236-bone boss the idle moves
+    /// a third of them, and the rest would be identical writes every frame. Track values are
+    /// converted to Unity space HERE rather than per frame -- the axis map is a linear isometry,
+    /// so interpolating converted keys gives the same result as converting an interpolated value,
+    /// and doing it once per key instead of once per frame is free.
+    /// </summary>
+    public void Setup(M2ParsedModel model, Transform[] boneTransforms, Vector3[] restLocalPositions,
+                      Action<string> log)
+    {
+        SequenceIndex = model.AnimatedSequence;
+        globalSequences = model.GlobalSequences;
+        M2Sequence seq = model.Sequences[SequenceIndex];
+        AnimId = seq.AnimId;
+        lengthMs = seq.Length > 0 ? seq.Length : 1f;
+
+        var kept = new List<AnimatedBone>();
+        int globalTracks = 0;
+        var unsupported = new Dictionary<M2Interpolation, int>();
+
+        int n = Math.Min(model.Bones.Length, boneTransforms.Length);
+        for (int i = 0; i < n; i++)
+        {
+            M2BoneDef def = model.Bones[i];
+            if (!def.IsAnimated)
+                continue;
+
+            AnimatedBone b;
+            b.Transform = boneTransforms[i];
+            b.RestLocalPosition = restLocalPositions[i];
+            b.Translation = ConvertVectorTrack(def.Translation, false);
+            b.Rotation = ConvertRotationTrack(def.Rotation);
+            b.Scale = ConvertVectorTrack(def.Scale, true);
+            kept.Add(b);
+
+            if (def.Translation.IsGlobal) globalTracks++;
+            if (def.Rotation.IsGlobal) globalTracks++;
+            if (def.Scale.IsGlobal) globalTracks++;
+            CountUnsupported(unsupported, def.Translation.Interpolation, def.Translation.HasData);
+            CountUnsupported(unsupported, def.Rotation.Interpolation, def.Rotation.HasData);
+            CountUnsupported(unsupported, def.Scale.Interpolation, def.Scale.HasData);
+        }
+
+        bones = kept.ToArray();
+        GlobalSequenceTrackCount = globalTracks;
+
+        if (log != null)
+        {
+            log(string.Format("anim: sequence [{0}] animId {1} \"{2}\", {3} ms, {4} of {5} bone(s) " +
+                              "move, {6} track(s) on a global sequence",
+                              SequenceIndex, AnimId, AnimId == 0 ? "Stand" : "fallback",
+                              lengthMs, bones.Length, model.Bones.Length, globalTracks));
+            foreach (var kv in unsupported)
+                log(string.Format("anim: {0} track(s) use {1} interpolation, which is read as " +
+                                  "linear in this milestone (its tangents are not)", kv.Value, kv.Key));
+        }
+        // Start at the beginning of the loop rather than wherever a previous model left off.
+        timeMs = 0.0;
+    }
+
+    static void CountUnsupported(Dictionary<M2Interpolation, int> counts, M2Interpolation kind, bool hasData)
+    {
+        if (!hasData || kind == M2Interpolation.None || kind == M2Interpolation.Linear)
+            return;
+        int v;
+        counts.TryGetValue(kind, out v);
+        counts[kind] = v + 1;
+    }
+
+    void LateUpdate()
+    {
+        double dt = Time.deltaTime * 1000.0;
+        GlobalTimeMs += dt;
+        timeMs += dt;
+        if (timeMs >= lengthMs)
+            timeMs -= Math.Floor(timeMs / lengthMs) * lengthMs;
+        ApplyPose((float)timeMs);
+    }
+
+    /// <summary>
+    /// Write the pose at one instant onto the bones. Public because the -wmvAnimCheck diagnostic
+    /// drives it directly: sampling the sequence is the only way to answer "does this move, and by
+    /// how much" without a person watching the viewport.
+    /// </summary>
+    public void ApplyPose(float t)
+    {
+        for (int i = 0; i < bones.Length; i++)
+        {
+            AnimatedBone b = bones[i];
+            if (b.Transform == null)
+                continue;
+
+            if (b.Translation.HasData)
+                b.Transform.localPosition = b.RestLocalPosition +
+                                            EvalVector(b.Translation, TrackTime(b.Translation.GlobalSequence, t));
+            if (b.Rotation.HasData)
+                b.Transform.localRotation = EvalRotation(b.Rotation, TrackTime(b.Rotation.GlobalSequence, t));
+            if (b.Scale.HasData)
+                b.Transform.localScale = EvalVector(b.Scale, TrackTime(b.Scale.GlobalSequence, t));
+        }
+    }
+
+    /// <summary>Put every animated bone back exactly where the bind pose expects it.</summary>
+    public void RestorePose()
+    {
+        for (int i = 0; i < bones.Length; i++)
+        {
+            if (bones[i].Transform == null)
+                continue;
+            bones[i].Transform.localPosition = bones[i].RestLocalPosition;
+            bones[i].Transform.localRotation = Quaternion.identity;
+            bones[i].Transform.localScale = Vector3.one;
+        }
+    }
+
+    /// <summary>
+    /// The time to evaluate a track at: the animation's own, or the global sequence's clock.
+    ///
+    /// A global sequence of zero length is a real thing in shipped data. The legacy evaluator
+    /// returns a default-constructed value for it, which is right for a translation (no movement)
+    /// and wrong for a scale (it collapses the bone to a point). Holding the first keyframe is the
+    /// reading that cannot make a model vanish.
+    /// </summary>
+    float TrackTime(int globalSequence, float animationTime)
+    {
+        if (globalSequence < 0 || globalSequence >= globalSequences.Length)
+            return animationTime;
+        uint duration = globalSequences[globalSequence];
+        if (duration == 0)
+            return 0f;
+        return (float)(GlobalTimeMs % duration);
+    }
+
+    /// <summary>
+    /// Find the keyframe span containing t and how far into it we are. Mirrors the legacy
+    /// evaluator: before the first key or past the last one, the nearest key is held rather than
+    /// wrapped -- a track need not span the whole sequence.
+    /// </summary>
+    static bool Span(uint[] times, float t, out int index, out float r)
+    {
+        index = 0;
+        r = 0f;
+        int n = times.Length;
+        if (n < 2)
+            return false;
+        if (t >= times[n - 1])
+        {
+            index = n - 1;
+            return false;
+        }
+        for (int i = 0; i < n - 1; i++)
+        {
+            if (t >= times[i] && t < times[i + 1])
+            {
+                index = i;
+                float span = times[i + 1] - times[i];
+                r = span > 0f ? (t - times[i]) / span : 0f;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static Vector3 EvalVector(Track<Vector3> track, float t)
+    {
+        int i;
+        float r;
+        if (!Span(track.Times, t, out i, out r))
+            return track.Values[Mathf.Min(i, track.Values.Length - 1)];
+        if (track.Interpolation == M2Interpolation.None)
+            return track.Values[i];
+        return Vector3.Lerp(track.Values[i], track.Values[i + 1], r);
+    }
+
+    static Quaternion EvalRotation(Track<Quaternion> track, float t)
+    {
+        int i;
+        float r;
+        if (!Span(track.Times, t, out i, out r))
+            return track.Values[Mathf.Min(i, track.Values.Length - 1)];
+        if (track.Interpolation == M2Interpolation.None)
+            return track.Values[i];
+        // Slerp, as the legacy evaluator does for quaternions -- a component-wise lerp would
+        // shorten the quaternion and pinch the joint at the middle of every span.
+        return Quaternion.Slerp(track.Values[i], track.Values[i + 1], r);
+    }
+
+    static Track<Vector3> ConvertVectorTrack(M2Track<WowVec3> src, bool isScale)
+    {
+        Track<Vector3> dst = new Track<Vector3>();
+        dst.Interpolation = src.Interpolation;
+        dst.GlobalSequence = src.GlobalSequence;
+        dst.Times = src.Times;
+        if (!src.HasData)
+            return dst;
+        var values = new Vector3[src.Values.Length];
+        for (int i = 0; i < values.Length; i++)
+        {
+            float x, y, z;
+            if (isScale)
+                WowCoordinateConverter.ConvertScale(src.Values[i], out x, out y, out z);
+            else
+                WowCoordinateConverter.ConvertPosition(src.Values[i], out x, out y, out z);
+            values[i] = new Vector3(x, y, z);
+        }
+        dst.Values = values;
+        return dst;
+    }
+
+    static Track<Quaternion> ConvertRotationTrack(M2Track<WowQuat> src)
+    {
+        Track<Quaternion> dst = new Track<Quaternion>();
+        dst.Interpolation = src.Interpolation;
+        dst.GlobalSequence = src.GlobalSequence;
+        dst.Times = src.Times;
+        if (!src.HasData)
+            return dst;
+        var values = new Quaternion[src.Values.Length];
+        for (int i = 0; i < values.Length; i++)
+        {
+            float x, y, z, w;
+            WowCoordinateConverter.ConvertRotation(src.Values[i], out x, out y, out z, out w);
+            values[i] = new Quaternion(x, y, z, w);
+        }
+        dst.Values = values;
+        return dst;
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -104,14 +104,23 @@ public static class WmvModelBuilder
     ///                    A/B for "did the skinned path change what I see?".
     ///   -wmvSkinCheck    after building a skinned model, bake the skinned result and report the
     ///                    largest distance between a baked vertex and the position the file gave
-    ///                    it. At rest that distance is the whole claim of this milestone, so it
-    ///                    is worth being able to measure rather than assert.
+    ///                    it. At rest that distance is the whole claim of the skinning milestone,
+    ///                    so it is worth being able to measure rather than assert. Only meaningful
+    ///                    together with -wmvNoAnim: a moving model is not in its rest pose.
+    ///   -wmvNoAnim       do not play anything. The model is still skinned, and still sits in the
+    ///                    rest pose the bind poses describe, which is what the milestone before
+    ///                    this one shipped.
+    ///   -wmvAnimCheck    sample the idle across its length and report how far the skinned mesh
+    ///                    moves away from its rest pose at each step, next to the model's own
+    ///                    size. Zero everywhere means nothing is animating; a number far larger
+    ///                    than the model means the rig is being applied wrongly. Both are
+    ///                    invisible in a still frame and obvious in this line.
     /// </summary>
     public static class Debug_
     {
         static bool parsed;
         static bool flipV, forceOpaque, forceSolid, matColors, showHidden, ownShader;
-        static bool noSkin, skinCheck;
+        static bool noSkin, skinCheck, noAnim, animCheck;
 
         static void Parse()
         {
@@ -132,13 +141,16 @@ public static class WmvModelBuilder
                 else if (a == "-wmvOwnShader") ownShader = true;
                 else if (a == "-wmvNoSkin") noSkin = true;
                 else if (a == "-wmvSkinCheck") skinCheck = true;
+                else if (a == "-wmvNoAnim") noAnim = true;
+                else if (a == "-wmvAnimCheck") animCheck = true;
             }
             if (flipV || forceOpaque || forceSolid || matColors || showHidden || ownShader ||
-                noSkin || skinCheck)
+                noSkin || skinCheck || noAnim || animCheck)
                 Debug.Log("WMV debug switches: flipV=" + flipV + " forceOpaque=" + forceOpaque +
                           " forceSolid=" + forceSolid + " matColors=" + matColors +
                           " showHidden=" + showHidden + " ownShader=" + ownShader +
-                          " noSkin=" + noSkin + " skinCheck=" + skinCheck);
+                          " noSkin=" + noSkin + " skinCheck=" + skinCheck + " noAnim=" + noAnim +
+                          " animCheck=" + animCheck);
         }
 
         public static bool FlipV { get { Parse(); return flipV; } }
@@ -149,6 +161,8 @@ public static class WmvModelBuilder
         public static bool OwnShader { get { Parse(); return ownShader; } }
         public static bool NoSkin { get { Parse(); return noSkin; } }
         public static bool SkinCheck { get { Parse(); return skinCheck; } }
+        public static bool NoAnim { get { Parse(); return noAnim; } }
+        public static bool AnimCheck { get { Parse(); return animCheck; } }
     }
 
     static readonly Color[] DebugColors =
@@ -255,7 +269,8 @@ public static class WmvModelBuilder
     /// and setting the rotation and scale from their tracks, reproduces the expression above term
     /// for term -- the pivot translations telescope through the parent chain.
     /// </summary>
-    static Transform[] BuildSkeleton(M2ParsedModel model, Transform root, out Transform rootBone)
+    static Transform[] BuildSkeleton(M2ParsedModel model, Transform root, out Transform rootBone,
+                                     out Vector3[] restLocalPositions)
     {
         int nb = model.Bones.Length;
         var pivots = new Vector3[nb];
@@ -281,10 +296,12 @@ public static class WmvModelBuilder
             if (parent < 0 && rootBone == null)
                 rootBone = bones[i];
         }
+        restLocalPositions = new Vector3[nb];
         for (int i = 0; i < nb; i++)
         {
             int parent = model.Bones[i].Parent;
-            bones[i].localPosition = parent >= 0 ? pivots[i] - pivots[parent] : pivots[i];
+            restLocalPositions[i] = parent >= 0 ? pivots[i] - pivots[parent] : pivots[i];
+            bones[i].localPosition = restLocalPositions[i];
             bones[i].localRotation = Quaternion.identity;
             bones[i].localScale = Vector3.one;
         }
@@ -566,7 +583,8 @@ public static class WmvModelBuilder
         if (skinPlan.CanSkin)
         {
             Transform rootBone;
-            boneTransforms = BuildSkeleton(model, go.transform, out rootBone);
+            Vector3[] restLocalPositions;
+            boneTransforms = BuildSkeleton(model, go.transform, out rootBone, out restLocalPositions);
 
             int dropped, unweighted;
             mesh.boneWeights = BuildBoneWeights(model, boneTransforms.Length, out dropped, out unweighted);
@@ -604,6 +622,41 @@ public static class WmvModelBuilder
 
             if (Debug_.SkinCheck)
                 ReportSkinDeviation(smr, positions, log);
+
+            // ---- animation ------------------------------------------------------------
+            // The bind poses above are read from the rest pose, so they must be taken BEFORE
+            // anything moves a bone. Adding the animator last keeps that ordering obvious.
+            if (Debug_.NoAnim)
+            {
+                if (log != null)
+                    log("anim: not playing -- -wmvNoAnim was passed");
+            }
+            else if (model.AnimatedSequence >= 0 && model.AnimatedSequence < model.Sequences.Length)
+            {
+                var animator = go.AddComponent<WmvM2Animator>();
+                animator.Setup(model, boneTransforms, restLocalPositions, log);
+                if (animator.AnimatedBoneCount == 0)
+                {
+                    // Nothing in the idle actually moves; the component would burn a LateUpdate
+                    // per frame to write nothing.
+                    UnityEngine.Object.Destroy(animator);
+                    if (log != null)
+                        log("anim: the idle sequence moves no bones -- staying in the rest pose");
+                }
+                else
+                {
+                    // A skinned renderer culls against localBounds, which was measured from the
+                    // rest pose. An animation moves vertices outside it, so let Unity measure the
+                    // real bounds each frame instead of clipping the model as it moves.
+                    smr.updateWhenOffscreen = true;
+                    if (Debug_.AnimCheck)
+                        ReportAnimationRange(smr, animator, positions, mesh.bounds, log);
+                }
+            }
+            else if (log != null)
+            {
+                log("anim: not playing -- " + (model.AnimationSkipReason ?? "no idle sequence was resolved"));
+            }
         }
         else
         {
@@ -670,6 +723,62 @@ public static class WmvModelBuilder
         finally
         {
             UnityEngine.Object.Destroy(baked);
+        }
+    }
+
+    /// <summary>
+    /// Sample the idle across its length and report how far the skinned mesh leaves its rest pose.
+    ///
+    /// This is the animation counterpart of ReportSkinDeviation, and it exists for the same
+    /// reason: the two ways this can be wrong -- nothing moves, or everything flies apart -- both
+    /// look like a perfectly ordinary still frame in a log. Displacements are printed next to the
+    /// model's own diagonal, because "0.4 units" means nothing until you know the chicken is 0.7
+    /// units across.
+    /// </summary>
+    static void ReportAnimationRange(SkinnedMeshRenderer smr, WmvM2Animator animator,
+                                     Vector3[] rest, Bounds bounds, Action<string> log)
+    {
+        if (log == null || smr == null || animator == null)
+            return;
+        const int Samples = 8;
+        var baked = new Mesh();
+        try
+        {
+            float worst = 0f, mean = 0f;
+            var perSample = new float[Samples];
+            for (int s = 0; s < Samples; s++)
+            {
+                animator.ApplyPose(animator.LengthMs * s / Samples);
+                smr.BakeMesh(baked, true);
+                Vector3[] now = baked.vertices;
+                float sampleWorst = 0f;
+                double sum = 0.0;
+                int n = Mathf.Min(now.Length, rest.Length);
+                for (int i = 0; i < n; i++)
+                {
+                    float dx = now[i].x - rest[i].x, dy = now[i].y - rest[i].y, dz = now[i].z - rest[i].z;
+                    float dist = Mathf.Sqrt(dx * dx + dy * dy + dz * dz);
+                    if (dist > sampleWorst) sampleWorst = dist;
+                    sum += dist;
+                }
+                perSample[s] = sampleWorst;
+                if (sampleWorst > worst) worst = sampleWorst;
+                mean += n > 0 ? (float)(sum / n) : 0f;
+            }
+            mean /= Samples;
+
+            var sb = new System.Text.StringBuilder();
+            for (int s = 0; s < Samples; s++)
+                sb.Append(s > 0 ? ", " : "").Append(perSample[s].ToString("F3"));
+            log(string.Format("anim check: over {0} samples of the {1} ms idle, vertices move at " +
+                              "most {2:F3} and on average {3:F3} units; the model is {4:F3} units " +
+                              "across. Per sample: {5}",
+                              Samples, animator.LengthMs, worst, mean, bounds.size.magnitude, sb));
+        }
+        finally
+        {
+            UnityEngine.Object.Destroy(baked);
+            animator.RestorePose();
         }
     }
 

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -19,6 +19,57 @@ namespace Wmv.Wow
         public override string ToString() { return string.Format("({0:F3}, {1:F3}, {2:F3})", X, Y, Z); }
     }
 
+    /// <summary>A quaternion in the file's own component order: x, y, z, then w.</summary>
+    public struct WowQuat
+    {
+        public float X, Y, Z, W;
+        public WowQuat(float x, float y, float z, float w) { X = x; Y = y; Z = z; W = w; }
+        public static WowQuat Identity { get { return new WowQuat(0f, 0f, 0f, 1f); } }
+    }
+
+    /// <summary>How a track's values are read between keyframes.</summary>
+    public enum M2Interpolation { None = 0, Linear = 1, Hermite = 2, Bezier = 3 }
+
+    /// <summary>
+    /// One animation track, already narrowed to the single sequence the renderer will play.
+    ///
+    /// On disk a track is an array of per-sequence keyframe arrays; carrying all of them would
+    /// mean parsing every animation a model has (hundreds, on a boss) to play one. This holds the
+    /// keys for the sequence that was asked for -- or, when the track is driven by a GLOBAL
+    /// SEQUENCE, the keys at index 0, because that is the entry the legacy evaluator reads for
+    /// those regardless of which sequence is playing.
+    /// </summary>
+    public struct M2Track<T>
+    {
+        public M2Interpolation Interpolation;
+
+        /// <summary>Index into the model's GlobalSequences, or -1 for an ordinary track. A global
+        /// sequence runs on its own clock, looping over its own duration, independently of the
+        /// animation being played.</summary>
+        public int GlobalSequence;
+
+        public uint[] Times;     // milliseconds, ascending
+        public T[] Values;
+
+        public bool HasData { get { return Values != null && Values.Length > 0; } }
+        public bool IsGlobal { get { return GlobalSequence >= 0; } }
+    }
+
+    /// <summary>One entry of the animation sequence table (64 bytes on disk).</summary>
+    public struct M2Sequence
+    {
+        public short AnimId;      // AnimationData.db2 id -- 0 is "Stand"
+        public short SubAnimId;
+        public uint Length;       // milliseconds
+        public uint Flags;
+
+        /// <summary>Bit 0x20. The legacy viewport calls it "looped"; in current data it marks the
+        /// sequences whose keyframes are stored in the .m2 rather than in a separate .anim file.
+        /// Nothing here relies on it -- whether the keys are really present is decided by looking
+        /// for them, not by trusting a flag.</summary>
+        public bool PrimarySequence { get { return (Flags & 0x20) != 0; } }
+    }
+
     /// <summary>One M2 vertex (48 bytes on disk).</summary>
     public struct M2Vertex
     {
@@ -49,6 +100,19 @@ namespace Wmv.Wow
         public short Parent;         // -1 for a root bone
         public ushort SubmeshId;
         public WowVec3 Pivot;        // model space, the point this bone rotates about
+
+        /// <summary>The three tracks that move this bone, narrowed to the sequence that was
+        /// parsed. Empty tracks are the common case: most bones hold still in any one animation,
+        /// and a bone with no track at all keeps its rest transform.</summary>
+        public M2Track<WowVec3> Translation;
+        public M2Track<WowQuat> Rotation;
+        public M2Track<WowVec3> Scale;
+
+        /// <summary>Does anything move this bone in the parsed sequence?</summary>
+        public bool IsAnimated
+        {
+            get { return Translation.HasData || Rotation.HasData || Scale.HasData; }
+        }
 
         /// <summary>Bit 0x08. A billboarded bone is re-oriented towards the viewer every frame by
         /// the legacy viewport; at rest it is an ordinary bone, which is all this milestone
@@ -168,6 +232,26 @@ namespace Wmv.Wow
         /// <summary>Number of bones the header declares. Equal to Bones.Length whenever the bones
         /// are in the .m2 itself.</summary>
         public int BoneCount;
+
+        /// <summary>The model's animation sequence table.</summary>
+        public M2Sequence[] Sequences = new M2Sequence[0];
+
+        /// <summary>
+        /// Durations, in milliseconds, of the model's global sequences. A track bound to one loops
+        /// over that duration on a clock of its own, independent of the animation being played --
+        /// which is how a torch flickers at its own rate whatever the creature is doing.
+        /// </summary>
+        public uint[] GlobalSequences = new uint[0];
+
+        /// <summary>
+        /// Which sequence the bone tracks above were parsed for, or -1 when none was. This is the
+        /// idle the legacy viewport itself would select: the first sequence whose AnimId is 0
+        /// ("Stand"), falling back to sequence 0 when the model has no such entry.
+        /// </summary>
+        public int AnimatedSequence = -1;
+
+        /// <summary>Why no sequence was parsed, for the log. Null when one was.</summary>
+        public string AnimationSkipReason;
 
         /// <summary>
         /// The SKID chunk: the FileDataID of a separate skeleton (.skel) file. Non-zero means the

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
@@ -33,14 +33,29 @@ namespace Wmv.Wow
         const int MaterialStride = 4;
 
         // One M2 bone on disk: keyBoneId(4) flags(4) parent(2) submeshId(2) boneNameCRC(4),
-        // three animation tracks of 20 bytes each, then the pivot (12). 88 bytes in total, and
-        // the pivot -- the only part a bind pose needs -- sits at the end of it.
+        // three animation tracks of 20 bytes each, then the pivot (12). 88 bytes in total.
         const int BoneStride = 88;
+        const int OfsBoneTranslation = 16;
+        const int OfsBoneRotation = 36;
+        const int OfsBoneScale = 56;
         const int OfsBonePivot = 76;
+
+        // A bone track's header is interpolation(2) globalSeq(2) then two nested M2Arrays -- the
+        // timestamps and the values, each an array with ONE ENTRY PER ANIMATION SEQUENCE. It is
+        // the same 20 bytes as TrackStride, declared below for the colour and weight tracks.
+        const int SequenceStride = 64;      // one entry of the animation sequence table
+        const int PackedQuatStride = 8;     // a rotation key: four int16
+        const int Vec3Stride = 12;          // a translation or scale key
+
+        /// <summary>The AnimId the legacy viewport looks for when picking a model's default
+        /// animation ("Stand"). See ResolveIdleSequence.</summary>
+        const int AnimIdStand = 0;
 
         // MD20 header offsets (relative to the MD21 payload)
         const int OfsName = 0x08;
         const int OfsGlobalFlags = 0x10;
+        const int OfsGlobalSequences = 0x14;
+        const int OfsSequences = 0x1C;
         const int OfsBones = 0x2C;
         const int OfsVertices = 0x3C;
         const int OfsNumSkinProfiles = 0x44;
@@ -102,6 +117,21 @@ namespace Wmv.Wow
             c.Seek(OfsGlobalFlags);
             model.GlobalFlags = c.ReadUInt32();
 
+            c.Seek(OfsGlobalSequences);
+            M2Array globalSeqs = c.ReadArray();
+            c.RequireArray(globalSeqs, 4, "global sequences");
+            model.GlobalSequences = new uint[globalSeqs.Count];
+            for (int i = 0; i < globalSeqs.Count; i++)
+            {
+                c.Seek(globalSeqs.Offset + i * 4);
+                model.GlobalSequences[i] = c.ReadUInt32();
+            }
+
+            c.Seek(OfsSequences);
+            M2Array sequences = c.ReadArray();
+            c.RequireArray(sequences, SequenceStride, "sequences");
+            model.Sequences = ReadSequences(c, sequences);
+
             c.Seek(OfsBones);
             M2Array bones = c.ReadArray();
             model.BoneCount = bones.Count;
@@ -111,7 +141,13 @@ namespace Wmv.Wow
             if (model.SkeletonFileDataID == 0)
             {
                 c.RequireArray(bones, BoneStride, "bones");
-                model.Bones = ReadBones(c, bones);
+                model.AnimatedSequence = ResolveIdleSequence(model, file, chunks,
+                                                             out model.AnimationSkipReason);
+                model.Bones = ReadBones(c, bones, model);
+            }
+            else
+            {
+                model.AnimationSkipReason = "its bones and animations live in a separate skeleton file";
             }
 
             c.Seek(OfsNumSkinProfiles);
@@ -357,19 +393,31 @@ namespace Wmv.Wow
         /// than left to blow up downstream -- the legacy viewport sanitises the same field for the
         /// same reason, since a bad parent otherwise recurses off the end of its bone vector.
         /// </summary>
-        static M2BoneDef[] ReadBones(ByteCursor c, M2Array arr)
+        static M2BoneDef[] ReadBones(ByteCursor c, M2Array arr, M2ParsedModel model)
         {
+            int seq = model.AnimatedSequence;
             var bones = new M2BoneDef[arr.Count];
             for (int i = 0; i < arr.Count; i++)
             {
-                c.Seek(arr.Offset + i * BoneStride);
+                int bone = arr.Offset + i * BoneStride;
+                c.Seek(bone);
                 bones[i].KeyBoneId = c.ReadInt32();
                 bones[i].Flags = c.ReadUInt32();
                 short parent = c.ReadInt16();
                 bones[i].Parent = (parent >= 0 && parent < arr.Count && parent != i) ? parent : (short)-1;
                 bones[i].SubmeshId = c.ReadUInt16();
-                c.Seek(arr.Offset + i * BoneStride + OfsBonePivot);
+                c.Seek(bone + OfsBonePivot);
                 bones[i].Pivot = new WowVec3(c.ReadSingle(), c.ReadSingle(), c.ReadSingle());
+
+                if (seq >= 0)
+                {
+                    bones[i].Translation = ReadTrack<WowVec3>(c, bone + OfsBoneTranslation, seq,
+                                                              Vec3Stride, ReadVec3);
+                    bones[i].Rotation = ReadTrack<WowQuat>(c, bone + OfsBoneRotation, seq,
+                                                           PackedQuatStride, ReadPackedQuat);
+                    bones[i].Scale = ReadTrack<WowVec3>(c, bone + OfsBoneScale, seq,
+                                                        Vec3Stride, ReadVec3);
+                }
             }
 
             // A parent chain that loops is a forest no more, and a renderer asked to parent one
@@ -384,6 +432,196 @@ namespace Wmv.Wow
                     bones[i].Parent = -1;
             }
             return bones;
+        }
+
+        delegate T ReadValue<T>(ByteCursor c);
+
+        static WowVec3 ReadVec3(ByteCursor c)
+        {
+            return new WowVec3(c.ReadSingle(), c.ReadSingle(), c.ReadSingle());
+        }
+
+        /// <summary>
+        /// A rotation as the file stores it: four int16 in x, y, z, w order, each mapping the
+        /// 16-bit range onto [-1, 1]. The halves are offset by one either side of zero, which is
+        /// how the legacy viewport unpacks them too (Quat16ToQuat32).
+        /// </summary>
+        static WowQuat ReadPackedQuat(ByteCursor c)
+        {
+            float x = UnpackQuatComponent(c.ReadInt16());
+            float y = UnpackQuatComponent(c.ReadInt16());
+            float z = UnpackQuatComponent(c.ReadInt16());
+            float w = UnpackQuatComponent(c.ReadInt16());
+            return new WowQuat(x, y, z, w);
+        }
+
+        static float UnpackQuatComponent(short v)
+        {
+            return (v < 0 ? v + 32768 : v - 32767) / 32767f;
+        }
+
+        /// <summary>
+        /// Read one animation track, narrowed to a single sequence.
+        ///
+        /// The header is interpolation(2), globalSequence(2), then two M2Arrays: timestamps and
+        /// values. Each of those is an array of ARRAYS -- one per animation sequence -- so the
+        /// keys for sequence n are found by taking entry n of both. A track bound to a global
+        /// sequence is read at entry 0 instead, whatever is playing, which is what the legacy
+        /// evaluator does with it (Animated::getValue forces the index to 0 for those).
+        ///
+        /// Anything malformed produces an empty track rather than an exception: a bone that will
+        /// not move is a far better outcome than a model that will not load, and the caller
+        /// already treats an empty track as "hold the rest pose".
+        /// </summary>
+        static M2Track<T> ReadTrack<T>(ByteCursor c, int offset, int sequence, int valueStride,
+                                       ReadValue<T> readValue)
+        {
+            M2Track<T> track = new M2Track<T>();
+            track.Times = EmptyTimes;
+            track.Values = new T[0];
+
+            c.Seek(offset);
+            track.Interpolation = (M2Interpolation)c.ReadInt16();
+            track.GlobalSequence = c.ReadInt16();
+            M2Array times = c.ReadArray();
+            M2Array values = c.ReadArray();
+
+            // A global-sequence track keeps its keys at entry 0, whichever animation is playing.
+            int entry = track.IsGlobal ? 0 : sequence;
+            if (entry >= times.Count || entry >= values.Count)
+                return track;
+
+            // Each entry is itself an M2Array: count then offset.
+            const int NestedStride = 8;
+            if (!Fits(c, times.Offset, times.Count, NestedStride) ||
+                !Fits(c, values.Offset, values.Count, NestedStride))
+                return track;
+
+            c.Seek(times.Offset + entry * NestedStride);
+            M2Array keyTimes = c.ReadArray();
+            c.Seek(values.Offset + entry * NestedStride);
+            M2Array keyValues = c.ReadArray();
+
+            int n = keyTimes.Count < keyValues.Count ? keyTimes.Count : keyValues.Count;
+            if (n <= 0 || !Fits(c, keyTimes.Offset, n, 4) || !Fits(c, keyValues.Offset, n, valueStride))
+                return track;
+
+            // Hermite and Bezier store three values per key (the value and two tangents); this
+            // milestone reads the value and interpolates it linearly, which is what those degrade
+            // to without their tangents. No bone track in the validation data uses either.
+            int stride = (track.Interpolation == M2Interpolation.Hermite ||
+                          track.Interpolation == M2Interpolation.Bezier) ? valueStride * 3 : valueStride;
+            if (!Fits(c, keyValues.Offset, n, stride))
+                return track;
+
+            var t = new uint[n];
+            var v = new T[n];
+            for (int i = 0; i < n; i++)
+            {
+                c.Seek(keyTimes.Offset + i * 4);
+                t[i] = c.ReadUInt32();
+                c.Seek(keyValues.Offset + i * stride);
+                v[i] = readValue(c);
+            }
+            track.Times = t;
+            track.Values = v;
+            return track;
+        }
+
+        static readonly uint[] EmptyTimes = new uint[0];
+
+        /// <summary>Does an array of count*stride bytes at offset lie inside the payload?</summary>
+        static bool Fits(ByteCursor c, int offset, int count, int stride)
+        {
+            if (offset < 0 || count < 0 || stride <= 0)
+                return false;
+            long end = (long)offset + (long)count * stride;
+            return end <= c.Length;
+        }
+
+        static M2Sequence[] ReadSequences(ByteCursor c, M2Array arr)
+        {
+            var seqs = new M2Sequence[arr.Count];
+            for (int i = 0; i < arr.Count; i++)
+            {
+                c.Seek(arr.Offset + i * SequenceStride);
+                seqs[i].AnimId = c.ReadInt16();
+                seqs[i].SubAnimId = c.ReadInt16();
+                seqs[i].Length = c.ReadUInt32();
+                c.ReadSingle();                     // moveSpeed
+                seqs[i].Flags = c.ReadUInt32();
+            }
+            return seqs;
+        }
+
+        /// <summary>
+        /// Which sequence to parse bone tracks for: the model's default idle.
+        ///
+        /// This is the legacy viewport's own rule (AnimControl::UpdateModel): the FIRST sequence
+        /// whose AnimId is "Stand", falling back to sequence 0 when the model has none. It is not
+        /// the same as "sequence 0" -- on chicken2 that is a run cycle and the idle is sequence 2.
+        ///
+        /// A sequence whose keyframes live in a separate .anim file, named by an AFID entry for
+        /// its (AnimId, SubAnimId), is refused: the offsets inside its track headers address that
+        /// file, not this one, and following them here would read whatever happens to sit at those
+        /// bytes of the model. Fetching .anim files is a later milestone.
+        /// </summary>
+        static int ResolveIdleSequence(M2ParsedModel model, byte[] file,
+                                       Dictionary<string, M2Array> chunks, out string skipReason)
+        {
+            skipReason = null;
+            if (model.Sequences.Length == 0)
+            {
+                skipReason = "it declares no animation sequences";
+                return -1;
+            }
+
+            int idle = 0;
+            for (int i = 0; i < model.Sequences.Length; i++)
+            {
+                if (model.Sequences[i].AnimId == AnimIdStand)
+                {
+                    idle = i;
+                    break;
+                }
+            }
+
+            if (model.Sequences[idle].Length == 0)
+            {
+                skipReason = "its idle sequence has zero length";
+                return -1;
+            }
+            if (HasExternalAnimFile(file, chunks, model.Sequences[idle]))
+            {
+                skipReason = "its idle sequence keeps its keyframes in a separate .anim file, " +
+                             "which this milestone does not fetch";
+                return -1;
+            }
+            return idle;
+        }
+
+        /// <summary>Does the AFID chunk name an .anim file for this sequence?</summary>
+        static bool HasExternalAnimFile(byte[] file, Dictionary<string, M2Array> chunks, M2Sequence seq)
+        {
+            M2Array afid;
+            if (!chunks.TryGetValue("AFID", out afid))
+                return false;
+            // Each entry is animId(2) subAnimId(2) fileId(4).
+            for (int i = 0; i + 8 <= afid.Count; i += 8)
+            {
+                int o = afid.Offset + i;
+                if (o + 4 > file.Length)
+                    break;
+                if (ReadUInt16At(file, o) == (ushort)seq.AnimId &&
+                    ReadUInt16At(file, o + 2) == (ushort)seq.SubAnimId)
+                    return true;
+            }
+            return false;
+        }
+
+        static ushort ReadUInt16At(byte[] file, int offset)
+        {
+            return (ushort)(file[offset] | (file[offset + 1] << 8));
         }
 
         static M2TextureDef[] ReadTextures(ByteCursor c, M2Array arr, M2ParsedModel model)

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/WowCoordinateConverter.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/WowCoordinateConverter.cs
@@ -50,6 +50,40 @@ namespace Wmv.Wow
         }
 
         /// <summary>
+        /// Convert a WoW rotation.
+        ///
+        /// A rotation is NOT converted like a position, and this is the one place in the renderer
+        /// where that matters. The axis map above has determinant -1: it mirrors. Conjugating a
+        /// rotation by a mirror gives a rotation about the mapped axis but turning the OTHER WAY,
+        /// so the axis is remapped and the angle negated. In quaternion terms, with the vector
+        /// part v = sin(a/2) * axis,
+        ///
+        ///     unity = (w, -M*v)  where  M*v = (-v.y, v.z, v.x)
+        ///           = (w,  v.y, -v.z, -v.x)
+        ///
+        /// Getting this wrong does not look subtly off; it looks like the model turning inside
+        /// out, which is why WowParserTests checks it against the matrix route.
+        /// </summary>
+        public static void ConvertRotation(WowQuat wow, out float x, out float y, out float z, out float w)
+        {
+            x = wow.Y;
+            y = -wow.Z;
+            z = -wow.X;
+            w = wow.W;
+        }
+
+        /// <summary>
+        /// Convert a WoW per-axis scale. A scale is diagonal, so the axis map permutes its
+        /// components and the sign flip cancels with itself -- magnitudes only, never negated.
+        /// </summary>
+        public static void ConvertScale(WowVec3 wow, out float x, out float y, out float z)
+        {
+            x = wow.Y;
+            y = wow.Z;
+            z = wow.X;
+        }
+
+        /// <summary>
         /// WoW texture coordinates have V running down from the top; Unity's run up from the
         /// bottom, so V is flipped once, here.
         /// </summary>

--- a/Tools/UnityRendererProject/README.md
+++ b/Tools/UnityRendererProject/README.md
@@ -237,6 +237,68 @@ drawn as a static mesh and the log says exactly that — as it does for any othe
 refuses. Reading the header's bone array anyway would be worse than not skinning: the vertices are
 not indexed against it.
 
+## The idle animation
+
+One animation plays: the model's default idle. There is no sequence selector, no blending and no
+UI — this is the smallest thing that makes a creature look alive, built on the skeleton above.
+
+**Which sequence is "the idle" is not sequence 0.** The legacy viewport picks the FIRST sequence
+whose `AnimId` is 0 ("Stand") and falls back to sequence 0 only when the model has none
+(`AnimControl::UpdateModel`). The difference is not academic: on `creature/chicken2` sequence 0 is
+a run cycle and the idle is sequence 2; on `creature/valkier` it is sequence 11.
+
+**How a track is stored.** A bone carries three tracks — translation, rotation, scale — and each is
+an array of *per-sequence* keyframe arrays. The keys for sequence *n* are entry *n* of both the
+timestamp array and the value array. Only the sequence being played is parsed: a boss with 109
+sequences would otherwise cost a hundred times the memory to play one of them. Rotations are four
+`int16` mapping onto [-1, 1], with the halves offset either side of zero, unpacked exactly as
+`Quat16ToQuat32` does.
+
+**How it is evaluated,** following `Animated::getValue` case for case: fewer than two keys holds
+the first value; a time past the last key holds the last (a track need not span the sequence);
+otherwise the span containing the time is found and interpolated. `None` steps, `Linear`
+interpolates — and *slerps* for rotations, which is what the legacy evaluator specialises it to.
+`Hermite` and `Bezier` store two extra tangents per key that this milestone does not read; their
+values are interpolated linearly and the count is logged. No bone track in any validation model
+uses either.
+
+**Global sequences are not optional.** A track can be bound to one instead of the animation, and
+then it loops over that sequence's own duration on a clock that ignores what is playing — a
+torch flickering at its own rate whatever the creature does. Such a track keeps its keys at entry
+0 whichever sequence is playing, and its time is `globalTime % duration`; both are reproduced. Of
+the validation models, `creature/valkier` drives 61 of its tracks this way. A global sequence of
+**zero** length exists in shipped data (`creature/wrathofazshara` has one): the legacy evaluator
+returns a default-constructed value for it, which is right for a translation and collapses a bone
+to a point for a scale, so this holds the first keyframe instead.
+
+**Where the animation is applied.** Not through an Animator Controller: Unity's animation system
+wants clips authored at build time, and a player build strips them, whereas this renderer receives
+its model over IPC at runtime. `WmvM2Animator` writes the bones directly, which is both less
+machinery and closer to what the legacy viewport does:
+
+```
+bone.localPosition = restLocalPosition + translation(t)
+bone.localRotation = rotation(t)
+bone.localScale    = scale(t)
+```
+
+That is the same expression the skinning section derives, with the tracks filled in instead of left
+at rest, so **the bind poses do not change and a bone with no track simply holds its rest
+transform**. Only bones that actually move are driven: a 236-bone boss moves 114 of them in its
+idle, and the rest would be identical writes every frame.
+
+**A rotation is not converted like a position.** The axis map mirrors (determinant -1), so
+conjugating a rotation by it remaps the axis *and reverses the turn*. `ConvertRotation` is where
+that lives, and `WowParserTests` checks it against the matrix route rather than trusting the
+algebra — a sign error there does not look subtly wrong, it looks like the model turning inside
+out.
+
+**What is not animated.** Only bones. Texture animation, colour and transparency tracks, particles,
+ribbons and attachments are untouched, as is anything belonging to characters or equipment. A model
+whose idle keeps its keyframes in a separate `.anim` file is not animated and says so; over a
+spread of 300 retail creature models that is a small minority, and fetching those files is a later
+milestone.
+
 ## Debug switches
 
 Pass these on the player command line to isolate a visual fault without rebuilding. They are also
@@ -253,7 +315,9 @@ process inherits the environment:
 | `-wmvShowHidden` | draw the batches the model hides at rest — shows *what* is hidden, and usually what it was covering |
 | `-wmvOwnShader` | resolve the renderer's own `WmvOpaque` shader ahead of any pipeline shader — the only one that can run an M2 combiner |
 | `-wmvNoSkin` | build every model as a static mesh, as before skinning existed — the A/B for "did the skinned path change what I see?" |
-| `-wmvSkinCheck` | bake the skinned result and report the largest distance between a baked vertex and the position the file gave it. At rest that distance is the milestone's whole claim, so it is measurable rather than asserted |
+| `-wmvSkinCheck` | bake the skinned result and report the largest distance between a baked vertex and the position the file gave it. Pair it with `-wmvNoAnim`: a moving model is not in its rest pose |
+| `-wmvNoAnim` | do not play anything. The model is still skinned, and still sits in the rest pose the bind poses describe |
+| `-wmvAnimCheck` | sample the idle across its length and report how far the skinned mesh moves from its rest pose, next to the model's own size. Zero everywhere means nothing animates; a number far larger than the model means the rig is being applied wrongly — both look like an ordinary still frame otherwise |
 
 Each model load also logs its UV sample, per-batch material/blend/texture-slot mapping, the alpha
 treatment per texture, which batches are hidden at rest and why, the resolved combiner and per-unit
@@ -274,6 +338,7 @@ to (or why it was not).
 | `Wow/WowCoordinateConverter.cs` | The single WoW -> Unity axis/winding/UV conversion. |
 | `Assets/Resources/WmvOpaque.shader` | The renderer's own textured shader, kept under `Resources/` so a player build cannot strip it. One variant, everything uniform-driven: `_SrcBlend`/`_DstBlend`/`_ZWrite`/`_Cull`/`_Cutoff` as real properties, plus `_CombinerMode`, `_Unit1UV`, `_AlphaMode`/`_AlphaScale` and `_OpaqueAlpha` for the second texture unit and the M2 combiners. |
 | `Wow/ByteCursor.cs` | Bounds-checked little-endian reader shared by the parsers. |
+| `WmvM2Animator.cs` | Plays the model's default idle by writing bone transforms each frame: sequence selection, track evaluation, global sequences and looping. No Animator Controller, no clips, nothing written to disk. |
 | `WmvOrbitCamera.cs` | Orbit / pan / zoom controls plus bounds-driven framing of a loaded model. |
 
 The parsing layer under `Assets/Scripts/Wow/` deliberately has no `UnityEngine` dependency, so

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -132,11 +132,13 @@ namespace Wmv.Wow.Tests
             return b;
         }
 
-        static byte[] WrapChunked(byte[] md20Payload, int[] sfid, int[] txid, int skid = 0)
+        static byte[] WrapChunked(byte[] md20Payload, int[] sfid, int[] txid, int skid = 0,
+                                  int afidAnimId = -1)
         {
             int total = 8 + md20Payload.Length + (sfid != null ? 8 + sfid.Length * 4 : 0)
                                                + (txid != null ? 8 + txid.Length * 4 : 0)
-                                               + (skid != 0 ? 12 : 0);
+                                               + (skid != 0 ? 12 : 0)
+                                               + (afidAnimId >= 0 ? 16 : 0);
             var b = new byte[total];
             int o = 0;
             PutMagic(b, o, "MD21"); PutU32(b, o + 4, (uint)md20Payload.Length); o += 8;
@@ -156,7 +158,99 @@ namespace Wmv.Wow.Tests
                 PutMagic(b, o, "SKID"); PutU32(b, o + 4, 4); o += 8;
                 PutU32(b, o, (uint)skid); o += 4;
             }
+            if (afidAnimId >= 0)
+            {
+                // One entry: animId(2) subAnimId(2) fileId(4).
+                PutMagic(b, o, "AFID"); PutU32(b, o + 4, 8); o += 8;
+                PutU16(b, o, (ushort)afidAnimId); PutU16(b, o + 2, 0);
+                PutU32(b, o + 4, 999999); o += 8;
+            }
             return b;
+        }
+
+        /// <summary>One int16 of a packed quaternion. 1.0 encodes as -1, 0.0 as 32767.</summary>
+        static void PutQuatComponent(byte[] b, int o, float value)
+        {
+            int v = value >= 0.999f ? -1 : (int)Math.Round(value * 32767f) + 32767;
+            PutU16(b, o, unchecked((ushort)v));
+        }
+
+        /// <summary>
+        /// A model with a real sequence table, two global sequences, and bone tracks: bone 0 holds
+        /// still, bone 1 has an ordinary rotation track on the idle sequence, and bone 2 has a
+        /// translation track bound to global sequence 1.
+        /// </summary>
+        static byte[] BuildAnimatedM2(short[] animIds, bool standTrack, int afidAnimId = -1)
+        {
+            int nSeq = animIds.Length;
+            byte[] b = BuildM2Payload(3, boneCount: 3);
+            int boneOffset = 0x100 + 3 * 48 + 16 + 4 + 2;
+
+            // Which sequence the parser will pick, so the fixture can put its keys there.
+            int idle = 0;
+            for (int i = 0; i < nSeq; i++)
+                if (animIds[i] == 0) { idle = i; break; }
+
+            int baseLen = b.Length;
+            int oGlobals = baseLen;                      // 2 uint32
+            int oSeqs = oGlobals + 8;                    // nSeq * 64
+            int oRotTimeHdr = oSeqs + nSeq * 64;         // nSeq * 8
+            int oRotKeyHdr = oRotTimeHdr + nSeq * 8;     // nSeq * 8
+            int oRotTimes = oRotKeyHdr + nSeq * 8;       // 2 * 4
+            int oRotKeys = oRotTimes + 8;                // 2 * 8
+            int oTransTimeHdr = oRotKeys + 16;           // 1 * 8
+            int oTransKeyHdr = oTransTimeHdr + 8;        // 1 * 8
+            int oTransTimes = oTransKeyHdr + 8;          // 2 * 4
+            int oTransKeys = oTransTimes + 8;            // 2 * 12
+            int total = oTransKeys + 24;
+            Array.Resize(ref b, total);
+
+            PutU32(b, oGlobals, 1000); PutU32(b, oGlobals + 4, 500);
+            PutU32(b, 0x14, 2); PutU32(b, 0x18, (uint)oGlobals);
+
+            for (int i = 0; i < nSeq; i++)
+            {
+                int o = oSeqs + i * 64;
+                PutU16(b, o, unchecked((ushort)animIds[i]));   // animId
+                PutU16(b, o + 2, 0);                            // subAnimId
+                PutU32(b, o + 4, 1000);                         // length
+                PutU32(b, o + 12, 0x20);                        // flags
+            }
+            PutU32(b, 0x1C, (uint)nSeq); PutU32(b, 0x20, (uint)oSeqs);
+
+            // bone 1: rotation, linear, ordinary track with keys on the idle sequence only
+            int rot = boneOffset + 1 * 88 + 36;
+            PutU16(b, rot, 1);                                  // interpolation: linear
+            PutU16(b, rot + 2, 0xFFFF);                         // globalSequence: -1
+            PutU32(b, rot + 4, (uint)nSeq); PutU32(b, rot + 8, (uint)oRotTimeHdr);
+            PutU32(b, rot + 12, (uint)nSeq); PutU32(b, rot + 16, (uint)oRotKeyHdr);
+            if (standTrack)
+            {
+                PutU32(b, oRotTimeHdr + idle * 8, 2);
+                PutU32(b, oRotTimeHdr + idle * 8 + 4, (uint)oRotTimes);
+                PutU32(b, oRotKeyHdr + idle * 8, 2);
+                PutU32(b, oRotKeyHdr + idle * 8 + 4, (uint)oRotKeys);
+            }
+            PutU32(b, oRotTimes, 0); PutU32(b, oRotTimes + 4, 400);
+            for (int k = 0; k < 2; k++)
+            {
+                int o = oRotKeys + k * 8;
+                PutQuatComponent(b, o, 0f); PutQuatComponent(b, o + 2, 0f);
+                PutQuatComponent(b, o + 4, 0f); PutQuatComponent(b, o + 6, 1f);
+            }
+
+            // bone 2: translation bound to global sequence 1, keys at entry 0
+            int tr = boneOffset + 2 * 88 + 16;
+            PutU16(b, tr, 1);
+            PutU16(b, tr + 2, 1);                               // globalSequence 1
+            PutU32(b, tr + 4, 1); PutU32(b, tr + 8, (uint)oTransTimeHdr);
+            PutU32(b, tr + 12, 1); PutU32(b, tr + 16, (uint)oTransKeyHdr);
+            PutU32(b, oTransTimeHdr, 2); PutU32(b, oTransTimeHdr + 4, (uint)oTransTimes);
+            PutU32(b, oTransKeyHdr, 2); PutU32(b, oTransKeyHdr + 4, (uint)oTransKeys);
+            PutU32(b, oTransTimes, 0); PutU32(b, oTransTimes + 4, 250);
+            PutF32(b, oTransKeys + 12, 1f);                     // second key moves 1 unit on X
+
+            return WrapChunked(b, null, null, 0, afidAnimId);
         }
 
         /// <summary>Skin with `vertexCount` lookup entries and one submesh covering `triangles`.</summary>
@@ -248,6 +342,8 @@ namespace Wmv.Wow.Tests
             VisibilityTests();
             log.Add("Bones");
             BoneTests();
+            log.Add("Animation");
+            AnimationTests();
 
             log.Add(failures == 0 ? "ALL TESTS PASSED" : (failures + " TEST(S) FAILED"));
             if (output != null)
@@ -300,6 +396,148 @@ namespace Wmv.Wow.Tests
             var badChunk = WrapChunked(BuildM2Payload(1), null, null);
             PutU32(badChunk, 4, (uint)(badChunk.Length * 4));
             Throws<WowParseException>(() => M2Parser.Parse(badChunk), "M2: oversized chunk rejected");
+        }
+
+        /// <summary>
+        /// The rotation conversion, verified the long way round.
+        ///
+        /// A quaternion formula that mixes up a sign is not something you can eyeball, so this
+        /// builds the rotation matrix in WoW space, conjugates it by the axis map (R_unity =
+        /// M * R_wow * M^-1, the definition of "the same rotation seen in the other basis"), and
+        /// checks the converted quaternion produces that same matrix. If ConvertRotation ever
+        /// drifts, this fails with an actual number rather than a model that looks wrong.
+        /// </summary>
+        static void RotationConversionTests()
+        {
+            // A handful of rotations about assorted axes, none of them axis-aligned by accident.
+            float[][] axes =
+            {
+                new[] { 0f, 0f, 1f }, new[] { 1f, 0f, 0f }, new[] { 0f, 1f, 0f },
+                new[] { 0.267f, 0.535f, 0.802f }, new[] { -0.577f, 0.577f, -0.577f },
+            };
+            float[] angles = { 0.3f, 1.1f, -0.7f, 2.4f };
+            int checkedCases = 0;
+            float worst = 0f;
+
+            foreach (float[] axis in axes)
+            {
+                foreach (float angle in angles)
+                {
+                    float s = (float)Math.Sin(angle / 2), cw = (float)Math.Cos(angle / 2);
+                    var q = new WowQuat(axis[0] * s, axis[1] * s, axis[2] * s, cw);
+
+                    float[,] rWow = MatrixFromQuat(q.X, q.Y, q.Z, q.W);
+                    float[,] expected = Conjugate(rWow);
+
+                    float ux, uy, uz, uw;
+                    WowCoordinateConverter.ConvertRotation(q, out ux, out uy, out uz, out uw);
+                    float[,] actual = MatrixFromQuat(ux, uy, uz, uw);
+
+                    for (int r = 0; r < 3; r++)
+                        for (int cc = 0; cc < 3; cc++)
+                            worst = Math.Max(worst, Math.Abs(expected[r, cc] - actual[r, cc]));
+                    checkedCases++;
+                }
+            }
+            Check(worst < 1e-4f, "coords: rotation conversion matches the matrix route (worst " +
+                                 worst.ToString("E2") + " over " + checkedCases + " cases)");
+
+            // A unit quaternion must stay one: the map is a permutation with signs, nothing more.
+            float qx, qy, qz, qw;
+            WowCoordinateConverter.ConvertRotation(new WowQuat(0.5f, 0.5f, 0.5f, 0.5f),
+                                                   out qx, out qy, out qz, out qw);
+            Near((float)Math.Sqrt(qx * qx + qy * qy + qz * qz + qw * qw), 1f,
+                 "coords: rotation stays unit length");
+
+            // Identity in, identity out -- the rest pose depends on it.
+            WowCoordinateConverter.ConvertRotation(WowQuat.Identity, out qx, out qy, out qz, out qw);
+            Check(Math.Abs(qx) < 1e-6f && Math.Abs(qy) < 1e-6f && Math.Abs(qz) < 1e-6f &&
+                  Math.Abs(qw - 1f) < 1e-6f, "coords: identity rotation is unchanged");
+
+            // Scale permutes with the axes and is never negated.
+            float sx, sy, sz;
+            WowCoordinateConverter.ConvertScale(new WowVec3(2f, 3f, 4f), out sx, out sy, out sz);
+            Check(sx == 3f && sy == 4f && sz == 2f, "coords: scale follows the axis permutation");
+        }
+
+        /// <summary>Rotation matrix from a quaternion, columns in x/y/z order.</summary>
+        static float[,] MatrixFromQuat(float x, float y, float z, float w)
+        {
+            return new float[3, 3]
+            {
+                { 1 - 2 * (y * y + z * z), 2 * (x * y - z * w),     2 * (x * z + y * w) },
+                { 2 * (x * y + z * w),     1 - 2 * (x * x + z * z), 2 * (y * z - x * w) },
+                { 2 * (x * z - y * w),     2 * (y * z + x * w),     1 - 2 * (x * x + y * y) },
+            };
+        }
+
+        /// <summary>M * m * M^-1 for the WoW->Unity axis map (x,y,z) -> (-y, z, x).</summary>
+        static float[,] Conjugate(float[,] m)
+        {
+            // M as a matrix, and its inverse (which is its transpose: it is orthogonal).
+            float[,] M = { { 0, -1, 0 }, { 0, 0, 1 }, { 1, 0, 0 } };
+            float[,] Mt = { { 0, 0, 1 }, { -1, 0, 0 }, { 0, 1, 0 } };
+            return Multiply(Multiply(M, m), Mt);
+        }
+
+        static float[,] Multiply(float[,] a, float[,] b)
+        {
+            var r = new float[3, 3];
+            for (int i = 0; i < 3; i++)
+                for (int j = 0; j < 3; j++)
+                    for (int k = 0; k < 3; k++)
+                        r[i, j] += a[i, k] * b[k, j];
+            return r;
+        }
+
+        static void AnimationTests()
+        {
+            RotationConversionTests();
+
+            // Sequence table and the idle rule: the FIRST sequence whose animId is 0, not
+            // sequence 0. The fixture puts "Stand" third on purpose.
+            byte[] file = BuildAnimatedM2(new[] { (short)5, (short)4, (short)0, (short)1 },
+                                          standTrack: true);
+            M2ParsedModel m = M2Parser.Parse(file);
+            Check(m.Sequences.Length == 4, "anim: sequence table read");
+            Check(m.Sequences[0].AnimId == 5 && m.Sequences[0].Length == 1000, "anim: sequence fields read");
+            Check(m.AnimatedSequence == 2, "anim: idle is the first Stand sequence, not sequence 0");
+            Check(m.AnimationSkipReason == null, "anim: nothing skipped");
+            Check(m.GlobalSequences.Length == 2 && m.GlobalSequences[1] == 500,
+                  "anim: global sequences read");
+
+            // The track for that sequence, and only that sequence.
+            M2Track<WowQuat> rot = m.Bones[1].Rotation;
+            Check(rot.HasData, "anim: bone rotation track read for the idle");
+            Check(rot.Times.Length == 2 && rot.Times[1] == 400, "anim: keyframe times read");
+            Check(rot.Interpolation == M2Interpolation.Linear, "anim: interpolation type read");
+            Check(!rot.IsGlobal, "anim: ordinary track is not global");
+            Check(Math.Abs(rot.Values[0].W - 1f) < 1e-3f, "anim: packed quaternion unpacked");
+            Check(m.Bones[1].IsAnimated && !m.Bones[0].IsAnimated,
+                  "anim: only the bone with keys is animated");
+
+            // A track bound to a global sequence reads entry 0 whatever is playing.
+            M2Track<WowVec3> glob = m.Bones[2].Translation;
+            Check(glob.IsGlobal && glob.GlobalSequence == 1, "anim: global sequence id read");
+            Check(glob.HasData && glob.Times.Length == 2, "anim: global track reads entry 0");
+
+            // No Stand sequence -> fall back to sequence 0.
+            M2ParsedModel noStand = M2Parser.Parse(BuildAnimatedM2(new[] { (short)5, (short)4 },
+                                                                   standTrack: false));
+            Check(noStand.AnimatedSequence == 0, "anim: no Stand sequence falls back to sequence 0");
+
+            // A model with no sequences at all is not animated, and says why.
+            M2ParsedModel none = M2Parser.Parse(BuildM2Payload(3, boneCount: 2));
+            Check(none.AnimatedSequence == -1 && none.AnimationSkipReason != null,
+                  "anim: a model with no sequences reports why it is not animated");
+
+            // An idle whose keyframes live in a separate .anim file is refused rather than read
+            // out of the wrong buffer.
+            byte[] external = BuildAnimatedM2(new[] { (short)5, (short)0 }, standTrack: true, afidAnimId: 0);
+            M2ParsedModel ext = M2Parser.Parse(external);
+            Check(ext.AnimatedSequence == -1, "anim: an idle with an AFID entry is skipped");
+            Check(ext.AnimationSkipReason != null && ext.AnimationSkipReason.Contains(".anim"),
+                  "anim: the skip reason names the .anim file");
         }
 
         static void BoneTests()

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -243,15 +243,23 @@ in-process, and shuts the player down. Result lines carry the `[unityipc-test]` 
   result is the static mesh it replaces to within float noise (largest measured deviation across
   the validation models: 3.8e-6 units). Models whose bones live in a separate skeleton file are
   still drawn static, and say so.
+- Idle animation playback: the model's default idle sequence loops on the rig above. The
+  sequence is the one the OpenGL viewport itself would select -- the first whose AnimId is
+  "Stand", not sequence 0 -- and its bone tracks are evaluated the way the legacy evaluator
+  does, including the global sequences that run on their own clock. One animation, no selector
+  and no UI; `-wmvNoAnim` returns the model to the rest pose.
 - Bounds-driven camera framing, so a loaded model is visible immediately.
 
 **Not yet implemented**
 
-- Animation playback. The rig is built and the mesh is skinned to it, but no animation track is
-  read, so nothing moves; sequences, interpolation, timing and an idle loop are the next step.
-- Bones from a separate skeleton file (the SKID chunk, and the SKPD parent it can defer to).
-  Over a spread of 300 retail creature models, 299 keep their bones in the .m2 itself and one
-  does not; that one is drawn unskinned.
+- Choosing an animation. One sequence plays, the default idle; there is no selector, no
+  blending between sequences and no animation UI.
+- Keyframes stored outside the .m2: the .anim files named by the AFID chunk, and bones from a
+  separate skeleton file (the SKID chunk and the SKPD parent it can defer to). A model that
+  needs either is drawn from what it does have -- unskinned, or skinned but still -- and says
+  which.
+- Animation of anything but bones: texture animation, colour and transparency tracks beyond the
+  rest-pose visibility gate, particles, ribbons and attachments.
 - The rest of the WoW material system: texture animation, colour and transparency tracks beyond
   the rest-pose visibility gate, the specular lobes the legacy viewport leaves unweighted by
   default, and the few combiners that mix more than two contributing units.


### PR DESCRIPTION
The rig built by the previous milestone stood still. Creatures now loop their default idle.

Which sequence that is was the first thing worth getting right, and it is NOT sequence 0. The legacy viewport picks the first sequence whose AnimId is 0 ("Stand") and falls back to sequence 0 only when a model has none (AnimControl::UpdateModel). On creature/chicken2 sequence 0 is a run cycle and the idle is sequence 2; on creature/valkier it is sequence 11.

Bone tracks are evaluated the way Animated::getValue does, case for case: fewer than two keys holds the first value, a time past the last key holds the last (a track need not span the sequence), and otherwise the containing span is interpolated -- stepped for "none", interpolated for "linear", and SLERPED rather than lerped for rotations, which is the specialisation the legacy evaluator makes. Hermite and Bezier keep two tangents per key that this milestone does not read; their values are interpolated linearly and the count is logged. No bone track in any validation model uses either.

GLOBAL SEQUENCES ARE IMPLEMENTED, NOT SKIPPED. A track bound to one loops on its own clock regardless of what is playing, and keeps its keys at entry 0 whichever sequence that is; creature/valkier drives 61 of its tracks that way. A global sequence of ZERO length is real shipped data (creature/wrathofazshara has one): the legacy evaluator returns a default-constructed value for it, which is right for a translation and collapses a bone to a point for a scale, so this holds the first keyframe instead.

Only the sequence being played is parsed -- a track on disk is an array of per-sequence keyframe arrays, so a 109-sequence boss would otherwise cost a hundred times the memory to play one of them -- and only bones that actually move are driven.

There is no Animator Controller and no clip. Unity's animation system wants assets authored at build time and a player build strips them, whereas this renderer receives its model over IPC at runtime; the animator writes localPosition/localRotation/localScale straight onto the bones. That is the same expression the skinning milestone derived, with the tracks filled in instead of left at rest, so the bind poses are untouched and a bone with no track holds its rest transform.

One conversion subtlety is worth naming: the WoW-to-Unity axis map MIRRORS, so converting a rotation remaps its axis AND reverses its turn. That is checked against the matrix route (R_unity = M * R_wow * M^-1) in the parser tests rather than trusted -- a sign error there does not look subtly wrong, it looks like the model turning inside out.

Validated with -unityipctest on eight models: all PASS, no exceptions. Every one resolves an AnimId 0 idle, moving 16 to 114 bones over 2000 to 5334 ms. Measured with the new -wmvAnimCheck, which samples the idle across its length and bakes the skinned result, vertices move at most 0.112 of chicken2's 0.718 units and stay bounded on every model -- neither frozen nor flying apart, the two failures that look identical in a still frame. With -wmvNoAnim the rest-pose deviations are unchanged from the skinning milestone to the digit (three models exactly zero, worst 3.8e-6). Selected-skin sync, geoset switching, the hidden-batch gate and material coverage all still hold while animated; creature/orcskeleton exercises the fallback. Over a spread of 300 retail creature models, 298 have an idle playable from the .m2. 108/108 parser tests pass, the player scripts type-check under all four input-backend configurations, and the branch contains no C++ at all, so the OpenGL viewport is untouched.