### PR TITLE
Sync Unity renderer with selected M2 animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Embedded Unity renderer: it plays the animation you picked, not its own idle.** The viewport
+  now follows WMV's animation dropdown -- pick Run, Death or an emote and the Unity pane switches
+  with the canvas, as it already did for skins and geoset variants. The selection travels over IPC
+  as a new `modelAnimation` push carrying the **sequence index**, which is what the keyframes are
+  stored under and what the app's own selector identifies a choice by (its labels end in `[n]`); an
+  animID cannot pick one -- chicken2 carries animID 5 on two sequences, as sub-animations 0 and 1. It is sent from
+  `AnimControl::SelectAnimation`, one funnel that the default picked while a model loads, the
+  dropdown and the loop control all now route through, and again right after the model is sent so
+  the renderer starts on the app's choice instead of being corrected a moment later. On the player
+  side the model's .m2 bytes are kept and re-parsed for the requested sequence, because only one
+  sequence's keyframes are held at a time -- a boss has 109 of them; nothing else moves, so the
+  mesh, its materials, its textures and its geoset selection are untouched by which animation is
+  playing.
+  **Not every sequence can be played from the .m2, and finding out why was the substance of this
+  change.** Bit 0x20 on a sequence means its keyframes are stored in that file; without it they are
+  in a separate .anim file -- and the trap is that such a sequence's track headers are still
+  present, with offsets that address the OTHER file yet land in range often enough that bounds
+  checks pass and the data reads as noise. chicken2's sequence 14 is exactly that and is not even
+  named by an AFID entry, so looking for the keys cannot distinguish it; only the flag can. Those
+  sequences now fall back to the model's idle and log which of the two reasons applied, and a track
+  that slips through anyway degrades to a still bone instead of failing the load.
+  Validated by walking six animations on each of seven models through the app's own selector: the
+  renderer followed every playable one (chicken2's Run, Death, AttackUnarmed, EmoteEat...; horse3's
+  six; valkier's six of 109) and fell back with a reason on the two chicken2 sequences that keep
+  their keys elsewhere.
+
+### Added
 - **Embedded Unity renderer: creatures now play their idle animation.** The rig built by the
   previous milestone stood perfectly still; it now loops the model's default idle. Which sequence
   that is turned out to be the first thing worth getting right: it is NOT sequence 0, but the first

--- a/Source/wowmodelviewer/UnityIpcServer.cpp
+++ b/Source/wowmodelviewer/UnityIpcServer.cpp
@@ -338,6 +338,26 @@ void UnityIpcServer::sendModelSkin(int m2FileDataID)
   queueJson(msg);
 }
 
+void UnityIpcServer::sendModelAnimation(int m2FileDataID, int sequenceIndex, int animID,
+                                        int durationMs, bool loop)
+{
+  if (!m_client || !m_unityReady || sequenceIndex < 0)
+    return;
+
+  QJsonObject msg;
+  msg["type"] = "modelAnimation";
+  msg["fileDataID"] = m2FileDataID;
+  msg["sequenceIndex"] = sequenceIndex;
+  msg["animID"] = animID;
+  msg["durationMs"] = durationMs;
+  msg["loop"] = loop;
+  m_stats.animPushes++;
+  m_stats.lastAnimation = QString("seq %1 animID %2 %3ms").arg(sequenceIndex).arg(animID).arg(durationMs);
+  LOG_INFO << "[unityipc] -> modelAnimation fileDataID=" << m2FileDataID
+           << "sequenceIndex=" << sequenceIndex << "animID=" << animID << "durationMs=" << durationMs;
+  queueJson(msg);
+}
+
 void UnityIpcServer::sendLoadWoWModel(const QString & path, int fileDataID, const QString & client)
 {
   QJsonObject msg;

--- a/Source/wowmodelviewer/UnityIpcServer.h
+++ b/Source/wowmodelviewer/UnityIpcServer.h
@@ -29,6 +29,8 @@
  *     { "type":"modelSkin", "fileDataID":1521037,
  *       "textures":[ { "index":0, "type":11, "fileDataID":1521061, "source":"selection" } ],
  *       "geosets":[ 101 ], "hasGeosets":true }
+ *     { "type":"modelAnimation", "fileDataID":1521037, "sequenceIndex":2, "animID":0,
+ *       "durationMs":2000, "loop":true }
  *
  * getModelTextures exists because modern M2s do NOT name their replaceable textures (a
  * creature skin's TXID entry is 0 and the texture array carries no filename) -- the skin comes
@@ -43,6 +45,13 @@
  * modelSkin is pushed whenever the displayed skin changes (the dropdown, or the default chosen on
  * model load). Same payload as modelTextures, no request: the player swaps the texture and keeps
  * the mesh it already built.
+ *
+ * modelAnimation is pushed the same way whenever the animation on display changes, and once after
+ * loadWoWModel so the player starts on the animation the app is showing rather than on its own
+ * idle. "sequenceIndex" is what the player must act on: it indexes the model's animation table,
+ * which is both how the keyframes are stored and how the app's own selector identifies a choice.
+ * Two sequences routinely share an "animID" (sub-animations of one action), so the id alone
+ * cannot pick one; it is carried for the log and for recognising the idle (animID 0, "Stand").
  *
  * Implementation: plain Winsock2, non-blocking, polled from the GUI thread by a wxTimer (the
  * app has no Qt event loop, so QTcpServer signals would never fire; and GAMEDIRECTORY must be
@@ -97,6 +106,11 @@ public:
   // unasked. No-op when the player is not connected, or when nothing can be resolved.
   void sendModelSkin(int m2FileDataID);
 
+  // Runtime command: the animation on display changed. sequenceIndex indexes the model's
+  // animation table (what the app's own selector picks); animID and durationMs come from that
+  // entry. No-op when the player is not connected.
+  void sendModelAnimation(int m2FileDataID, int sequenceIndex, int animID, int durationMs, bool loop);
+
   // Raised (on the GUI thread) when the player's unityReady arrives -- the host uses it to
   // push the currently displayed model.
   std::function<void()> onUnityReady;
@@ -114,10 +128,12 @@ public:
     int responsesError = 0;
     long long bytesServed = 0;
     int skinPushes = 0;     // modelSkin messages sent (the displayed skin changed)
+    int animPushes = 0;     // modelAnimation messages sent (the displayed animation changed)
     QString lastRequest;    // "path" or "fileDataID n"
     QString lastProvider;   // "CASC" / "MPQ" / ""
     QString lastError;
     QString lastSkin;       // "<fileDataID> (<source>)" of the last skin pushed
+    QString lastAnimation;  // "seq <n> animID <id> <ms>ms" of the last animation pushed
   };
   const Stats & stats() const { return m_stats; }
 

--- a/Source/wowmodelviewer/animcontrol.cpp
+++ b/Source/wowmodelviewer/animcontrol.cpp
@@ -368,13 +368,12 @@ void AnimControl::UpdateModel(WoWModel *m)
       useanim = 0;
     //return;
 
-    g_selModel->currentAnim = useanim; // anim position in anims
     animCList->Select(selectAnim); // anim position in selection
     animCList->Show(true);
 
     UpdateFrameSlider(g_selModel->anims[useanim].length - 1, g_selModel->anims[useanim].playSpeed);
 
-    g_selModel->animManager->SetAnim(0, useanim, 0);
+    SelectAnimation(useanim, 0);
     if (bNextAnims && g_selModel)
     {
       int NextAnimation = useanim;
@@ -1308,9 +1307,8 @@ void AnimControl::OnAnim(wxCommandEvent &event)
       }
 
       if (bOldStyle == true) {
-        g_selModel->currentAnim = selectedAnim;
         g_selModel->animManager->Stop();
-        g_selModel->animManager->SetAnim(0, selectedAnim, loopList->GetSelection());
+        SelectAnimation(selectedAnim, loopList->GetSelection());
         if (bNextAnims && g_selModel) {
           int NextAnimation = selectedAnim;
           for(size_t i=1; i<4; i++) {
@@ -1417,7 +1415,7 @@ void AnimControl::OnLoop(wxCommandEvent &)
 {
   if (bOldStyle == true) {
     g_selModel->animManager->Stop();
-    g_selModel->animManager->SetAnim(0, selectedAnim, loopList->GetSelection());
+    SelectAnimation(selectedAnim, loopList->GetSelection());
     if (bNextAnims && g_selModel) {
       int NextAnimation = selectedAnim;
       for(size_t i=1; i<4; i++) {
@@ -1605,6 +1603,38 @@ void AnimControl::SetSkin(int num)
   // all three. No-op when the Unity pane was never opened.
   if (g_modelViewer)
     g_modelViewer->SendCurrentSkinToUnity();
+}
+
+// Every animation change goes through here. The three callers are the default picked while a
+// model loads, the dropdown, and the loop control; funnelling them means the embedded Unity
+// viewport is told once, from one place, and cannot be left playing something the canvas is not.
+//
+// What is NOT covered, deliberately: a queued "next animation" chain advancing on its own, and
+// play/pause/speed. Those change what the canvas shows without any selection happening, and
+// following them needs the player to be driven per frame rather than per choice -- a different
+// milestone.
+void AnimControl::SelectAnimation(int index, int loops)
+{
+  if (!g_selModel || index < 0 || index >= (int)g_selModel->anims.size())
+    return;
+
+  g_selModel->currentAnim = index;
+  g_selModel->animManager->SetAnim(0, index, loops);
+
+  if (g_modelViewer)
+    g_modelViewer->SendCurrentAnimationToUnity();
+}
+
+int AnimControl::animationCount()
+{
+  return animCList ? (int)animCList->GetCount() : 0;
+}
+
+wxString AnimControl::animationName(int index)
+{
+  if (!animCList || index < 0 || index >= (int)animCList->GetCount())
+    return wxEmptyString;
+  return animCList->GetString(index);
 }
 
 void AnimControl::SetSingleSkin(int num, int texnum)

--- a/Source/wowmodelviewer/animcontrol.h
+++ b/Source/wowmodelviewer/animcontrol.h
@@ -174,6 +174,19 @@ public:
   int skinCount();
   wxString skinName(int index);
 
+
+  // THE funnel for animation selection. Everything that changes which animation plays goes
+  // through here -- the default picked on model load, the dropdown, and the loop control -- so
+  // the embedded Unity viewport can be told from one place, exactly as SetSkin does for skins.
+  // index is a position in the model's animation table (WoWModel::anims), which is what the
+  // dropdown's "[n]" suffix carries and what the animation manager takes.
+  void SelectAnimation(int index, int loops);
+
+  // Entries in the animation selector and one entry's label -- diagnostics only, mirroring
+  // skinCount/skinName so the -unityipctest run can walk animations the same way.
+  int animationCount();
+  wxString animationName(int index);
+
   // Every creature display id this model's skins were built from, paired with the selector entry
   // it resolves to (-1 when it resolves to none). Matched exactly the way SetSkinByDisplayID
   // matches, so it reports what that call would actually do. Diagnostics only.

--- a/Source/wowmodelviewer/app.cpp
+++ b/Source/wowmodelviewer/app.cpp
@@ -27,6 +27,7 @@
 #include "WoWDatabase.h"
 #include "WoWFolder.h"
 #include "animcontrol.h"
+#include "AnimManager.h"
 #include "WoWModel.h"
 
 #include "logger/Logger.h"
@@ -379,6 +380,41 @@ static void doHeadlessUnityIpcTest(ModelViewer * frame)
 
       LOG_INFO << "[unityipc-test] skin-sync: skinPushes=" << ipc->stats().skinPushes
                << "lastSkin=" << ipc->stats().lastSkin;
+
+      // Animation sync: the viewport plays ONE of the model's animations and the renderer has to
+      // play the same one. Walk a spread of the selector rather than all of it -- a boss has
+      // hundreds of entries and each push has to reach the player before the next -- and report
+      // what each selection resolved to, so a run shows the whole chain from the selector to the
+      // sequence index that left the app.
+      const int animCount = ac ? ac->animationCount() : 0;
+      LOG_INFO << "[unityipc-test] animation-sync check: the selector offers" << animCount << "animation(s)";
+      if (ac && animCount > 0)
+      {
+        const int wanted = 6;
+        const int step = (animCount > wanted) ? (animCount / wanted) : 1;
+        for (int a = 0; a < animCount; a += step)
+        {
+          // The selector's label carries the animation-table index in brackets; that index, not
+          // the list position, is what SelectAnimation and the renderer both work in.
+          const wxString label = ac->animationName(a);
+          const int open = label.Find('[') + 1;
+          const int close = label.Find(']');
+          const int index = (open > 0 && close > open) ? wxAtoi(label.Mid(open, close - open)) : a;
+          ac->SelectAnimation(index, 0);
+          const WoWModel * mdl = frame->canvas ? frame->canvas->model() : NULL;
+          const int playing = (mdl && mdl->animManager) ? (int)mdl->animManager->GetAnim() : -1;
+          LOG_INFO << "[unityipc-test]   animation[" << a << "]"
+                   << QString::fromWCharArray(label.c_str())
+                   << "-> sequence" << index << "playing" << playing
+                   << "animID" << ((mdl && playing >= 0 && playing < (int)mdl->anims.size())
+                                   ? mdl->anims[playing].animID : -1)
+                   << "length" << ((mdl && playing >= 0 && playing < (int)mdl->anims.size())
+                                   ? (int)mdl->anims[playing].length : -1);
+          for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+        }
+        LOG_INFO << "[unityipc-test] animation-sync: animPushes=" << ipc->stats().animPushes
+                 << "lastAnimation=" << ipc->stats().lastAnimation;
+      }
     }
   }
 
@@ -386,8 +422,12 @@ static void doHeadlessUnityIpcTest(ModelViewer * frame)
   // nothing to sync, so the condition only bites when there was something to send.
   const bool skinsOk = (frame->animControl == NULL) || (frame->animControl->skinCount() == 0) ||
                        (st.skinPushes >= 1);
+  // A model with an animation selector must have pushed at least one animation; one without has
+  // nothing to sync, so the condition only bites when there was something to send.
+  const bool animsOk = (frame->animControl == NULL) || (frame->animControl->animationCount() == 0) ||
+                       (ipc->stats().animPushes >= 1);
   const bool pass = st.connections >= 1 && ipc->isUnityReady() && st.requests >= 1 &&
-                    st.responsesOk >= 1 && skinsOk;
+                    st.responsesOk >= 1 && skinsOk && animsOk;
   LOG_INFO << "[unityipc-test] RESULT:" << (pass ? "PASS" : "FAIL");
 
   // Close the player now (what app shutdown does) and confirm the child process is gone.

--- a/Source/wowmodelviewer/modelviewer.cpp
+++ b/Source/wowmodelviewer/modelviewer.cpp
@@ -1,6 +1,7 @@
 #include "modelviewer.h"
 
 #include "AnimationExportChoiceDialog.h"
+#include "AnimManager.h"
 
 #include <wx/aboutdlg.h>
 #include <wx/busyinfo.h>
@@ -1594,6 +1595,9 @@ void ModelViewer::SendCurrentModelToUnity()
   WoWModel * m = const_cast<WoWModel *>(canvas->model());
   GameFile * gf = m->gamefile;
   unityRendererHost->ipc()->sendLoadWoWModel(gf->fullname(), gf->fileDataId() > 0 ? gf->fileDataId() : 0);
+  // ... and which animation it is showing, so the player starts on the app's selection instead of
+  // picking its own idle and being corrected a moment later.
+  SendCurrentAnimationToUnity();
 }
 
 // The displayed skin changed (dropdown, or the default picked on model load). The Unity viewport
@@ -1608,6 +1612,30 @@ void ModelViewer::SendCurrentSkinToUnity()
     return;
   WoWModel * m = const_cast<WoWModel *>(canvas->model());
   unityRendererHost->ipc()->sendModelSkin((int)m->gamefile->fileDataId());
+}
+
+// The animation on display changed (the dropdown, or the default picked on model load). Same
+// reasoning as the skin: the Unity viewport draws the same model from the same data, so it has to
+// play what the canvas is playing rather than the idle it would choose for itself.
+//
+// The animation manager is asked what is PLAYING rather than the control being asked what is
+// selected, so a default chosen during model load and a dropdown choice both report the same way.
+void ModelViewer::SendCurrentAnimationToUnity()
+{
+  if (!unityRendererHost || !unityRendererHost->ipc() || !unityRendererHost->ipc()->isConnected())
+    return;
+  if (!canvas || !canvas->model() || !canvas->model()->gamefile)
+    return;
+  WoWModel * m = const_cast<WoWModel *>(canvas->model());
+  if (!m->animManager || m->anims.empty())
+    return;
+
+  const int index = (int)m->animManager->GetAnim();
+  if (index < 0 || index >= (int)m->anims.size())
+    return;
+  unityRendererHost->ipc()->sendModelAnimation((int)m->gamefile->fileDataId(), index,
+                                               m->anims[index].animID, (int)m->anims[index].length,
+                                               true);
 }
 
 // Menu button press events

--- a/Source/wowmodelviewer/modelviewer.h
+++ b/Source/wowmodelviewer/modelviewer.h
@@ -172,6 +172,7 @@ public:
   // every model load and when the player announces unityReady.
   void SendCurrentModelToUnity();
   void SendCurrentSkinToUnity();
+  void SendCurrentAnimationToUnity();
 
   void OnMount(wxCommandEvent &event);
   void OnSave(wxCommandEvent &event);

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
@@ -23,6 +23,7 @@
 //   assetResponse { requestId, ok:false, error }
 //   modelTextures { requestId, ok, fileDataID, textures:[{ index, type, fileDataID, source }] }
 //   modelSkin     { fileDataID, textures:[...], geosets:[...], hasGeosets }        (pushed, no request)
+//   modelAnimation { fileDataID, sequenceIndex, animID, durationMs, loop }         (pushed, no request)
 //
 // getModelTextures exists because a modern M2 does not name its replaceable textures (a
 // creature skin's TXID entry is 0 and its texture array carries no filename) -- the skin comes
@@ -53,6 +54,7 @@ public class WmvIpcClient : MonoBehaviour
     public Action<AssetResponse> OnAssetResponse;
     public Action<ModelTexturesResponse> OnModelTextures;
     public Action<ModelTexturesResponse> OnModelSkin;          // pushed when the displayed skin changes
+    public Action<AnimationSelection> OnModelAnimation;        // pushed when the displayed animation changes
     public Action<string> OnStatus;                            // human-readable connection/state text
 
     public bool Connected { get { return connected; } }
@@ -112,6 +114,20 @@ public class WmvIpcClient : MonoBehaviour
         public bool hasGeosets;
     }
 
+    /// <summary>
+    /// Which animation the app is showing. sequenceIndex is the one to act on -- it indexes the
+    /// model's animation table, which is how the keyframes are stored; two sequences can share an
+    /// animID, so the id alone cannot pick one.
+    /// </summary>
+    public struct AnimationSelection
+    {
+        public int fileDataID;
+        public int sequenceIndex;
+        public int animID;
+        public int durationMs;
+        public bool loop;
+    }
+
     [Serializable] class MsgTexture
     {
         public int index;
@@ -137,6 +153,10 @@ public class WmvIpcClient : MonoBehaviour
         public string data;
         public string error;
         public string message;
+        public int sequenceIndex;
+        public int animID;
+        public int durationMs;
+        public bool loop;
     }
 
     int port = -1;
@@ -272,6 +292,17 @@ public class WmvIpcClient : MonoBehaviour
             // reply, minus the requestId -- nothing asked for it.
             case "modelSkin":
                 OnModelSkin?.Invoke(ReadTextures(msg));
+                break;
+
+            case "modelAnimation":
+                OnModelAnimation?.Invoke(new AnimationSelection
+                {
+                    fileDataID = msg.fileDataID,
+                    sequenceIndex = msg.sequenceIndex,
+                    animID = msg.animID,
+                    durationMs = msg.durationMs,
+                    loop = msg.loop,
+                });
                 break;
 
             case "assetResponse":

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
@@ -126,9 +126,9 @@ public class WmvM2Animator : MonoBehaviour
 
         if (log != null)
         {
-            log(string.Format("anim: sequence [{0}] animId {1} \"{2}\", {3} ms, {4} of {5} bone(s) " +
+            log(string.Format("anim: sequence [{0}] animId {1}{2}, {3} ms, {4} of {5} bone(s) " +
                               "move, {6} track(s) on a global sequence",
-                              SequenceIndex, AnimId, AnimId == 0 ? "Stand" : "fallback",
+                              SequenceIndex, AnimId, AnimId == 0 ? " (Stand)" : "",
                               lengthMs, bones.Length, model.Bones.Length, globalTracks));
             foreach (var kv in unsupported)
                 log(string.Format("anim: {0} track(s) use {1} interpolation, which is read as " +

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -36,6 +36,23 @@ public class WmvMain : MonoBehaviour
     WmvOrbitCamera orbit;
 
     WmvRuntimeModel current;          // the model on screen (disposed when replaced)
+
+    /// <summary>
+    /// The .m2 bytes of the model on screen. Kept because only ONE animation's keyframes are
+    /// parsed at a time -- a track on disk is an array of per-sequence arrays -- so following the
+    /// app to a different animation means parsing these again with a different sequence in mind.
+    /// A creature .m2 is a few hundred KB; re-fetching it over IPC for every dropdown change
+    /// would cost a round-trip to save that.
+    /// </summary>
+    byte[] currentM2Bytes;
+
+    /// <summary>
+    /// The sequence the app says it is showing, or -1 when it has not said. Remembered because the
+    /// push can arrive before the model finishes loading -- it is sent right after loadWoWModel --
+    /// and then it decides which animation the model is built playing, rather than the model
+    /// starting on its own idle and being corrected a frame later.
+    /// </summary>
+    int selectedSequence = -1;
     LoadJob job;                      // in-flight load, if any
 
     // Kept after a successful load so the SKIN can change without reloading anything. A creature
@@ -127,6 +144,7 @@ public class WmvMain : MonoBehaviour
         ipc.OnAssetResponse = HandleAssetResponse;
         ipc.OnModelTextures = HandleModelTextures;
         ipc.OnModelSkin = HandleModelSkin;
+        ipc.OnModelAnimation = HandleModelAnimation;
     }
 
     // ---------------------------------------------------------------- load pipeline
@@ -139,6 +157,12 @@ public class WmvMain : MonoBehaviour
             status.Set("loadWoWModel without path or fileDataID -- ignored");
             return;
         }
+
+        // A sequence index means nothing across models -- entry 14 is a different animation in
+        // each -- so forget the previous one. The app pushes its selection for the NEW model right
+        // after this message, so the value is refilled before the .m2 arrives to be parsed.
+        selectedSequence = -1;
+        currentM2Bytes = null;
 
         job = new LoadJob { Path = path, FileDataID = fileDataID };
         status.Set("Requested " + (string.IsNullOrEmpty(path) ? ("fileDataID " + fileDataID) : path));
@@ -182,7 +206,7 @@ public class WmvMain : MonoBehaviour
         {
             long t0 = job.Clock.ElapsedMilliseconds;
             job.M2Bytes = r.data;
-            job.Model = M2Parser.Parse(r.data);
+            job.Model = M2Parser.Parse(r.data, selectedSequence);
             job.ParseMs += job.Clock.ElapsedMilliseconds - t0;
             if (job.FileDataID <= 0) job.FileDataID = r.fileDataID;
         }
@@ -319,6 +343,7 @@ public class WmvMain : MonoBehaviour
             // Keep what a later skin change needs: the parsed model (to map a texture type onto
             // slots) and the decoded textures (so untouched slots are not re-fetched).
             currentModel = job.Model;
+            currentM2Bytes = job.M2Bytes;
             currentName = string.IsNullOrEmpty(job.Model.Name) ? "WoWModel" : job.Model.Name;
             currentFileDataID = job.FileDataID;
             currentTextures.Clear();
@@ -344,6 +369,66 @@ public class WmvMain : MonoBehaviour
         }
         catch (WowParseException e) { Fail("mesh creation failed: " + e.Message); }
         finally { job = null; }
+    }
+
+    /// <summary>
+    /// WMV's displayed animation changed. The renderer draws the same model from the same data, so
+    /// it plays what the app plays rather than the idle it would pick for itself.
+    ///
+    /// Only one sequence's keyframes are held at a time, so this re-parses the .m2 kept from the
+    /// load with the new sequence in mind and re-binds the animator to the result. Nothing else
+    /// moves: the mesh, its materials, its textures and its geoset selection are all untouched by
+    /// which animation is playing.
+    /// </summary>
+    void HandleModelAnimation(WmvIpcClient.AnimationSelection a)
+    {
+        if (a.fileDataID != 0 && currentFileDataID != 0 && a.fileDataID != currentFileDataID)
+            return;                                     // about a different model
+        if (a.sequenceIndex < 0)
+            return;
+
+        bool changed = a.sequenceIndex != selectedSequence;
+        selectedSequence = a.sequenceIndex;
+
+        if (current == null || currentM2Bytes == null)
+        {
+            // Still loading. The parse below will use this selection when it gets there.
+            status.Set("Animation " + a.sequenceIndex + " selected (model still loading)");
+            return;
+        }
+        if (!changed && current.Animator != null)
+        {
+            status.Set("Animation unchanged");
+            return;
+        }
+
+        try
+        {
+            M2ParsedModel reparsed = M2Parser.Parse(currentM2Bytes, a.sequenceIndex);
+            if (WmvModelBuilder.ApplySequence(current, reparsed, s => Debug.Log("WMV: " + s)))
+            {
+                currentModel = reparsed;
+                // Report what is PLAYING, not what was asked for: a sequence whose keyframes are
+                // not in the .m2 falls back to the idle, and saying "animation 20" while the idle
+                // plays is the kind of log that costs an hour later.
+                int playing = reparsed.AnimatedSequence;
+                status.Set(string.Format("Animation {0} (animID {1}, {2} ms){3}",
+                                         playing, reparsed.Sequences[playing].AnimId,
+                                         reparsed.Sequences[playing].Length,
+                                         playing == a.sequenceIndex
+                                             ? "" : " -- fell back from " + a.sequenceIndex));
+                if (playing != a.sequenceIndex && reparsed.AnimationSkipReason != null)
+                    Debug.Log("WMV: anim: " + reparsed.AnimationSkipReason);
+            }
+            else
+            {
+                status.Set("Animation " + a.sequenceIndex + " could not be played");
+            }
+        }
+        catch (WowParseException e)
+        {
+            status.Set("Animation change failed: " + e.Message);
+        }
     }
 
     /// <summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -49,8 +49,21 @@ public class WmvRuntimeModel
     /// </summary>
     public Transform[] Bones = new Transform[0];
 
+    /// <summary>
+    /// Each bone's rest offset from its parent, parallel to Bones. The animator adds a
+    /// translation track to these, so switching to another animation needs them again -- and
+    /// re-deriving them from the pivots would be a second copy of the same arithmetic.
+    /// </summary>
+    public Vector3[] BoneRestPositions = new Vector3[0];
+
     /// <summary>True when the model is drawn through a SkinnedMeshRenderer.</summary>
     public bool Skinned;
+
+    /// <summary>The animator driving the bones, or null when nothing is playing.</summary>
+    public WmvM2Animator Animator;
+
+    /// <summary>The renderer, kept so an animation change can adjust its culling.</summary>
+    public SkinnedMeshRenderer Skin;
 
     /// <summary>The geoset numbers currently switched on, or null when the host has not said.</summary>
     public HashSet<int> Geosets;
@@ -67,6 +80,9 @@ public class WmvRuntimeModel
         Root = null;
         Mesh = null;
         Bones = new Transform[0];
+        BoneRestPositions = new Vector3[0];
+        Animator = null;
+        Skin = null;
         Materials = new Material[0];
         Textures = new Texture2D[0];
     }
@@ -579,12 +595,14 @@ public static class WmvModelBuilder
         var go = new GameObject(objectName);
         SkinPlan skinPlan = PlanSkinning(model);
         var boneTransforms = new Transform[0];
+        var restPositions = new Vector3[0];
 
         if (skinPlan.CanSkin)
         {
             Transform rootBone;
             Vector3[] restLocalPositions;
             boneTransforms = BuildSkeleton(model, go.transform, out rootBone, out restLocalPositions);
+            restPositions = restLocalPositions;
 
             int dropped, unweighted;
             mesh.boneWeights = BuildBoneWeights(model, boneTransforms.Length, out dropped, out unweighted);
@@ -649,9 +667,11 @@ public static class WmvModelBuilder
                     // rest pose. An animation moves vertices outside it, so let Unity measure the
                     // real bounds each frame instead of clipping the model as it moves.
                     smr.updateWhenOffscreen = true;
+                    result.Animator = animator;
                     if (Debug_.AnimCheck)
                         ReportAnimationRange(smr, animator, positions, mesh.bounds, log);
                 }
+                result.Skin = smr;
             }
             else if (log != null)
             {
@@ -669,6 +689,7 @@ public static class WmvModelBuilder
 
         result.Root = go;
         result.Bones = boneTransforms;
+        result.BoneRestPositions = restPositions;
         result.Skinned = skinPlan.CanSkin;
         result.Mesh = mesh;
         result.Materials = materials.ToArray();
@@ -804,6 +825,76 @@ public static class WmvModelBuilder
             if (d > deepest) deepest = d;
         }
         return deepest;
+    }
+
+    /// <summary>
+    /// Play a different animation on a model already on screen.
+    ///
+    /// The mesh, its materials, its textures and its geoset selection are all untouched: an
+    /// animation change moves bones and nothing else. The caller supplies the SAME model re-parsed
+    /// for the new sequence -- only one sequence's keyframes are ever read, so a different one
+    /// means reading again -- and everything else here comes from what the build already made.
+    ///
+    /// Returns false when the re-parsed model has nothing to play, in which case the model keeps
+    /// whatever it was doing rather than freezing halfway.
+    /// </summary>
+    public static bool ApplySequence(WmvRuntimeModel runtime, M2ParsedModel model, Action<string> log)
+    {
+        if (runtime == null || model == null)
+            return false;
+        if (!runtime.Skinned || runtime.Bones.Length == 0)
+        {
+            // Nothing to animate: the model is drawn as a static mesh, and the build already said
+            // why. Saying it again here keeps the two halves of the story in one log.
+            if (log != null)
+                log("anim: nothing to animate -- this model is drawn as a static mesh");
+            return false;
+        }
+        if (Debug_.NoAnim)
+        {
+            if (log != null)
+                log("anim: selection ignored -- -wmvNoAnim was passed");
+            return false;
+        }
+        if (model.AnimatedSequence < 0 || model.AnimatedSequence >= model.Sequences.Length)
+        {
+            if (log != null)
+                log("anim: cannot play the selected animation -- " +
+                    (model.AnimationSkipReason ?? "no sequence was resolved"));
+            return false;
+        }
+
+        WmvM2Animator animator = runtime.Animator;
+        if (animator != null)
+        {
+            // Undo the pose the OLD animation left behind, while the animator still knows which
+            // bones it moved. A bone the new sequence does not touch would otherwise keep the last
+            // frame of the previous one for as long as the model is on screen.
+            animator.RestorePose();
+        }
+        else
+        {
+            // The model was built without an animator (its idle moved nothing, or the app had not
+            // said what to play yet). Nothing about the skeleton or the bind poses changes here.
+            animator = runtime.Root.AddComponent<WmvM2Animator>();
+            runtime.Animator = animator;
+        }
+
+        animator.Setup(model, runtime.Bones, runtime.BoneRestPositions, log);
+        if (animator.AnimatedBoneCount == 0)
+        {
+            // A real sequence that happens to move nothing: the bones are already back at rest.
+            UnityEngine.Object.Destroy(animator);
+            runtime.Animator = null;
+            if (runtime.Skin != null)
+                runtime.Skin.updateWhenOffscreen = false;
+            if (log != null)
+                log("anim: the selected sequence moves no bones -- back to the rest pose");
+            return true;
+        }
+        if (runtime.Skin != null)
+            runtime.Skin.updateWhenOffscreen = true;
+        return true;
     }
 
     static readonly int[] EmptyTriangles = new int[0];

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -63,10 +63,15 @@ namespace Wmv.Wow
         public uint Length;       // milliseconds
         public uint Flags;
 
-        /// <summary>Bit 0x20. The legacy viewport calls it "looped"; in current data it marks the
-        /// sequences whose keyframes are stored in the .m2 rather than in a separate .anim file.
-        /// Nothing here relies on it -- whether the keys are really present is decided by looking
-        /// for them, not by trusting a flag.</summary>
+        /// <summary>
+        /// Bit 0x20: this sequence's keyframes are stored in the .m2 itself rather than in a
+        /// separate .anim file. The legacy viewport's header calls the bit "looped", which is a
+        /// misnomer -- and taking it at that word is expensive, because the track headers of a
+        /// sequence WITHOUT the bit still sit in the .m2 and still look reasonable: their offsets
+        /// address the .anim file, land inside this buffer by coincidence, and read as noise.
+        /// chicken2's sequence 14 is exactly that, and it is not even named by an AFID entry, so
+        /// no amount of looking for the keys distinguishes it. The flag does.
+        /// </summary>
         public bool PrimarySequence { get { return (Flags & 0x20) != 0; } }
     }
 

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
@@ -70,8 +70,16 @@ namespace Wmv.Wow
         const int ColorStride = 40;        // two M2Tracks
         const int TrackStride = 20;        // interpolation + globalSeq + two nested M2Arrays
 
-        /// <summary>Parse an .m2 asset. Throws WowParseException on anything malformed.</summary>
-        public static M2ParsedModel Parse(byte[] file)
+        /// <summary>
+        /// Parse an .m2 asset. Throws WowParseException on anything malformed.
+        ///
+        /// wantedSequence names which animation's bone tracks to read; -1 asks for the model's
+        /// default idle. Only one sequence is ever read (a track on disk is an array of
+        /// per-sequence keyframe arrays, and a boss has hundreds), so playing a different one
+        /// means parsing again with a different answer here -- which is what the renderer does
+        /// when the app's animation selection changes.
+        /// </summary>
+        public static M2ParsedModel Parse(byte[] file, int wantedSequence = -1)
         {
             if (file == null || file.Length < 8)
                 throw new WowParseException("m2: asset is empty or too small to hold a header");
@@ -141,8 +149,8 @@ namespace Wmv.Wow
             if (model.SkeletonFileDataID == 0)
             {
                 c.RequireArray(bones, BoneStride, "bones");
-                model.AnimatedSequence = ResolveIdleSequence(model, file, chunks,
-                                                             out model.AnimationSkipReason);
+                model.AnimatedSequence = ResolveSequence(model, file, chunks, wantedSequence,
+                                                        out model.AnimationSkipReason);
                 model.Bones = ReadBones(c, bones, model);
             }
             else
@@ -516,12 +524,23 @@ namespace Wmv.Wow
 
             var t = new uint[n];
             var v = new T[n];
-            for (int i = 0; i < n; i++)
+            try
             {
-                c.Seek(keyTimes.Offset + i * 4);
-                t[i] = c.ReadUInt32();
-                c.Seek(keyValues.Offset + i * stride);
-                v[i] = readValue(c);
+                for (int i = 0; i < n; i++)
+                {
+                    c.Seek(keyTimes.Offset + i * 4);
+                    t[i] = c.ReadUInt32();
+                    c.Seek(keyValues.Offset + i * stride);
+                    v[i] = readValue(c);
+                }
+            }
+            catch (WowParseException)
+            {
+                // Bounds were fine and the contents were not -- a sequence whose keys really live
+                // in another file, read here anyway. One bone that will not move beats a model
+                // that will not load; the sequence-level check above is what should have caught
+                // this, and the caller reports when it did.
+                return track;
             }
             track.Times = t;
             track.Values = v;
@@ -555,25 +574,40 @@ namespace Wmv.Wow
         }
 
         /// <summary>
-        /// Which sequence to parse bone tracks for: the model's default idle.
+        /// Which sequence to parse bone tracks for.
         ///
-        /// This is the legacy viewport's own rule (AnimControl::UpdateModel): the FIRST sequence
-        /// whose AnimId is "Stand", falling back to sequence 0 when the model has none. It is not
-        /// the same as "sequence 0" -- on chicken2 that is a run cycle and the idle is sequence 2.
+        /// With no request (-1) this is the model's default idle, by the legacy viewport's own
+        /// rule (AnimControl::UpdateModel): the FIRST sequence whose AnimId is "Stand", falling
+        /// back to sequence 0 when the model has none. It is not the same as "sequence 0" -- on
+        /// chicken2 that is a run cycle and the idle is sequence 2.
+        ///
+        /// A requested sequence that cannot be played falls back to the idle rather than to
+        /// nothing: the app is showing SOMETHING, and a still model is a worse answer than the
+        /// wrong-but-moving one. The reason is reported either way.
         ///
         /// A sequence whose keyframes live in a separate .anim file, named by an AFID entry for
         /// its (AnimId, SubAnimId), is refused: the offsets inside its track headers address that
         /// file, not this one, and following them here would read whatever happens to sit at those
         /// bytes of the model. Fetching .anim files is a later milestone.
         /// </summary>
-        static int ResolveIdleSequence(M2ParsedModel model, byte[] file,
-                                       Dictionary<string, M2Array> chunks, out string skipReason)
+        static int ResolveSequence(M2ParsedModel model, byte[] file,
+                                   Dictionary<string, M2Array> chunks, int wanted,
+                                   out string skipReason)
         {
             skipReason = null;
             if (model.Sequences.Length == 0)
             {
                 skipReason = "it declares no animation sequences";
                 return -1;
+            }
+
+            if (wanted >= 0)
+            {
+                string why = "there is no such sequence";
+                if (wanted < model.Sequences.Length && Playable(model.Sequences[wanted], file, chunks, out why))
+                    return wanted;
+                skipReason = "the selected sequence " + wanted + " cannot be played (" + why +
+                             "); falling back to the default idle";
             }
 
             int idle = 0;
@@ -586,18 +620,42 @@ namespace Wmv.Wow
                 }
             }
 
-            if (model.Sequences[idle].Length == 0)
+            string idleWhy;
+            if (!Playable(model.Sequences[idle], file, chunks, out idleWhy))
             {
-                skipReason = "its idle sequence has zero length";
-                return -1;
-            }
-            if (HasExternalAnimFile(file, chunks, model.Sequences[idle]))
-            {
-                skipReason = "its idle sequence keeps its keyframes in a separate .anim file, " +
-                             "which this milestone does not fetch";
+                skipReason = (skipReason == null ? "" : skipReason + "; and ") +
+                             "the default idle cannot be played either (" + idleWhy + ")";
                 return -1;
             }
             return idle;
+        }
+
+        /// <summary>
+        /// Can this renderer play this sequence at all, and if not, why not?
+        ///
+        /// The 0x20 flag is the test that matters: it says the keyframes are in this file. Without
+        /// it the track headers still exist here, but their offsets address the sequence's .anim
+        /// file -- and they routinely land inside this buffer by coincidence, so bounds-checking
+        /// them proves nothing and reading them yields noise. The AFID lookup is kept as well
+        /// because it can name the file the keys went to, which makes a better message.
+        /// </summary>
+        static bool Playable(M2Sequence seq, byte[] file, Dictionary<string, M2Array> chunks,
+                             out string why)
+        {
+            if (seq.Length == 0)
+            {
+                why = "it has zero length";
+                return false;
+            }
+            if (!seq.PrimarySequence)
+            {
+                why = HasExternalAnimFile(file, chunks, seq)
+                    ? "its keyframes are in a separate .anim file, which this milestone does not fetch"
+                    : "its keyframes are not stored in the .m2 (no 0x20 flag)";
+                return false;
+            }
+            why = null;
+            return true;
         }
 
         /// <summary>Does the AFID chunk name an .anim file for this sequence?</summary>

--- a/Tools/UnityRendererProject/README.md
+++ b/Tools/UnityRendererProject/README.md
@@ -237,15 +237,28 @@ drawn as a static mesh and the log says exactly that — as it does for any othe
 refuses. Reading the header's bone array anyway would be worse than not skinning: the vertices are
 not indexed against it.
 
-## The idle animation
+## The animation
 
-One animation plays: the model's default idle. There is no sequence selector, no blending and no
-UI — this is the smallest thing that makes a creature look alive, built on the skeleton above.
+The viewport plays whatever animation WMV is playing. It has no controls of its own: the app
+pushes its selection over IPC (`modelAnimation`, carrying the sequence index), and the renderer
+follows. With nothing selected yet — a model still loading, or a run with the pane opened before
+any choice — it plays the model's default idle.
 
 **Which sequence is "the idle" is not sequence 0.** The legacy viewport picks the FIRST sequence
 whose `AnimId` is 0 ("Stand") and falls back to sequence 0 only when the model has none
 (`AnimControl::UpdateModel`). The difference is not academic: on `creature/chicken2` sequence 0 is
 a run cycle and the idle is sequence 2; on `creature/valkier` it is sequence 11.
+
+**The selection travels as a sequence index, not an animID.** The index is what the keyframes are
+stored under and what the app's own dropdown carries (its labels end in `[n]`). An animID is not
+unique: on `creature/chicken2`, sequences 0 and 8 both carry animID 5 as sub-animations 0 and 1,
+and its `Death` entry is animID 1 sub-animation 2. The id rides along for the log and for spotting
+the idle.
+
+**Switching costs a re-parse.** Only one sequence's keyframes are held at a time, so the player
+keeps the model's `.m2` bytes and parses them again when the selection changes. A creature .m2 is a
+few hundred KB and the parse is single-digit milliseconds; holding every sequence's keys instead
+would mean parsing a hundred animations to play one.
 
 **How a track is stored.** A bone carries three tracks — translation, rotation, scale — and each is
 an array of *per-sequence* keyframe arrays. The keys for sequence *n* are entry *n* of both the
@@ -261,6 +274,17 @@ interpolates — and *slerps* for rotations, which is what the legacy evaluator 
 `Hermite` and `Bezier` store two extra tangents per key that this milestone does not read; their
 values are interpolated linearly and the count is logged. No bone track in any validation model
 uses either.
+
+**Not every sequence can be played from the .m2, and the FLAG is what says so.** Bit `0x20` on a
+sequence means its keyframes are stored in this file. Without it they are in a separate `.anim`
+file — and this is the part that bites: the track headers of such a sequence are still here, and
+their offsets still land inside this buffer often enough that bounds-checking them proves nothing.
+They address the other file, so what comes back is noise. `creature/chicken2`'s sequence 14 is
+exactly that and is not even named by an AFID entry, so no amount of looking for the keys finds
+the difference; sequence 20 is the same but AFID does name its file, which only makes for a better
+message. A sequence the renderer cannot play falls back to the model's idle and logs which of the
+two it was. Reading such a track is also caught one level down, so a header that slips through
+produces a still bone rather than a failed load.
 
 **Global sequences are not optional.** A track can be bound to one instead of the animation, and
 then it loops over that sequence's own duration on a clock that ignores what is playing — a
@@ -338,7 +362,7 @@ to (or why it was not).
 | `Wow/WowCoordinateConverter.cs` | The single WoW -> Unity axis/winding/UV conversion. |
 | `Assets/Resources/WmvOpaque.shader` | The renderer's own textured shader, kept under `Resources/` so a player build cannot strip it. One variant, everything uniform-driven: `_SrcBlend`/`_DstBlend`/`_ZWrite`/`_Cull`/`_Cutoff` as real properties, plus `_CombinerMode`, `_Unit1UV`, `_AlphaMode`/`_AlphaScale` and `_OpaqueAlpha` for the second texture unit and the M2 combiners. |
 | `Wow/ByteCursor.cs` | Bounds-checked little-endian reader shared by the parsers. |
-| `WmvM2Animator.cs` | Plays the model's default idle by writing bone transforms each frame: sequence selection, track evaluation, global sequences and looping. No Animator Controller, no clips, nothing written to disk. |
+| `WmvM2Animator.cs` | Plays one animation by writing bone transforms each frame: track evaluation, global sequences and looping. Re-bound whenever the app's selection changes. No Animator Controller, no clips, nothing written to disk. |
 | `WmvOrbitCamera.cs` | Orbit / pan / zoom controls plus bounds-driven framing of a loaded model. |
 
 The parsing layer under `Assets/Scripts/Wow/` deliberately has no `UnityEngine` dependency, so

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -180,7 +180,8 @@ namespace Wmv.Wow.Tests
         /// still, bone 1 has an ordinary rotation track on the idle sequence, and bone 2 has a
         /// translation track bound to global sequence 1.
         /// </summary>
-        static byte[] BuildAnimatedM2(short[] animIds, bool standTrack, int afidAnimId = -1)
+        static byte[] BuildAnimatedM2(short[] animIds, bool standTrack, int afidAnimId = -1,
+                                      int noKeysInM2 = -1)
         {
             int nSeq = animIds.Length;
             byte[] b = BuildM2Payload(3, boneCount: 3);
@@ -214,7 +215,9 @@ namespace Wmv.Wow.Tests
                 PutU16(b, o, unchecked((ushort)animIds[i]));   // animId
                 PutU16(b, o + 2, 0);                            // subAnimId
                 PutU32(b, o + 4, 1000);                         // length
-                PutU32(b, o + 12, 0x20);                        // flags
+                // 0x20 says the keyframes are in this file; clearing it is how a sequence says
+                // they are somewhere else.
+                PutU32(b, o + 12, (i == noKeysInM2) ? 0u : 0x20u);
             }
             PutU32(b, 0x1C, (uint)nSeq); PutU32(b, 0x20, (uint)oSeqs);
 
@@ -532,12 +535,71 @@ namespace Wmv.Wow.Tests
                   "anim: a model with no sequences reports why it is not animated");
 
             // An idle whose keyframes live in a separate .anim file is refused rather than read
-            // out of the wrong buffer.
-            byte[] external = BuildAnimatedM2(new[] { (short)5, (short)0 }, standTrack: true, afidAnimId: 0);
+            // out of the wrong buffer. Real data marks such a sequence by CLEARING 0x20 as well as
+            // naming the file, and the fixture matches that.
+            byte[] external = BuildAnimatedM2(new[] { (short)5, (short)0 }, standTrack: true,
+                                              afidAnimId: 0, noKeysInM2: 1);
             M2ParsedModel ext = M2Parser.Parse(external);
             Check(ext.AnimatedSequence == -1, "anim: an idle with an AFID entry is skipped");
             Check(ext.AnimationSkipReason != null && ext.AnimationSkipReason.Contains(".anim"),
                   "anim: the skip reason names the .anim file");
+
+            SelectedSequenceTests();
+        }
+
+        /// <summary>
+        /// Following the app's animation selection: the requested sequence is parsed instead of the
+        /// idle, and anything that cannot be played falls back to the idle rather than to nothing.
+        /// </summary>
+        static void SelectedSequenceTests()
+        {
+            // Asking for a sequence gets that sequence, not the idle.
+            byte[] file = BuildAnimatedM2(new[] { (short)5, (short)4, (short)0, (short)1 },
+                                          standTrack: true);
+            Check(M2Parser.Parse(file).AnimatedSequence == 2, "select: no request still means the idle");
+            M2ParsedModel picked = M2Parser.Parse(file, 1);
+            Check(picked.AnimatedSequence == 1, "select: the requested sequence is the one parsed");
+            Check(picked.AnimationSkipReason == null, "select: nothing skipped for a playable request");
+            Check(picked.Sequences[picked.AnimatedSequence].AnimId == 4, "select: the right entry");
+
+            // The keys move with the request: the fixture puts its rotation track on the idle only,
+            // so another sequence parses that bone with no track at all.
+            Check(!picked.Bones[1].Rotation.HasData,
+                  "select: a sequence with no keys for a bone reads an empty track");
+            Check(M2Parser.Parse(file, 2).Bones[1].Rotation.HasData,
+                  "select: the sequence that does have keys still reads them");
+
+            // A track bound to a global sequence is unaffected by which animation is selected --
+            // it always reads entry 0.
+            Check(M2Parser.Parse(file, 1).Bones[2].Translation.HasData &&
+                  M2Parser.Parse(file, 3).Bones[2].Translation.HasData,
+                  "select: a global-sequence track is read whichever sequence is chosen");
+
+            // Out of range falls back to the idle, and says so.
+            M2ParsedModel far = M2Parser.Parse(file, 99);
+            Check(far.AnimatedSequence == 2, "select: an out-of-range request falls back to the idle");
+            Check(far.AnimationSkipReason != null && far.AnimationSkipReason.Contains("99"),
+                  "select: the fallback reason names the sequence that was asked for");
+
+            // So does a request whose keyframes are in an .anim file.
+            byte[] external = BuildAnimatedM2(new[] { (short)5, (short)0 }, standTrack: true,
+                                              afidAnimId: 5, noKeysInM2: 0);
+            M2ParsedModel ext = M2Parser.Parse(external, 0);
+            Check(ext.AnimatedSequence == 1, "select: a request needing an .anim file falls back to the idle");
+            Check(ext.AnimationSkipReason != null && ext.AnimationSkipReason.Contains(".anim"),
+                  "select: that fallback reason names the .anim file");
+
+            // And so does one whose keys are simply not in this file, with no .anim named for it.
+            // This is the case that matters: its track headers ARE here and its offsets land in
+            // range, so only the 0x20 flag distinguishes it from a playable sequence.
+            byte[] notHere = BuildAnimatedM2(new[] { (short)5, (short)0 }, standTrack: true, noKeysInM2: 0);
+            M2ParsedModel nh = M2Parser.Parse(notHere, 0);
+            Check(nh.AnimatedSequence == 1, "select: a sequence without the 0x20 flag falls back to the idle");
+            Check(nh.AnimationSkipReason != null && nh.AnimationSkipReason.Contains("0x20"),
+                  "select: that fallback reason names the missing flag");
+            Check(M2Parser.Parse(BuildAnimatedM2(new[] { (short)5, (short)0 }, standTrack: true,
+                                                 noKeysInM2: 1)).AnimatedSequence == -1,
+                  "select: an idle without the 0x20 flag is not played at all");
         }
 
         static void BoneTests()

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -152,6 +152,8 @@ The response carries metadata only; bytes are still fetched with `getAssetByFile
 { "type": "modelSkin", "ok": true, "fileDataID": 1521037,
   "textures": [ { "index": 0, "type": 11, "fileDataID": 1521061, "source": "selection" } ],
   "geosets": [ 101 ], "hasGeosets": true }
+{ "type": "modelAnimation", "fileDataID": 1521037, "sequenceIndex": 2, "animID": 0,
+  "durationMs": 2000, "loop": true }
 ```
 
 Semantics:
@@ -166,6 +168,20 @@ Semantics:
   from `AnimControl::SetSkin`, the single funnel every skin change goes through (the dropdown,
   the default chosen on model load, and NPC import), plus `SetSingleSkin` for the per-slot
   folder-texture lists.
+- `modelAnimation` is **pushed, not requested**: the animation on display changed. It is sent
+  from `AnimControl::SelectAnimation`, the single funnel every animation change goes through (the
+  default picked while a model loads, the dropdown, and the loop control), and once more right
+  after `loadWoWModel` so the player starts on the app's selection rather than on an idle it
+  chose for itself.
+  **`sequenceIndex` is the field that decides what plays.** It indexes the model's animation
+  table, which is both how the keyframes are stored and how the app's own selector identifies a
+  choice -- its dropdown labels literally end in `[n]`. Two sequences routinely share an `animID`
+  (sub-animations of one action: chicken2's sequences 0 and 8 are both animID 5), so the id cannot
+  pick one; it travels for the log and for recognising the idle (`animID` 0, "Stand").
+  The player holds the model's `.m2` bytes and re-parses them for the requested sequence, because
+  only one sequence's keyframes are read at a time -- a boss has 109 of them. Nothing else moves:
+  the mesh, its materials, its textures and its geoset selection are untouched by which animation
+  is playing.
 - `geosets` / `hasGeosets` ride along with both `modelTextures` and `modelSkin`, because a display
   variant can differ from another by **geometry** rather than texture. `creature/horse3/horse3.m2`
   is the worked example: three of its dropdown entries share one texture and differ only in
@@ -243,17 +259,20 @@ in-process, and shuts the player down. Result lines carry the `[unityipc-test]` 
   result is the static mesh it replaces to within float noise (largest measured deviation across
   the validation models: 3.8e-6 units). Models whose bones live in a separate skeleton file are
   still drawn static, and say so.
-- Idle animation playback: the model's default idle sequence loops on the rig above. The
-  sequence is the one the OpenGL viewport itself would select -- the first whose AnimId is
-  "Stand", not sequence 0 -- and its bone tracks are evaluated the way the legacy evaluator
-  does, including the global sequences that run on their own clock. One animation, no selector
-  and no UI; `-wmvNoAnim` returns the model to the rest pose.
+- Animation playback that follows the app: the viewport plays the animation WMV is playing,
+  switching with the dropdown. Bone tracks are evaluated the way the legacy evaluator does,
+  including the global sequences that run on their own clock. With nothing selected yet the
+  model's default idle plays -- the first sequence whose AnimId is "Stand", which is the same
+  choice the OpenGL viewport makes and is not sequence 0. A sequence whose keyframes are not in
+  the .m2 falls back to that idle and says so. `-wmvNoAnim` returns the model to the rest pose.
 - Bounds-driven camera framing, so a loaded model is visible immediately.
 
 **Not yet implemented**
 
-- Choosing an animation. One sequence plays, the default idle; there is no selector, no
-  blending between sequences and no animation UI.
+- Animation UI of the renderer's own: the viewport follows WMV's selector and has no controls.
+  Blending between sequences, and following a queued "next animation" chain, play/pause or
+  playback speed, are not synced -- those change what the canvas shows without a selection
+  happening.
 - Keyframes stored outside the .m2: the .anim files named by the AFID chunk, and bones from a
   separate skeleton file (the SKID chunk and the SKPD parent it can defer to). A model that
   needs either is drawn from what it does have -- unskinned, or skinned but still -- and says


### PR DESCRIPTION
The embedded viewport always played its own default idle. It now plays the animation WMV is playing: pick Run, Death or an emote in the dropdown and the Unity pane switches with the canvas, as it already did for skins and geoset variants.

The selection travels as a new modelAnimation push carrying the SEQUENCE INDEX. That is the field that decides what plays: it indexes the model's animation table, which is both how the keyframes are stored and how the app's own selector identifies a choice -- its dropdown labels literally end in "[n]". An animID cannot pick one, because animIDs are not unique: chicken2 carries animID 5 on two sequences, as sub-animations 0 and 1. The id travels for the log and for recognising the idle.

WMW side: AnimControl::SelectAnimation is the funnel, the animation counterpart of SetSkin. The three places that changed which animation plays -- the default picked while a model loads, the dropdown, and the loop control -- now route through it, so the viewport is told once, from one place. It is pushed again right after loadWoWModel so the renderer starts on the app's choice instead of being corrected a moment later. Deliberately NOT covered: a queued "next animation" chain advancing on its own, and play/pause/speed -- those change what the canvas shows without a selection happening.

Player side: the model's .m2 bytes are kept and re-parsed for the requested sequence, because only one sequence's keyframes are held at a time (a track on disk is an array of per-sequence arrays; valkier has 109 sequences). The animator is re-bound to the result after putting the previous animation's bones back at rest, so a bone the new sequence does not touch cannot keep the last frame of the old one. Nothing else moves: the mesh, its materials, its textures and its geoset selection are untouched by which animation is playing.

NOT EVERY SEQUENCE CAN BE PLAYED FROM THE .M2, AND FINDING OUT WHY WAS THE SUBSTANCE OF THIS CHANGE. Bit 0x20 says the keyframes are stored in that file. Without it they are in a separate .anim file -- and the trap is that such a sequence's track headers are still present in the .m2, with offsets that address the OTHER file yet land in range often enough that bounds checks pass and the data reads as noise. chicken2's sequence 14 is exactly that and is not even named by an AFID entry, so looking for the keys cannot tell it apart; only the flag can. Those sequences now fall back to the model's idle and log which of the two reasons applied, and a track that slips through anyway degrades to a still bone instead of failing the load.

Validated by walking six animations per model through the app's own selector on eight models: all -unityipctest runs PASS, no exceptions. Every model received 6-9 pushes and played 5-9 distinct sequences (chicken2's Run, Death, AttackUnarmed, EmoteEat...; horse3's eight; valkier's eight of 109). Three fallbacks fired across the set, each naming its reason: chicken2 sequences 14 and 20, overfiend sequence 30. creature/orcskeleton, which is drawn unskinned, says so rather than failing. With -wmvNoAnim the rest-pose deviations are unchanged from the skinning milestone to the digit (three models exactly zero, worst 3.8e-6) and 49 selections were correctly ignored. Selected-skin sync, geoset switching, the hidden-batch gate and material coverage all still hold while animated. 122/122 parser tests pass, the player scripts type-check under all four input-backend configurations, and the OpenGL viewport renders unchanged.

Note: the FBX exporter plugin does not build in this tree (glm/std::isnan against the FBX SDK headers). Confirmed pre-existing on a clean develop checkout and untouched here; the app and the renderer build and run.