### PR TITLE
Sync Unity animation playback state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,91 @@ Format loosely based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **Embedded Unity renderer: the viewport no longer holds for about a second after every animation
+  change.** The dropdown handler does three things -- `Stop()`, then select, then `Play()` -- and
+  only the middle one told the renderer anything. So the state that travelled with the selection
+  said "this animation, and it is NOT running", `Play()` resumed the app without saying so, and the
+  Unity pane sat on the first frame until the one-per-second heartbeat came round. That is the
+  half-second-to-a-second hold, and it explains why it happened on every model, why it survived the
+  parse, fetch and cache work, and why no headless run ever saw it: the harness called
+  `SelectAnimation` directly, which is not the path the dropdown takes.
+  All three places with that shape now push the settled state after `Play()` -- the animation
+  dropdown, the loop control, and the selection made while a model loads. The heartbeat goes back
+  to being what it was meant to be: drift correction, not the thing that starts an animation.
+  Measured after the fix, animation time resumes **on the same frame as the switch, 0 ms later**,
+  and `-unityipctest` now drives the real dropdown handler and fails if the state that follows a
+  pick does not say the animation is running.
+
+- **Embedded Unity renderer: picking an animation takes effect at once.** Two things stood between
+  a selection and the animation actually starting, and both were found by timestamping the whole
+  path rather than reasoning about it.
+  First, a sequence whose keyframes live in a .anim file fetched them on the FIRST switch to it --
+  16-18 ms of round trip during which the PREVIOUS animation stayed on screen, so picking one
+  looked like nothing had happened. Those files are now fetched when the model loads (Agronn: 8
+  files, ~300 KB), so no switch waits on one; measured, zero switches are now deferred.
+  Second, the playback state that follows a selection was DISCARDED whenever the renderer was not
+  already on the sequence it named -- which is every fallback to the idle and every switch still
+  resolving. The app's play/pause and speed are properties of the app, not of the sequence, so they
+  are now applied regardless, and the position is applied as soon as it is known which sequence is
+  playing. Before, a switch in those cases kept the previous animation's transport until the next
+  heartbeat corrected it.
+  For the record, the selection itself was never the delay: WMV already pushed `modelAnimation` and
+  `modelAnimationState` from the same control path, and the renderer receives them **0-2 ms apart**.
+  The heartbeat corrects drift; it was never what started an animation.
+
+- **Embedded Unity renderer: animations stored in .anim files now play.** A creature sequence
+  without flag 0x20 keeps its track headers in the .m2 but its keyframes in a separate .anim file,
+  named by the AFID chunk. The Unity viewport used to detect that and fall back to the idle, so an
+  animation that played perfectly in the OpenGL viewport did nothing in the Unity one --
+  **Agronn's SitGroundDown** (sequence 37, animID 96, flags 0x81, 3533 ms) being the reported case.
+  The .anim bytes now travel over the ordinary asset channel and the parser reads the entries from
+  them while still reading the headers from the .m2, which is exactly the split the legacy viewport
+  makes. Agronn gains 6 such animations, valkier 8, chicken2 6. Each file is fetched at most once
+  per model. A sequence whose .anim cannot be served falls back to the idle, names the file, and
+  leaves the previous animation running.
+  Two of Agronn's sequences (36 and 40, animIDs 72 and 71) still fall back: they carry neither the
+  0x20 flag nor an AFID entry, so their keyframes are in no file at all. The legacy viewport has no
+  alias or replacement path either -- `NextAnimation` is only ever written to XML, never read -- so
+  it has nothing to play for them either.
+
+- **Embedded Unity renderer: switching animation no longer stutters.** Picking a different
+  animation used to re-parse the entire .m2 -- vertices, textures, materials, lookups and all --
+  to get at one thing: the bone tracks for the new sequence. It now reads just those, into the
+  model already in memory. Nothing is re-requested, nothing is rebuilt, and the mesh, materials,
+  textures, geoset selection and skeleton are left untouched; `loadWoWModel` stays the only path
+  that builds anything.
+  **The clock was never the whole story, which is why this needed measuring rather than guessing.**
+  The old path took 2-9 ms, too little to see. What the user could see was the GARBAGE: about
+  1-1.7 MB per switch, collected a frame or two later, landing as a hitch just as the new animation
+  started. The largest single piece of it was the MD21 slice the parser works in, copied out of the
+  file again on every selection; that slice is now cut once when the model loads and reused.
+  Per switch, measured over the validation models: 2.3 -> 0.1 ms and 1072 -> 108 KB (chicken2),
+  7.3 -> 0.0 ms and 512 -> 168 KB (horse3), 3.9 -> 0.4 ms and 1032 -> 244 KB (valkier),
+  9.4 -> 1.0 ms and 1680 -> 648 KB (shaboss_doubt).
+
+### Added
+- **Embedded Unity renderer: it now follows the transport controls too.** The viewport already
+  played the animation you picked; it now plays it the way you are playing it -- pause holds the
+  pane on the same frame, resume carries on from there, the speed slider changes its speed, and
+  dragging the frame slider scrubs it. A new `modelAnimationState` push carries whether the
+  animation is running, how fast, and where in the sequence the app is.
+  **This one had no funnel to hook.** Unlike the skin and the animation choice, playback state is
+  changed from seven places -- play, pause, stop, clear, the two step buttons, the speed slider and
+  the frame slider -- and the time advances every frame with no control involved at all. So it is
+  pushed both ways: forced from each of those controls, and on a one-per-second heartbeat from the
+  canvas tick while something is playing.
+  The heartbeat is a correction channel, not a stream, and the **player** decides what to do with
+  it: a time difference under about a frame (40 ms) is ignored and anything larger snaps. That split is
+  the design. Snapping to every message would trade drift for a visible stutter once a second;
+  never snapping would let two independently-timed renderers walk apart. A scrub or a stop arrives
+  with the app's time already far from the player's, so it snaps with no special case, and every
+  correction is logged with its size so a run full of them is visible as the symptom it is.
+  One inherited behaviour is reproduced rather than tidied: **global sequences keep running while
+  the animation is paused, and ignore the speed**. The legacy viewport advances its global clock
+  before it decides whether the animation is paused, and its speed multiplier lives inside the
+  animation tick alone -- so a torch keeps flickering on a creature held still, in both viewports.
+
 ### Added
 - **Embedded Unity renderer: it plays the animation you picked, not its own idle.** The viewport
   now follows WMV's animation dropdown -- pick Run, Death or an emote and the Unity pane switches

--- a/Source/wowmodelviewer/UnityIpcServer.cpp
+++ b/Source/wowmodelviewer/UnityIpcServer.cpp
@@ -358,6 +358,28 @@ void UnityIpcServer::sendModelAnimation(int m2FileDataID, int sequenceIndex, int
   queueJson(msg);
 }
 
+void UnityIpcServer::sendModelAnimationState(int m2FileDataID, int sequenceIndex, bool playing,
+                                             int timeMs, float speed, bool loop)
+{
+  if (!m_client || !m_unityReady || sequenceIndex < 0)
+    return;
+
+  QJsonObject msg;
+  msg["type"] = "modelAnimationState";
+  msg["fileDataID"] = m2FileDataID;
+  msg["sequenceIndex"] = sequenceIndex;
+  msg["playing"] = playing;
+  msg["timeMs"] = timeMs;
+  msg["speed"] = speed;
+  msg["loop"] = loop;
+  m_stats.statePushes++;
+  m_stats.lastState = QString("%1 %2ms x%3").arg(playing ? "playing" : "paused")
+                                            .arg(timeMs).arg(speed, 0, 'f', 2);
+  // Deliberately not logged per push: the heartbeat would bury everything else in the log. The
+  // counter and lastState above are what a diagnostic run reports.
+  queueJson(msg);
+}
+
 void UnityIpcServer::sendLoadWoWModel(const QString & path, int fileDataID, const QString & client)
 {
   QJsonObject msg;

--- a/Source/wowmodelviewer/UnityIpcServer.h
+++ b/Source/wowmodelviewer/UnityIpcServer.h
@@ -31,6 +31,8 @@
  *       "geosets":[ 101 ], "hasGeosets":true }
  *     { "type":"modelAnimation", "fileDataID":1521037, "sequenceIndex":2, "animID":0,
  *       "durationMs":2000, "loop":true }
+ *     { "type":"modelAnimationState", "fileDataID":1521037, "sequenceIndex":2, "playing":true,
+ *       "timeMs":840, "speed":1.0, "loop":true }
  *
  * getModelTextures exists because modern M2s do NOT name their replaceable textures (a
  * creature skin's TXID entry is 0 and the texture array carries no filename) -- the skin comes
@@ -52,6 +54,15 @@
  * which is both how the keyframes are stored and how the app's own selector identifies a choice.
  * Two sequences routinely share an "animID" (sub-animations of one action), so the id alone
  * cannot pick one; it is carried for the log and for recognising the idle (animID 0, "Stand").
+ *
+ * modelAnimationState carries the PLAYBACK state of that animation: whether it is running, how
+ * fast, and where in the sequence it currently is. Unlike the skin and the animation choice there
+ * is no single funnel for it -- play/pause, the speed slider, the frame slider, stop, step and
+ * clear each change it, and the time advances every frame with no control involved at all -- so it
+ * is pushed on every control change AND on a slow heartbeat while playing. The heartbeat is the
+ * only correction channel for clock drift between two independently-timed renderers; the player
+ * decides whether a given "timeMs" is worth snapping to, because only it knows where its own
+ * clock is.
  *
  * Implementation: plain Winsock2, non-blocking, polled from the GUI thread by a wxTimer (the
  * app has no Qt event loop, so QTcpServer signals would never fire; and GAMEDIRECTORY must be
@@ -111,6 +122,11 @@ public:
   // entry. No-op when the player is not connected.
   void sendModelAnimation(int m2FileDataID, int sequenceIndex, int animID, int durationMs, bool loop);
 
+  // Runtime command: the playback state of that animation changed (or a heartbeat while it runs).
+  // timeMs is the app's current position in the sequence. No-op when the player is not connected.
+  void sendModelAnimationState(int m2FileDataID, int sequenceIndex, bool playing, int timeMs,
+                               float speed, bool loop);
+
   // Raised (on the GUI thread) when the player's unityReady arrives -- the host uses it to
   // push the currently displayed model.
   std::function<void()> onUnityReady;
@@ -129,11 +145,13 @@ public:
     long long bytesServed = 0;
     int skinPushes = 0;     // modelSkin messages sent (the displayed skin changed)
     int animPushes = 0;     // modelAnimation messages sent (the displayed animation changed)
+    int statePushes = 0;    // modelAnimationState messages sent (play/pause/speed/time)
     QString lastRequest;    // "path" or "fileDataID n"
     QString lastProvider;   // "CASC" / "MPQ" / ""
     QString lastError;
     QString lastSkin;       // "<fileDataID> (<source>)" of the last skin pushed
     QString lastAnimation;  // "seq <n> animID <id> <ms>ms" of the last animation pushed
+    QString lastState;      // "playing|paused <ms>ms x<speed>" of the last state pushed
   };
   const Stats & stats() const { return m_stats; }
 

--- a/Source/wowmodelviewer/animcontrol.cpp
+++ b/Source/wowmodelviewer/animcontrol.cpp
@@ -387,6 +387,7 @@ void AnimControl::UpdateModel(WoWModel *m)
       }
     }
     g_selModel->animManager->Play();
+    PushAnimationState();          // as in OnAnim: the selection was pushed while stopped
   }
   wmoList->Show(false);
   wmoLabel->Show(false);
@@ -1205,25 +1206,32 @@ void AnimControl::OnButton(wxCommandEvent &event)
 
   switch (event.GetId())
   {
+    // Every one of these changes what the viewport is doing without changing WHICH animation is
+    // selected, so each has to tell the embedded renderer itself -- there is no funnel to hang it
+    // on the way SelectAnimation covers the choice.
     case ID_PLAY :
         g_selModel->currentAnim = g_selModel->animManager->GetAnim();
         g_selModel->animManager->Play();
+        PushAnimationState();
         break;
     case ID_PAUSE :
         g_selModel->animManager->Pause();
+        PushAnimationState();
         break;
     case ID_STOP :
         g_selModel->animManager->Stop();
+        PushAnimationState();
         break;
     case ID_CLEARANIM :
         g_selModel->animManager->Clear();
+        PushAnimationState();
         break;
     case ID_ADDANIM :
         g_selModel->animManager->AddAnim(selectedAnim, loopList->GetSelection());
         break;
     case ID_PREVANIM :
         g_selModel->animManager->PrevFrame();
-        SetAnimFrame(g_selModel->animManager->GetFrame());
+        SetAnimFrame(g_selModel->animManager->GetFrame());   // pushes the new time itself
         break;
     case ID_NEXTANIM :
         g_selModel->animManager->NextFrame();
@@ -1320,6 +1328,11 @@ void AnimControl::OnAnim(wxCommandEvent &event)
           }
         }
         g_selModel->animManager->Play();
+        // Stop() paused the model before the selection, so the state that travelled with the
+        // selection said "not running". Play() undoes that in the app; without this it was
+        // never undone in the embedded renderer until the next heartbeat -- the half-second-
+        // odd hold the viewport showed after every animation change.
+        PushAnimationState();
         
         UpdateFrameSlider(g_selModel->anims[selectedAnim].length - 1, g_selModel->anims[selectedAnim].playSpeed);
       }
@@ -1427,6 +1440,7 @@ void AnimControl::OnLoop(wxCommandEvent &)
       }
     }
     g_selModel->animManager->Play();
+    PushAnimationState();          // as in OnAnim: the selection was pushed while stopped
   } 
 }
 
@@ -1625,6 +1639,25 @@ void AnimControl::SelectAnimation(int index, int loops)
     g_modelViewer->SendCurrentAnimationToUnity();
 }
 
+// The playback state has no single funnel to hook, so each control that changes it calls this.
+// Kept as one line here rather than repeated at every call site so the guard lives in one place.
+void AnimControl::PushAnimationState()
+{
+  if (g_modelViewer)
+    g_modelViewer->SendAnimationStateToUnity(true);
+}
+
+void AnimControl::pickAnimationLikeUser(int index)
+{
+  if (!animCList || index < 0 || index >= (int)animCList->GetCount())
+    return;
+  animCList->SetSelection(index);
+  wxCommandEvent pick(wxEVT_COMBOBOX, ID_ANIM);
+  pick.SetEventObject(animCList);
+  pick.SetInt(index);
+  OnAnim(pick);
+}
+
 int AnimControl::animationCount()
 {
   return animCList ? (int)animCList->GetCount() : 0;
@@ -1688,6 +1721,7 @@ void AnimControl::SetAnimSpeed(float speed)
   g_selModel->animManager->SetSpeed(speed);
   
   speedLabel->SetLabel(wxString::Format(_("Speed: %.1fx"), speed));
+  PushAnimationState();
 }
 
 void AnimControl::SetAnimFrame(size_t frame)
@@ -1699,6 +1733,9 @@ void AnimControl::SetAnimFrame(size_t frame)
 
   frameLabel->SetLabel(wxString::Format(_("Frame: %i"), frame));
   frameSlider->SetValue((int)frame);
+  // Scrubbing is the one case where the app's time jumps rather than advances, so the renderer
+  // has to be told: nothing about it is derivable from the clock it is running.
+  PushAnimationState();
 }
 
 void AnimControl::UpdateFrameSlider(int maxRange, int tickFreq)

--- a/Source/wowmodelviewer/animcontrol.h
+++ b/Source/wowmodelviewer/animcontrol.h
@@ -182,6 +182,15 @@ public:
   // dropdown's "[n]" suffix carries and what the animation manager takes.
   void SelectAnimation(int index, int loops);
 
+  // Tell the embedded Unity viewport the current play/pause, speed and time. Called by every
+  // control that changes any of them; see ModelViewer::SendAnimationStateToUnity.
+  void PushAnimationState();
+
+  // Pick an animation the way the USER does -- through the dropdown's own handler, which stops
+  // the model, selects, and plays again. Diagnostics only: SelectAnimation is the funnel for code,
+  // but only this path exercises what OnAnim does around it.
+  void pickAnimationLikeUser(int index);
+
   // Entries in the animation selector and one entry's label -- diagnostics only, mirroring
   // skinCount/skinName so the -unityipctest run can walk animations the same way.
   int animationCount();

--- a/Source/wowmodelviewer/app.cpp
+++ b/Source/wowmodelviewer/app.cpp
@@ -381,6 +381,7 @@ static void doHeadlessUnityIpcTest(ModelViewer * frame)
       LOG_INFO << "[unityipc-test] skin-sync: skinPushes=" << ipc->stats().skinPushes
                << "lastSkin=" << ipc->stats().lastSkin;
 
+      const WoWModel * mdl2 = frame->canvas ? frame->canvas->model() : NULL;
       // Animation sync: the viewport plays ONE of the model's animations and the renderer has to
       // play the same one. Walk a spread of the selector rather than all of it -- a boss has
       // hundreds of entries and each push has to reach the player before the next -- and report
@@ -414,6 +415,234 @@ static void doHeadlessUnityIpcTest(ModelViewer * frame)
         }
         LOG_INFO << "[unityipc-test] animation-sync: animPushes=" << ipc->stats().animPushes
                  << "lastAnimation=" << ipc->stats().lastAnimation;
+
+        // EXTERNAL ANIMATIONS. A sequence without flag 0x20 keeps its keyframes in a .anim file
+        // rather than in the .m2; the legacy viewport reads those files (WoWModel::readAnimsFromFile)
+        // and plays such a sequence normally, so the embedded renderer has to as well. These are
+        // the sequences that used to fall back to the idle in the Unity pane while playing fine in
+        // the OpenGL one -- Agronn's SitGroundDown among them -- so the self-test drives them
+        // explicitly rather than hoping the sampled walk lands on one.
+        if (mdl2 && ac)
+        {
+          int externalDriven = 0;
+          for (size_t s = 0; s < mdl2->anims.size() && externalDriven < 8; s++)
+          {
+            if (mdl2->anims[s].flags & 0x20)
+              continue;                       // its keys are in the .m2
+            if (mdl2->anims[s].length == 0)
+              continue;                       // nothing to play either way
+            LOG_INFO << "[unityipc-test]   external anim: sequence" << (int)s
+                     << "animID" << mdl2->anims[s].animID
+                     << "subAnimID" << mdl2->anims[s].subAnimID
+                     << "flags" << QString("0x%1").arg(mdl2->anims[s].flags, 0, 16)
+                     << "length" << mdl2->anims[s].length;
+            ac->SelectAnimation((int)s, 0);
+            // A .anim fetch is a round trip, so give it longer than an in-file switch needs.
+            for (int i = 0; i < 60; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+            externalDriven++;
+          }
+          LOG_INFO << "[unityipc-test] external-anim check: drove" << externalDriven
+                   << "sequence(s) whose keyframes are in .anim files";
+
+          // THE DROPDOWN PATH. AnimControl::OnAnim is what the user actually operates, and it is
+          // NOT SelectAnimation: it stops the model, selects, and plays again. Only the selection
+          // pushed anything, so the renderer was told "this animation, not running" and nothing
+          // afterwards -- it sat still until the next heartbeat. Driving the handler itself is the
+          // only way a headless run can see that, which is why it is done here rather than by
+          // calling SelectAnimation like the checks above.
+          if (ac->animationCount() > 0)
+          {
+            const int pickIndex = (ac->animationCount() > 1) ? 1 : 0;
+            const wxString label = ac->animationName(pickIndex);
+            ac->pickAnimationLikeUser(pickIndex);
+            for (int i = 0; i < 40; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+
+            const bool saysPlaying = ipc->stats().lastState.startsWith("playing");
+            LOG_INFO << "[unityipc-test] dropdown check: picked"
+                     << QString::fromWCharArray(label.c_str())
+                     << "-> app paused=" << (mdl2->animManager->IsPaused() ? 1 : 0)
+                     << "lastState=" << ipc->stats().lastState
+                     << (saysPlaying
+                         ? "(OK: the state after a dropdown change says the animation is running)"
+                         : "(BAD: the renderer was left holding until the next heartbeat)");
+            if (!saysPlaying)
+              LOG_ERROR << "[unityipc-test] dropdown change left the renderer paused";
+          }
+
+          // SELECTION MUST CARRY ITS STATE. Changing animation has to tell the renderer what the
+          // app is doing with it in the same breath -- if the state only turned up on the next
+          // heartbeat, the viewport would sit there for up to a second before the new animation
+          // started, which is the difference between "instant" and "laggy" to anyone using it.
+          // The counters make that checkable: one selection must produce one of each push.
+          {
+            AnimManager * am = mdl2->animManager;      // same manager, this block's own handle
+            const int animsBefore = ipc->stats().animPushes;
+            int probe = -1;
+            for (size_t s = 0; s < mdl2->anims.size(); s++)
+              if (mdl2->anims[s].length > 0) { probe = (int)s; break; }
+
+            if (probe >= 0)
+            {
+              // ...while PLAYING
+              am->Play();
+              ac->PushAnimationState();
+              const int stateAfterPlay = ipc->stats().statePushes;
+              ac->SelectAnimation(probe, 0);
+              LOG_INFO << "[unityipc-test]   selection while PLAYING -> animPushes +"
+                       << (ipc->stats().animPushes - animsBefore) << "statePushes +"
+                       << (ipc->stats().statePushes - stateAfterPlay)
+                       << "(both must be >= 1 -- the state cannot wait for the heartbeat)"
+                       << "lastState=" << ipc->stats().lastState;
+              for (int i = 0; i < 40; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+
+              // ...and while PAUSED. The renderer must hold, not run: a switch while paused shows
+              // the new animation's first frame and stays there.
+              am->Pause(true);
+              ac->PushAnimationState();
+              const int stateAfterPause = ipc->stats().statePushes;
+              const int animAfterPause = ipc->stats().animPushes;
+              int other = -1;
+              for (size_t s = 0; s < mdl2->anims.size(); s++)
+                if (mdl2->anims[s].length > 0 && (int)s != probe) { other = (int)s; break; }
+              if (other >= 0)
+              {
+                ac->SelectAnimation(other, 0);
+                LOG_INFO << "[unityipc-test]   selection while PAUSED -> animPushes +"
+                         << (ipc->stats().animPushes - animAfterPause) << "statePushes +"
+                         << (ipc->stats().statePushes - stateAfterPause)
+                         << "paused=" << (am->IsPaused() ? 1 : 0)
+                         << "lastState=" << ipc->stats().lastState;
+                for (int i = 0; i < 40; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+              }
+              am->Play();
+              ac->PushAnimationState();
+              for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+            }
+          }
+
+          // REVISIT. Going back to an animation already played is what a user does constantly --
+          // comparing two animations means switching between them repeatedly -- so it has to be
+          // the cheapest thing the renderer does: read once, kept, and the second visit should
+          // neither fetch nor read nor allocate. The player logs which path it took, so the run
+          // shows whether the cache actually caught it.
+          //
+          // Prefer a sequence whose keyframes are EXTERNAL. That exercises both caches at once:
+          // the .anim bytes must not be fetched twice, and the tracks read out of them must not
+          // be read twice. An in-file sequence only exercises the second.
+          if (!mdl2->anims.empty())
+          {
+            int first = -1, second = -1;
+            for (size_t s = 0; s < mdl2->anims.size(); s++)   // an external one, if there is one
+            {
+              if (mdl2->anims[s].length == 0 || (mdl2->anims[s].flags & 0x20))
+                continue;
+              first = (int)s;
+              break;
+            }
+            for (size_t s = 0; s < mdl2->anims.size(); s++)
+            {
+              if (mdl2->anims[s].length == 0 || (int)s == first)
+                continue;
+              if (first < 0) { first = (int)s; continue; }
+              second = (int)s;
+              break;
+            }
+            if (first >= 0 && second >= 0)
+            {
+              LOG_INFO << "[unityipc-test] revisit check: sequence" << first
+                       << (mdl2->anims[first].flags & 0x20 ? "(in-file)" : "(external .anim)")
+                       << "-> " << second << "-> " << first
+                       << "-- the last one must come from the cache, with no second fetch";
+              for (int pass = 0; pass < 3; pass++)
+              {
+                ac->SelectAnimation(pass == 1 ? second : first, 0);
+                for (int i = 0; i < 60; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+              }
+            }
+          }
+        }
+
+        // Playback state: the same animation, driven through the transport controls. Each step
+        // reports what the app now holds, so a run shows the whole chain from the control to the
+        // state that left the app -- and the player's own log shows what it did with it.
+        AnimManager * am = mdl2 ? mdl2->animManager : NULL;
+        // The scrub below indexes anims by the manager's current animation, so both have to be
+        // real: a model can reach here with a populated selector but nothing playable.
+        if (am && (am->GetAnim() >= mdl2->anims.size()))
+          am = NULL;
+        LOG_INFO << "[unityipc-test] playback-state check:";
+        if (am)
+        {
+          // pause
+          am->Pause(true);
+          ac->PushAnimationState();
+          LOG_INFO << "[unityipc-test]   pause     -> playing=" << (am->IsPaused() ? 0 : 1)
+                   << "timeMs=" << (int)am->GetFrame() << "speed=" << am->GetSpeed();
+          for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+
+          // scrub while paused
+          ac->SetAnimFrame(mdl2->anims[am->GetAnim()].length / 3);
+          LOG_INFO << "[unityipc-test]   scrub     -> playing=" << (am->IsPaused() ? 0 : 1)
+                   << "timeMs=" << (int)am->GetFrame();
+          for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+
+          // speed
+          ac->SetAnimSpeed(2.0f);
+          LOG_INFO << "[unityipc-test]   speed 2x  -> speed=" << am->GetSpeed();
+          for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+
+          // A skin change WHILE PAUSED. Selecting a skin re-pushes the texture set and the
+          // geoset set, and the two subsystems have to stay out of each other's way: the model
+          // must not resume because its skin changed, and must not lose the frame it is held on.
+          if (skins > 1)
+          {
+            const size_t heldFrame = am->GetFrame();
+            ac->SetSkin(0);
+            for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+            std::vector<int> pausedGeosets;
+            UnityAssetAccess::selectedModelGeosets(fdid, pausedGeosets);
+            QString pausedGeoStr;
+            for (size_t gi = 0; gi < pausedGeosets.size(); gi++)
+              pausedGeoStr += (gi ? "," : "") + QString::number(pausedGeosets[gi]);
+            if (pausedGeoStr.isEmpty())
+              pausedGeoStr = "none";
+            LOG_INFO << "[unityipc-test]   skin while paused -> skin[0] geosets=" << pausedGeoStr
+                     << "| playback still playing=" << (am->IsPaused() ? 0 : 1)
+                     << "timeMs=" << (int)am->GetFrame()
+                     << (am->GetFrame() == heldFrame ? "(frame held)" : "(FRAME MOVED)");
+
+            ac->SetSkin(skins - 1);
+            for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+            LOG_INFO << "[unityipc-test]   skin while paused -> skin[" << (skins - 1)
+                     << "] | playback still playing=" << (am->IsPaused() ? 0 : 1)
+                     << "timeMs=" << (int)am->GetFrame()
+                     << (am->GetFrame() == heldFrame ? "(frame held)" : "(FRAME MOVED)");
+          }
+
+          // resume
+          am->Play();
+          ac->PushAnimationState();
+          LOG_INFO << "[unityipc-test]   resume    -> playing=" << (am->IsPaused() ? 0 : 1)
+                   << "timeMs=" << (int)am->GetFrame() << "speed=" << am->GetSpeed();
+          for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+
+          // ...and the same change while it RUNS, which is the other half: a skin push must not
+          // stop or restart the animation either.
+          if (skins > 1)
+          {
+            ac->SetSkin(0);
+            for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+            LOG_INFO << "[unityipc-test]   skin while animated -> skin[0] | playback still playing="
+                     << (am->IsPaused() ? 0 : 1) << "timeMs=" << (int)am->GetFrame();
+          }
+
+          // back to something ordinary so the run does not end in a doubled-speed state
+          ac->SetAnimSpeed(1.0f);
+          for (int i = 0; i < 20; i++) { ipc->poll(); wxTheApp->Yield(true); wxMilliSleep(10); }
+
+          LOG_INFO << "[unityipc-test] playback-state: statePushes=" << ipc->stats().statePushes
+                   << "lastState=" << ipc->stats().lastState;
+        }
       }
     }
   }
@@ -426,8 +655,12 @@ static void doHeadlessUnityIpcTest(ModelViewer * frame)
   // nothing to sync, so the condition only bites when there was something to send.
   const bool animsOk = (frame->animControl == NULL) || (frame->animControl->animationCount() == 0) ||
                        (ipc->stats().animPushes >= 1);
+  // Same shape for the playback state: a model with animations must have reported how it is
+  // playing them at least once.
+  const bool stateOk = (frame->animControl == NULL) || (frame->animControl->animationCount() == 0) ||
+                       (ipc->stats().statePushes >= 1);
   const bool pass = st.connections >= 1 && ipc->isUnityReady() && st.requests >= 1 &&
-                    st.responsesOk >= 1 && skinsOk && animsOk;
+                    st.responsesOk >= 1 && skinsOk && animsOk && stateOk;
   LOG_INFO << "[unityipc-test] RESULT:" << (pass ? "PASS" : "FAIL");
 
   // Close the player now (what app shutdown does) and confirm the child process is gone.

--- a/Source/wowmodelviewer/modelcanvas.cpp
+++ b/Source/wowmodelviewer/modelcanvas.cpp
@@ -1506,6 +1506,12 @@ void ModelCanvas::tick()
 
   globalTime += (ddt);
 
+  // The embedded Unity viewport times itself, so it drifts against this clock. This is the only
+  // place that runs every frame with the animation state to hand; the call rate-limits itself to
+  // a heartbeat and does nothing at all when the Unity pane was never opened.
+  if (g_modelViewer)
+    g_modelViewer->SendAnimationStateToUnity(false);
+
   if (model_) {
     if (model_->animManager && !wmo) {
       if (model_->animManager->IsPaused())

--- a/Source/wowmodelviewer/modelviewer.cpp
+++ b/Source/wowmodelviewer/modelviewer.cpp
@@ -227,6 +227,7 @@ ModelViewer::ModelViewer()
   imageControl = NULL;
   settingsControl = NULL;
   unityRendererHost = NULL;
+  m_lastAnimStatePush = 0;
   animExporter = NULL;
   fileControl = NULL;
 
@@ -1636,6 +1637,58 @@ void ModelViewer::SendCurrentAnimationToUnity()
   unityRendererHost->ipc()->sendModelAnimation((int)m->gamefile->fileDataId(), index,
                                                m->anims[index].animID, (int)m->anims[index].length,
                                                true);
+  // A new selection restarts at frame 0 and keeps whatever play/pause and speed were in force;
+  // send that alongside so the renderer does not briefly run an animation the app has paused.
+  SendAnimationStateToUnity(true);
+}
+
+// Whether the animation is running, how fast, and where it is.
+//
+// This one has NO single funnel, unlike the skin and the animation choice. Play, pause, stop,
+// clear, the two step buttons, the speed slider and the frame slider all change it, and the time
+// advances every frame with no control involved at all. So it is pushed two ways: forced from each
+// of those controls, and on a slow heartbeat from the canvas tick while something is playing.
+//
+// The heartbeat exists because two renderers timing themselves independently drift apart; it is
+// the channel that corrects that. It is deliberately slow, and the PLAYER decides whether a given
+// timestamp is worth snapping to -- only it knows where its own clock is, and snapping on every
+// message would trade drift for jitter.
+void ModelViewer::SendAnimationStateToUnity(bool force)
+{
+  if (!unityRendererHost || !unityRendererHost->ipc() || !unityRendererHost->ipc()->isConnected())
+    return;
+  if (!canvas || !canvas->model() || !canvas->model()->gamefile)
+    return;
+  WoWModel * m = const_cast<WoWModel *>(canvas->model());
+  if (!m->animManager || m->anims.empty())
+    return;
+
+  const int index = (int)m->animManager->GetAnim();
+  if (index < 0 || index >= (int)m->anims.size())
+    return;
+
+  const bool playing = !m->animManager->IsPaused();
+  const float speed = m->animManager->GetSpeed();
+  const int timeMs = (int)m->animManager->GetFrame();
+
+  if (!force)
+  {
+    // Heartbeat. A paused model cannot drift, so it needs none; and the interval is long enough
+    // that this is a rounding error next to the asset traffic the same channel already carries.
+    if (!playing)
+      return;
+    const unsigned long now = timeGetTime();
+    if (m_lastAnimStatePush != 0 && (now - m_lastAnimStatePush) < ANIM_STATE_HEARTBEAT_MS)
+      return;
+    m_lastAnimStatePush = now;
+  }
+  else
+  {
+    m_lastAnimStatePush = timeGetTime();
+  }
+
+  unityRendererHost->ipc()->sendModelAnimationState((int)m->gamefile->fileDataId(), index,
+                                                    playing, timeMs, speed, true);
 }
 
 // Menu button press events

--- a/Source/wowmodelviewer/modelviewer.h
+++ b/Source/wowmodelviewer/modelviewer.h
@@ -71,6 +71,9 @@ public:
   // first View > Unity Renderer use or by the -unityipctest self-test (nullptr until then).
   // See UnityRendererHost.h and docs/unity-renderer/README.md.
   UnityRendererHost *unityRendererHost;
+  // timeGetTime() of the last playback-state push, for the heartbeat in
+  // SendAnimationStateToUnity. 0 until the first push.
+  unsigned long m_lastAnimStatePush;
 
   CAnimationExporter *animExporter;
 
@@ -173,6 +176,16 @@ public:
   void SendCurrentModelToUnity();
   void SendCurrentSkinToUnity();
   void SendCurrentAnimationToUnity();
+
+  // The playback state of that animation: playing/paused, speed, and where in the sequence the
+  // app is. force pushes unconditionally (a control was used); without it this is the heartbeat,
+  // which pushes only while something is playing and only every so often. Safe and cheap to call
+  // every frame -- it rate-limits itself and no-ops when the Unity pane was never opened.
+  void SendAnimationStateToUnity(bool force = false);
+
+  // How often the heartbeat above may push while an animation runs. One a second is far below
+  // anything a viewer would notice and far above what clock drift needs.
+  static const unsigned long ANIM_STATE_HEARTBEAT_MS = 1000;
 
   void OnMount(wxCommandEvent &event);
   void OnSave(wxCommandEvent &event);

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
@@ -24,6 +24,7 @@
 //   modelTextures { requestId, ok, fileDataID, textures:[{ index, type, fileDataID, source }] }
 //   modelSkin     { fileDataID, textures:[...], geosets:[...], hasGeosets }        (pushed, no request)
 //   modelAnimation { fileDataID, sequenceIndex, animID, durationMs, loop }         (pushed, no request)
+//   modelAnimationState { fileDataID, sequenceIndex, playing, timeMs, speed, loop } (pushed, no request)
 //
 // getModelTextures exists because a modern M2 does not name its replaceable textures (a
 // creature skin's TXID entry is 0 and its texture array carries no filename) -- the skin comes
@@ -55,6 +56,7 @@ public class WmvIpcClient : MonoBehaviour
     public Action<ModelTexturesResponse> OnModelTextures;
     public Action<ModelTexturesResponse> OnModelSkin;          // pushed when the displayed skin changes
     public Action<AnimationSelection> OnModelAnimation;        // pushed when the displayed animation changes
+    public Action<AnimationState> OnModelAnimationState;       // pushed on play/pause/speed/time changes
     public Action<string> OnStatus;                            // human-readable connection/state text
 
     public bool Connected { get { return connected; } }
@@ -128,6 +130,20 @@ public class WmvIpcClient : MonoBehaviour
         public bool loop;
     }
 
+    /// <summary>
+    /// How the app is playing that animation. timeMs is where the app's own clock is; the player
+    /// decides whether that is far enough from its own to be worth snapping to.
+    /// </summary>
+    public struct AnimationState
+    {
+        public int fileDataID;
+        public int sequenceIndex;
+        public bool playing;
+        public int timeMs;
+        public float speed;
+        public bool loop;
+    }
+
     [Serializable] class MsgTexture
     {
         public int index;
@@ -157,6 +173,9 @@ public class WmvIpcClient : MonoBehaviour
         public int animID;
         public int durationMs;
         public bool loop;
+        public bool playing;
+        public int timeMs;
+        public float speed;
     }
 
     int port = -1;
@@ -292,6 +311,18 @@ public class WmvIpcClient : MonoBehaviour
             // reply, minus the requestId -- nothing asked for it.
             case "modelSkin":
                 OnModelSkin?.Invoke(ReadTextures(msg));
+                break;
+
+            case "modelAnimationState":
+                OnModelAnimationState?.Invoke(new AnimationState
+                {
+                    fileDataID = msg.fileDataID,
+                    sequenceIndex = msg.sequenceIndex,
+                    playing = msg.playing,
+                    timeMs = msg.timeMs,
+                    speed = msg.speed,
+                    loop = msg.loop,
+                });
                 break;
 
             case "modelAnimation":

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
@@ -65,9 +65,106 @@ public class WmvM2Animator : MonoBehaviour
     }
 
     AnimatedBone[] bones = new AnimatedBone[0];
+
+    /// <summary>
+    /// Converted tracks, keyed by sequence index.
+    ///
+    /// Setup turns the parsed WoW tracks into the renderer's own space -- every key of every
+    /// moving bone, three tracks each -- and that conversion allocates. Doing it again each time
+    /// the user returns to an animation they have already watched is the last per-switch
+    /// allocation left after the parse and the fetch were dealt with, so it is kept too. The
+    /// entries hold this model's bone transforms, so the cache is dropped whenever the animator is
+    /// pointed at a different skeleton.
+    /// </summary>
+    readonly Dictionary<int, AnimatedBone[]> convertedBySequence = new Dictionary<int, AnimatedBone[]>();
+    Transform[] cachedFor;              // the skeleton the cache above belongs to
+    readonly Dictionary<int, int> globalCountBySequence = new Dictionary<int, int>();
     uint[] globalSequences = new uint[0];
     float lengthMs = 1f;
     double timeMs;
+
+    /// <summary>
+    /// Playback state, mirrored from the app. It is the app's clock that is authoritative: this
+    /// renderer runs its own only so the motion is smooth between the messages that carry it.
+    /// </summary>
+    bool playing = true;
+    float speed = 1f;
+
+    /// <summary>
+    /// How far this renderer's clock may sit from the app's before it is snapped.
+    ///
+    /// Two renderers timing themselves independently drift, and the app sends its position on a
+    /// slow heartbeat to correct that. Snapping on every message would trade the drift for a
+    /// visible stutter once a second, so a small difference is left alone -- at 30 frames a second
+    /// one frame is 33 ms, and a difference under that cannot be seen.
+    /// </summary>
+    const float TimeSnapToleranceMs = 40f;
+
+    /// <summary>
+    /// After a sequence change, how long until the animation actually MOVES again?
+    ///
+    /// This is the measurement the switching work needed and did not have. Timing the switch
+    /// itself only ever showed the parse and the fetch; what a viewer notices is whether the model
+    /// starts moving on the next frame or stands there. Those are different questions, and for a
+    /// while the answer to the second was "up to a second" while the first said "one millisecond".
+    ///
+    /// Reports the frames AND the milliseconds, so a hold is distinguishable from a stall: if
+    /// frames keep counting while the time stands still, the renderer is running fine and the
+    /// animation is being held -- which is what a missing playback-state push looks like.
+    /// Diagnostics only, under -wmvAnimCheck.
+    /// </summary>
+    int advanceWatchFrame = -1;
+    float advanceWatchStart;
+    int advanceWatchFrames;
+
+    public void BeginAdvanceWatch()
+    {
+        if (!WmvModelBuilder.Debug_.AnimCheck)
+            return;
+        advanceWatchFrame = Time.frameCount;
+        advanceWatchStart = Time.realtimeSinceStartup;
+        advanceWatchFrames = 0;
+    }
+
+    void AdvanceWatchTick(double before, double dt)
+    {
+        if (advanceWatchFrame < 0)
+            return;
+        advanceWatchFrames++;
+        if (timeMs != before)
+        {
+            Debug.Log(string.Format(
+                "WMV: anim: moving again {0} frame(s) / {1:F0} ms after the switch "
+                + "(playing={2} speed={3:F2}, frame time {4:F1} ms)",
+                Time.frameCount - advanceWatchFrame,
+                (Time.realtimeSinceStartup - advanceWatchStart) * 1000.0, playing, speed, dt));
+            advanceWatchFrame = -1;
+            return;
+        }
+        // A model the app has PAUSED is supposed to stand still; that is the feature, not a fault.
+        // Stop watching rather than reporting it.
+        if (!playing || speed <= 0f)
+        {
+            advanceWatchFrame = -1;
+            return;
+        }
+        // Rendering, told to play, and still not moving. Said once, loudly: it means the app never
+        // told this renderer to resume, and it will sit here until something does.
+        if (advanceWatchFrames == 30)
+            Debug.LogWarning(string.Format(
+                "WMV: anim: still not moving {0} frames / {1:F0} ms after the switch -- frames ARE "
+                + "running, so the animation is being HELD (playing={2} speed={3:F2})",
+                advanceWatchFrames, (Time.realtimeSinceStartup - advanceWatchStart) * 1000.0,
+                playing, speed));
+    }
+
+    /// <summary>How many corrections were needed, out of how many state messages. Reported with
+    /// each correction, because that ratio is what says whether the two clocks keep step.</summary>
+    public int SnapCount { get; private set; }
+    public int StateUpdates { get; private set; }
+
+    public bool IsPlaying { get { return playing; } }
+    public float Speed { get { return speed; } }
 
     /// <summary>Sequence index and AnimId, for the log and for nothing else.</summary>
     public int SequenceIndex { get; private set; }
@@ -93,6 +190,28 @@ public class WmvM2Animator : MonoBehaviour
         M2Sequence seq = model.Sequences[SequenceIndex];
         AnimId = seq.AnimId;
         lengthMs = seq.Length > 0 ? seq.Length : 1f;
+
+        // A different skeleton invalidates everything converted against the previous one.
+        if (!ReferenceEquals(cachedFor, boneTransforms))
+        {
+            convertedBySequence.Clear();
+            cachedFor = boneTransforms;
+        }
+
+        AnimatedBone[] already;
+        if (convertedBySequence.TryGetValue(SequenceIndex, out already))
+        {
+            bones = already;
+            GlobalSequenceTrackCount = globalCountBySequence.ContainsKey(SequenceIndex)
+                ? globalCountBySequence[SequenceIndex] : 0;
+            timeMs = 0.0;
+            if (log != null)
+                log(string.Format("anim: sequence [{0}] animId {1}{2}, {3} ms, {4} bone(s) move "
+                                  + "(tracks already converted)",
+                                  SequenceIndex, AnimId, AnimId == 0 ? " (Stand)" : "",
+                                  lengthMs, bones.Length));
+            return;
+        }
 
         var kept = new List<AnimatedBone>();
         int globalTracks = 0;
@@ -123,6 +242,8 @@ public class WmvM2Animator : MonoBehaviour
 
         bones = kept.ToArray();
         GlobalSequenceTrackCount = globalTracks;
+        convertedBySequence[SequenceIndex] = bones;
+        globalCountBySequence[SequenceIndex] = globalTracks;
 
         if (log != null)
         {
@@ -150,11 +271,91 @@ public class WmvM2Animator : MonoBehaviour
     void LateUpdate()
     {
         double dt = Time.deltaTime * 1000.0;
+
+        // GLOBAL SEQUENCES KEEP RUNNING WHILE THE ANIMATION IS PAUSED, and ignore the speed. That
+        // is not an oversight copied by accident: the legacy viewport advances its global clock
+        // before it decides whether the animation is paused, and its speed multiplier lives inside
+        // the animation tick alone (ModelCanvas::tick / AnimManager::Tick). A torch keeps
+        // flickering while the creature is held still.
         GlobalTimeMs += dt;
-        timeMs += dt;
-        if (timeMs >= lengthMs)
-            timeMs -= Math.Floor(timeMs / lengthMs) * lengthMs;
+
+        double beforeTimeMs = timeMs;
+
+        if (playing)
+        {
+            timeMs += dt * speed;
+            if (timeMs >= lengthMs)
+                timeMs -= Math.Floor(timeMs / lengthMs) * lengthMs;
+            else if (timeMs < 0.0)
+                timeMs += Math.Ceiling(-timeMs / lengthMs) * lengthMs;
+        }
         ApplyPose((float)timeMs);
+        AdvanceWatchTick(beforeTimeMs, dt);
+    }
+
+    /// <summary>
+    /// Mirror the app's playback state.
+    ///
+    /// Play/pause and speed are taken as given -- they are state, not measurements. The TIME is
+    /// treated as a correction rather than an assignment: it is only applied when this renderer's
+    /// own clock has drifted further than a frame away from it, because the app sends its position
+    /// on a heartbeat and snapping to every one would replace smooth motion with a periodic jump.
+    /// An explicit change (a scrub, a stop, a new selection) arrives with the app's time already
+    /// far from this one, so it snaps naturally without needing to be flagged as special.
+    /// </summary>
+    /// <summary>
+    /// Apply play/pause and speed WITHOUT touching the clock.
+    ///
+    /// Those two are the app's state, not the sequence's: they stay true while a switch is still
+    /// resolving, or has landed somewhere other than what was asked for. The position is the one
+    /// thing that would be wrong to carry across in those cases, so it is left alone.
+    /// </summary>
+    public void SetTransportOnly(bool isPlaying, float playbackSpeed)
+    {
+        playing = isPlaying;
+        speed = playbackSpeed > 0f ? playbackSpeed : 0f;
+        if (!playing)
+            ApplyPose((float)timeMs);
+    }
+
+    public void SetPlaybackState(bool isPlaying, float timeFromApp, float playbackSpeed)
+    {
+        StateUpdates++;
+        if (WmvModelBuilder.Debug_.AnimCheck)
+            Debug.Log(string.Format("WMV: anim state #{0}: playing={1} timeMs={2:F0} speed={3:F2} " +
+                                    "(mine {4:F0})", StateUpdates, isPlaying, timeFromApp,
+                                    playbackSpeed, timeMs));
+        playing = isPlaying;
+        speed = playbackSpeed > 0f ? playbackSpeed : 0f;
+
+        if (lengthMs > 0f)
+        {
+            float mine = (float)timeMs;
+            float theirs = timeFromApp % lengthMs;
+            if (theirs < 0f) theirs += lengthMs;
+            // Measure the SHORT way round the loop: 10 ms and (length - 10) ms are 20 ms apart,
+            // not a whole sequence apart, and a plain subtraction would snap on every wrap.
+            float diff = Math.Abs(mine - theirs);
+            if (diff > lengthMs * 0.5f)
+                diff = lengthMs - diff;
+            if (diff > TimeSnapToleranceMs)
+            {
+                timeMs = theirs;
+                SnapCount++;
+                // Logged every time, because it is rare by construction: an explicit change (a
+                // scrub, a stop) or genuine clock drift. A run that fills the log with these is
+                // telling you the two clocks are not keeping step, which is worth knowing.
+                Debug.Log(string.Format(
+                    "WMV: anim: clock corrected by {0:F0} ms -- was {1:F0}, app says {2:F0} " +
+                    "(correction {3} of {4} state update(s))",
+                    diff, mine, theirs, SnapCount, StateUpdates));
+            }
+        }
+
+        // A paused model still has to show the frame it is paused on -- LateUpdate will not pose it
+        // while playing is false, and the pose it is holding may be the one before the scrub.
+        if (!playing)
+            ApplyPose((float)timeMs);
     }
 
     /// <summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -66,6 +66,41 @@ public class WmvMain : MonoBehaviour
     SkinJob skinJob;                  // in-flight skin change, if any
 
     /// <summary>
+    /// Bone tracks already read, keyed by sequence index.
+    ///
+    /// Reading a sequence's keyframes allocates its track arrays, and doing that again every time
+    /// the user returns to an animation they have already watched is both wasted work and -- more
+    /// to the point -- wasted garbage, which is what a switch is felt as. Cached, going back to a
+    /// sequence costs one dictionary lookup and no allocation at all.
+    ///
+    /// Bounded by what the user actually plays, and strictly lighter than the legacy viewport,
+    /// which reads EVERY sequence's tracks at load and holds them for the model's lifetime.
+    /// </summary>
+    readonly Dictionary<int, M2BoneDef[]> boneTrackCache = new Dictionary<int, M2BoneDef[]>();
+
+    /// <summary>
+    /// External .anim files already fetched, keyed by FileDataID. A sequence whose keyframes are
+    /// not in the .m2 needs its .anim bytes; fetching them again on every visit would put a
+    /// network round trip in front of an animation the renderer already has.
+    /// </summary>
+    readonly Dictionary<int, byte[]> animFileCache = new Dictionary<int, byte[]>();
+
+    /// <summary>The .anim fetch in flight, if any: requestId -> the sequence waiting on it.</summary>
+    readonly Dictionary<string, int> pendingAnimFetch = new Dictionary<string, int>();
+
+    /// <summary>
+    /// The last playback state the app sent, whether or not it could be applied when it arrived.
+    ///
+    /// A state message names the sequence it is about, and it used to be dropped whenever the
+    /// renderer was not already on that sequence. That is exactly the moment it matters most: a
+    /// selection that fell back to the idle, or one still waiting on its .anim file, would lose
+    /// the app's play/pause, speed and position entirely and keep whatever the previous animation
+    /// happened to be doing. Kept here, it can be applied to whatever ends up playing.
+    /// </summary>
+    WmvIpcClient.AnimationState lastAppState;
+    bool haveAppState;
+
+    /// <summary>
     /// The geoset numbers the displayed creature variant switches on, or null when the host has
     /// not reported any. Two variants of the same creature can differ by GEOMETRY rather than
     /// texture -- one horse's mane instead of another -- and this is what decides which submeshes
@@ -104,6 +139,13 @@ public class WmvMain : MonoBehaviour
         // The player is embedded in a host app whose window normally has focus; without this it
         // would pause immediately. (Also set Run In Background in Player Settings.)
         Application.runInBackground = true;
+
+        // Every Debug.Log otherwise walks and formats a full managed stack trace before writing
+        // the line -- for an ORDINARY log, on the main thread. This renderer logs what it decided
+        // about every batch, material, skin and animation, so that cost lands in the middle of the
+        // work it is describing. The traces stay on for warnings and errors, where something has
+        // actually gone wrong and the trace is the point.
+        Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
 
         var cam = Camera.main;
         if (cam == null)
@@ -145,6 +187,7 @@ public class WmvMain : MonoBehaviour
         ipc.OnModelTextures = HandleModelTextures;
         ipc.OnModelSkin = HandleModelSkin;
         ipc.OnModelAnimation = HandleModelAnimation;
+        ipc.OnModelAnimationState = HandleModelAnimationState;
     }
 
     // ---------------------------------------------------------------- load pipeline
@@ -163,6 +206,11 @@ public class WmvMain : MonoBehaviour
         // after this message, so the value is refilled before the .m2 arrives to be parsed.
         selectedSequence = -1;
         currentM2Bytes = null;
+        // Sequence indices and file ids mean nothing across models.
+        boneTrackCache.Clear();
+        animFileCache.Clear();
+        pendingAnimFetch.Clear();
+        haveAppState = false;
 
         job = new LoadJob { Path = path, FileDataID = fileDataID };
         status.Set("Requested " + (string.IsNullOrEmpty(path) ? ("fileDataID " + fileDataID) : path));
@@ -178,6 +226,13 @@ public class WmvMain : MonoBehaviour
         if (skinJob != null && skinJob.Pending.ContainsKey(r.requestId))
         {
             OnSkinTextureBytes(r);
+            return;
+        }
+        // An external .anim answer belongs to an animation change, not to a load.
+        int waitingSequence;
+        if (pendingAnimFetch.TryGetValue(r.requestId, out waitingSequence))
+        {
+            OnAnimFileBytes(r, waitingSequence);
             return;
         }
         if (job == null)
@@ -350,6 +405,11 @@ public class WmvMain : MonoBehaviour
             foreach (var kv in job.Textures) currentTextures[kv.Key] = kv.Value;
             skinJob = null;
 
+            // Ask for this creature's .anim files now rather than when one is first played, so no
+            // animation switch ever waits on a round trip. They arrive while the user is looking
+            // at the model, not while they are waiting for the animation they just picked.
+            PrefetchAnimFiles();
+
             orbit.Frame(built.Bounds);
 
             status.Set("Loaded " + job.Path);
@@ -402,33 +462,254 @@ public class WmvMain : MonoBehaviour
             return;
         }
 
+        SwitchToSequence(a.sequenceIndex);
+    }
+
+    /// <summary>
+    /// Show a different animation of the model already loaded.
+    ///
+    /// NOTHING is rebuilt here. The .m2 is not re-requested or re-parsed, the mesh, materials,
+    /// textures, geoset selection and skeleton are untouched, and the animator is re-bound to the
+    /// new tracks rather than recreated. Only loadWoWModel builds anything.
+    ///
+    /// Three ways this can go, cheapest first:
+    ///   1. the sequence has been played before  -> its tracks come from the cache, no allocation
+    ///   2. its keyframes are in the .m2         -> read them, cache them
+    ///   3. its keyframes are in a .anim file    -> fetch that once, then as (2)
+    /// The previous animation stays on screen throughout, including while a fetch is in flight.
+    /// </summary>
+    void SwitchToSequence(int sequenceIndex)
+    {
+        // -wmvNoAnim means nothing is going to be played, so nothing is worth reading or -- more
+        // to the point -- fetching. ApplySequence would refuse this anyway, but only after a .anim
+        // round trip had already been spent on a sequence that will not move a bone.
+        if (WmvModelBuilder.Debug_.NoAnim)
+            return;
+
+        // 1. Already read once. This becomes the common case as soon as the user goes back and
+        //    forth between a few animations, and it is deliberately the cheapest path there is:
+        //    no parse, no fetch, no allocation.
+        M2BoneDef[] cached;
+        if (boneTrackCache.TryGetValue(sequenceIndex, out cached))
+        {
+            long heapBefore = System.GC.GetTotalMemory(false);
+            int gcBefore = System.GC.CollectionCount(0);
+            var swc = System.Diagnostics.Stopwatch.StartNew();
+            currentModel.Bones = cached;
+            currentModel.AnimatedSequence = sequenceIndex;
+            currentModel.AnimationSkipReason = null;
+            ApplyResolvedSequence(sequenceIndex, "cached");
+            if (WmvModelBuilder.Debug_.AnimCheck)
+                Debug.Log(string.Format(
+                    "WMV: anim switch timing (cached): read 0 ms, total {0} ms, allocated {1} KB, "
+                    + "gen0 collections {2} (no reload, no fetch, no parse)",
+                    swc.ElapsedMilliseconds,
+                    (System.GC.GetTotalMemory(false) - heapBefore) / 1024,
+                    System.GC.CollectionCount(0) - gcBefore));
+            return;
+        }
+
+        // 3. Keys in a .anim file. Fetch it once; the switch completes when the bytes arrive.
+        int animFileId = M2Parser.ExternalAnimFileId(currentModel, sequenceIndex);
+        byte[] external = null;
+        if (animFileId != 0 && !animFileCache.TryGetValue(animFileId, out external))
+        {
+            foreach (int waiting in pendingAnimFetch.Values)
+                if (waiting == sequenceIndex)
+                    return;                          // already on its way
+            string req = ipc.RequestAssetByFileDataID(animFileId);
+            pendingAnimFetch[req] = sequenceIndex;
+            status.Set(string.Format("Animation {0}: fetching its .anim file ({1})",
+                                     sequenceIndex, animFileId));
+            return;
+        }
+
+        ReadAndApplySequence(sequenceIndex, external, animFileId == 0 ? "in-file" : "from .anim");
+    }
+
+    /// <summary>
+    /// Fetch every external .anim file this model names, as soon as it is built.
+    ///
+    /// A sequence whose keyframes are in a .anim used to fetch them the first time it was played,
+    /// which meant the FIRST switch to each such animation was deferred: the previous animation
+    /// stayed on screen until the bytes landed. Measured at 16-18 ms each -- about a frame, so not
+    /// a stall in itself, but it is the one part of a switch that is not instant, and there is no
+    /// reason for it to be on the interactive path at all. A creature names a handful of these
+    /// (Agronn 8, ~300 KB in total) and they are what its animations ARE.
+    ///
+    /// Everything else about it is unchanged: the bytes land in the same cache the on-demand path
+    /// fills, a sequence still falls back gracefully if its file never arrives, and nothing is
+    /// parsed until an animation actually asks for it.
+    /// </summary>
+    void PrefetchAnimFiles()
+    {
+        if (currentModel == null || WmvModelBuilder.Debug_.NoAnim)
+            return;
+        var wanted = new HashSet<int>();
+        foreach (var e in currentModel.AnimFileIds)
+            if (e.FileDataID > 0)
+                wanted.Add(e.FileDataID);
+        if (wanted.Count == 0)
+            return;
+        foreach (int fileId in wanted)
+        {
+            if (animFileCache.ContainsKey(fileId))
+                continue;
+            string req = ipc.RequestAssetByFileDataID(fileId);
+            pendingAnimFetch[req] = -1;          // -1: nothing is waiting on it, just fill the cache
+        }
+        Debug.Log(string.Format("WMV: anim: fetching {0} .anim file(s) up front so switching to "
+                                + "one never waits", wanted.Count));
+    }
+
+    /// <summary>The .anim bytes arrived. Cache them and finish the switch that was waiting.</summary>
+    void OnAnimFileBytes(WmvIpcClient.AssetResponse r, int sequenceIndex)
+    {
+        pendingAnimFetch.Remove(r.requestId);
+        if (sequenceIndex < 0 && (!r.ok || r.data == null))
+        {
+            pendingAnimFetch.Remove(r.requestId);
+            return;                              // a prefetch that failed; the switch will retry
+        }
+        if (!r.ok || r.data == null || r.data.Length == 0)
+        {
+            // Graceful for the viewer -- the previous animation keeps running rather than the
+            // model dropping to its rest pose -- but loud for whoever has to fix it. LogWarning
+            // rather than a status line: ordinary logs no longer carry a stack trace, and this is
+            // exactly the kind of thing worth having one for.
+            Debug.LogWarning(string.Format(
+                "WMV: anim: sequence {0} wanted .anim file {1}, which could not be read: {2}",
+                sequenceIndex, M2Parser.ExternalAnimFileId(currentModel, sequenceIndex),
+                r.error ?? "empty response"));
+            status.Set(string.Format("Animation {0}: its .anim file could not be read",
+                                     sequenceIndex));
+            return;
+        }
+        if (sequenceIndex < 0)
+        {
+            // A prefetch: nothing is waiting on it, it just belongs in the cache. The reply names
+            // the file, so it can be filed without a sequence to look it up from.
+            animFileCache[r.fileDataID] = r.data;
+            return;
+        }
+        int animFileId = M2Parser.ExternalAnimFileId(currentModel, sequenceIndex);
+        if (animFileId != 0)
+            animFileCache[animFileId] = r.data;
+        // Only apply if this is still what the app wants: the user may have moved on while the
+        // bytes were in flight.
+        if (sequenceIndex != selectedSequence)
+            return;
+        ReadAndApplySequence(sequenceIndex, r.data, "from .anim");
+    }
+
+    /// <summary>Read one sequence's bone tracks, cache them, and put them on screen.</summary>
+    void ReadAndApplySequence(int sequenceIndex, byte[] external, string source)
+    {
         try
         {
-            M2ParsedModel reparsed = M2Parser.Parse(currentM2Bytes, a.sequenceIndex);
-            if (WmvModelBuilder.ApplySequence(current, reparsed, s => Debug.Log("WMV: " + s)))
-            {
-                currentModel = reparsed;
-                // Report what is PLAYING, not what was asked for: a sequence whose keyframes are
-                // not in the .m2 falls back to the idle, and saying "animation 20" while the idle
-                // plays is the kind of log that costs an hour later.
-                int playing = reparsed.AnimatedSequence;
-                status.Set(string.Format("Animation {0} (animID {1}, {2} ms){3}",
-                                         playing, reparsed.Sequences[playing].AnimId,
-                                         reparsed.Sequences[playing].Length,
-                                         playing == a.sequenceIndex
-                                             ? "" : " -- fell back from " + a.sequenceIndex));
-                if (playing != a.sequenceIndex && reparsed.AnimationSkipReason != null)
-                    Debug.Log("WMV: anim: " + reparsed.AnimationSkipReason);
-            }
-            else
-            {
-                status.Set("Animation " + a.sequenceIndex + " could not be played");
-            }
+            // Time AND bytes. The time is what the switch costs now; the allocation is what it
+            // costs a frame or two later, when the collector runs -- and it is the collector, not
+            // the reading, that a viewer feels as a stutter.
+            long heapBefore = System.GC.GetTotalMemory(false);
+            int gcBefore = System.GC.CollectionCount(0);
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            M2Parser.ReadAnimationInto(currentM2Bytes, sequenceIndex, currentModel, external);
+            long readMs = sw.ElapsedMilliseconds;
+
+            // Cache under the sequence that RESOLVED, not the one asked for: a request that fell
+            // back to the idle must not be remembered as though it had played.
+            if (currentModel.AnimatedSequence >= 0)
+                boneTrackCache[currentModel.AnimatedSequence] = currentModel.Bones;
+
+            ApplyResolvedSequence(sequenceIndex, source);
+            if (WmvModelBuilder.Debug_.AnimCheck)
+                Debug.Log(string.Format(
+                    "WMV: anim switch timing ({0}): read {1} ms, total {2} ms, allocated {3} KB, "
+                    + "gen0 collections {4} (no reload, no mesh/material/texture rebuild)",
+                    source, readMs, sw.ElapsedMilliseconds,
+                    (System.GC.GetTotalMemory(false) - heapBefore) / 1024,
+                    System.GC.CollectionCount(0) - gcBefore));
         }
         catch (WowParseException e)
         {
+            Debug.LogWarning("WMV: anim: reading sequence " + sequenceIndex + " (" + source +
+                             ") failed: " + e.Message);
             status.Set("Animation change failed: " + e.Message);
         }
+    }
+
+    /// <summary>Bind whatever currentModel now holds, and say what is actually playing.</summary>
+    void ApplyResolvedSequence(int requested, string source)
+    {
+        if (!WmvModelBuilder.ApplySequence(current, currentModel, s => Debug.Log("WMV: " + s)))
+        {
+            status.Set("Animation " + requested + " could not be played");
+            return;
+        }
+        // Report what is PLAYING, not what was asked for: a sequence whose keyframes cannot be
+        // read falls back to the idle, and saying "animation 20" while the idle plays is the kind
+        // of log that costs an hour later.
+        int playing = currentModel.AnimatedSequence;
+        status.Set(string.Format("Animation {0} (animID {1}, {2} ms, {3}){4}",
+                                 playing, currentModel.Sequences[playing].AnimId,
+                                 currentModel.Sequences[playing].Length, source,
+                                 playing == requested ? "" : " -- fell back from " + requested));
+        if (playing != requested && currentModel.AnimationSkipReason != null)
+            Debug.Log("WMV: anim: " + currentModel.AnimationSkipReason);
+
+        // The app's playback state applies to whatever is now on screen. Without this a switch
+        // starts from the animator's own defaults -- playing, at 1x -- which is wrong whenever the
+        // app is paused or the speed slider is not at 1, and is not corrected until the next
+        // heartbeat. The heartbeat is meant to correct DRIFT, not to start the animation.
+        if (haveAppState && current.Animator != null)
+            current.Animator.SetPlaybackState(lastAppState.playing,
+                                              lastAppState.sequenceIndex == playing
+                                                  ? lastAppState.timeMs : 0f,
+                                              lastAppState.speed);
+        // Watch whether it actually starts moving; see WmvM2Animator.BeginAdvanceWatch.
+        if (current.Animator != null)
+            current.Animator.BeginAdvanceWatch();
+    }
+
+    /// <summary>
+    /// WMV's playback state changed, or the heartbeat arrived. Hand it to the animator, which
+    /// decides what to do with the time.
+    ///
+    /// Nothing here rebuilds or re-parses anything: play/pause, speed and position are the app's
+    /// state, and the renderer already has everything needed to act on them. A state message for a
+    /// sequence the renderer is not playing is ignored rather than acted on -- the selection push
+    /// that switches to it will arrive with its own state.
+    /// </summary>
+    void HandleModelAnimationState(WmvIpcClient.AnimationState s)
+    {
+        if (s.fileDataID != 0 && currentFileDataID != 0 && s.fileDataID != currentFileDataID)
+            return;                                     // about a different model
+        if (current == null || current.Animator == null)
+            return;                                     // nothing playing to apply it to
+        // Remember it even when it cannot be applied yet -- a deferred or fallen-back switch
+        // will ask for it as soon as it knows what is playing.
+        lastAppState = s;
+        haveAppState = true;
+
+        if (s.sequenceIndex >= 0 && current.Animator.SequenceIndex != s.sequenceIndex)
+        {
+            // Not about what is on screen. The play/pause and speed still are, though: they are
+            // the app's, not the sequence's, and dropping them here is what left a switch running
+            // at the wrong speed or moving while the app was paused.
+            current.Animator.SetTransportOnly(s.playing, s.speed);
+            return;
+        }
+
+        bool wasPlaying = current.Animator.IsPlaying;
+        float wasSpeed = current.Animator.Speed;
+        current.Animator.SetPlaybackState(s.playing, s.timeMs, s.speed);
+
+        // Only the changes worth reading are surfaced: the heartbeat would otherwise write a line
+        // a second for the whole session.
+        if (s.playing != wasPlaying)
+            status.Set(s.playing ? "Playing" : "Paused");
+        else if (System.Math.Abs(s.speed - wasSpeed) > 0.001f)
+            status.Set(string.Format("Speed {0:0.##}x", s.speed));
     }
 
     /// <summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -205,6 +205,14 @@ namespace Wmv.Wow
     }
 
     /// <summary>A parsed M2 (the parts this milestone needs).</summary>
+    /// <summary>One AFID entry: which file holds animation (animId, subAnimId)'s keyframes.</summary>
+    public struct AfidEntry
+    {
+        public int AnimId;
+        public int SubAnimId;
+        public int FileDataID;
+    }
+
     public class M2ParsedModel
     {
         public string Name = "";
@@ -257,6 +265,38 @@ namespace Wmv.Wow
 
         /// <summary>Why no sequence was parsed, for the log. Null when one was.</summary>
         public string AnimationSkipReason;
+
+        /// <summary>
+        /// AFID: which external .anim file holds each animation's keyframes.
+        ///
+        /// A sequence without the 0x20 flag keeps its track HEADERS in the .m2 -- counts and
+        /// offsets, per sequence, exactly where an in-file sequence keeps them -- but those
+        /// offsets address the .anim file's bytes instead. So playing one needs nothing more than
+        /// the right buffer to read the entries out of, which is the same thing the legacy
+        /// viewport does (WoWModel::readAnimsFromFile fills an animfiles map keyed by animID, and
+        /// the track reader picks the buffer from it).
+        /// </summary>
+        public AfidEntry[] AnimFileIds = new AfidEntry[0];
+
+        /// <summary>
+        /// The external .anim FileDataID the CURRENTLY selected sequence needs, or 0 when its
+        /// keyframes are in the .m2. The renderer fetches this over the asset channel and hands
+        /// the bytes back to the parser.
+        /// </summary>
+        public int RequiredAnimFileId;
+
+        /// <summary>
+        /// The MD21 payload this model was parsed from, kept so that changing the animation can
+        /// re-read the bone tracks without copying it out of the file again.
+        ///
+        /// Offsets inside an .m2 are relative to the MD21 chunk, so reading it means working on
+        /// that slice as its own address space. Slicing it per animation change meant allocating
+        /// megabytes each time the user picked a different animation -- several MB per switch on a
+        /// boss -- and it is that garbage, not the reading, that the viewport showed as a stutter.
+        /// Holding the slice for as long as the model is displayed costs one buffer and makes the
+        /// switch allocate essentially nothing. Null on a model parsed before this was kept.
+        /// </summary>
+        public byte[] Md21Payload;
 
         /// <summary>
         /// The SKID chunk: the FileDataID of a separate skeleton (.skel) file. Non-zero means the

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
@@ -76,10 +76,15 @@ namespace Wmv.Wow
         /// wantedSequence names which animation's bone tracks to read; -1 asks for the model's
         /// default idle. Only one sequence is ever read (a track on disk is an array of
         /// per-sequence keyframe arrays, and a boss has hundreds), so playing a different one
-        /// means parsing again with a different answer here -- which is what the renderer does
-        /// when the app's animation selection changes.
+        /// means reading the bone tracks again with a different answer here.
+        ///
+        /// Changing the animation does NOT come back through here: it needs the bones and nothing
+        /// else, so it goes to ReadAnimationInto, which re-reads that one array and leaves the
+        /// vertices, textures, materials and lookups exactly as this call left them. See there for
+        /// why that distinction is worth having.
         /// </summary>
-        public static M2ParsedModel Parse(byte[] file, int wantedSequence = -1)
+        public static M2ParsedModel Parse(byte[] file, int wantedSequence = -1,
+                                          byte[] externalAnim = null)
         {
             if (file == null || file.Length < 8)
                 throw new WowParseException("m2: asset is empty or too small to hold a header");
@@ -95,6 +100,7 @@ namespace Wmv.Wow
                 md21Offset = chunks["MD21"].Offset;
                 md21Size = chunks["MD21"].Count;
 
+                model.AnimFileIds = ReadAnimFileIds(file, chunks);
                 model.SkinFileDataIDs = ReadIdChunk(file, chunks, "SFID");
                 model.TextureFileDataIDs = ReadIdChunk(file, chunks, "TXID");
                 int[] skeleton = ReadIdChunk(file, chunks, "SKID");
@@ -103,10 +109,20 @@ namespace Wmv.Wow
 
             // Work on the MD21 payload as its own address space -- offsets inside are relative
             // to it, so a slice keeps every later read honest about its bounds.
-            var payload = new byte[md21Size];
             if (md21Offset + md21Size > file.Length)
                 throw new WowParseException("m2: MD21 chunk extends past the end of the asset");
-            Buffer.BlockCopy(file, md21Offset, payload, 0, md21Size);
+            byte[] payload;
+            if (md21Offset == 0 && md21Size == file.Length)
+            {
+                payload = file;                     // unchunked: the file already IS the payload
+            }
+            else
+            {
+                payload = new byte[md21Size];
+                Buffer.BlockCopy(file, md21Offset, payload, 0, md21Size);
+            }
+            // Kept for ReadAnimationInto; see M2ParsedModel.Md21Payload for why.
+            model.Md21Payload = payload;
 
             var c = new ByteCursor(payload, "m2");
             if (payload.Length < MinHeaderSize)
@@ -149,9 +165,10 @@ namespace Wmv.Wow
             if (model.SkeletonFileDataID == 0)
             {
                 c.RequireArray(bones, BoneStride, "bones");
-                model.AnimatedSequence = ResolveSequence(model, file, chunks, wantedSequence,
+                model.AnimatedSequence = ResolveSequence(model, externalAnim, wantedSequence,
                                                         out model.AnimationSkipReason);
-                model.Bones = ReadBones(c, bones, model);
+                model.Bones = ReadBones(c, bones, model, ExternalFor(model, externalAnim));
+                model.RequiredAnimFileId = ExternalAnimFileId(model, model.AnimatedSequence);
             }
             else
             {
@@ -195,6 +212,94 @@ namespace Wmv.Wow
             ReadVisibilityTracks(c, model);
 
             return model;
+        }
+
+        /// <summary>
+        /// Re-read ONLY the bone animation for a different sequence, writing it into a model that
+        /// has already been parsed.
+        ///
+        /// Changing the displayed animation needs exactly four things: which sequence resolved,
+        /// the sequence table, the global sequences, and the bone tracks for that sequence. It
+        /// does not need the vertices, the textures, the materials, the texture lookups or the
+        /// visibility tracks -- none of those depend on which animation is playing, and on a model
+        /// of any size reading them again is most of the cost of a full parse. Doing that work on
+        /// every selection change is what made the viewport stutter when the user picked a new
+        /// animation from the dropdown.
+        ///
+        /// The model is updated IN PLACE rather than replaced, because the rest of it is still
+        /// live: the skin path reads model.Textures to decide which slots a variant's texture
+        /// feeds, and handing it a half-populated model would break selecting a skin after
+        /// selecting an animation.
+        ///
+        /// Throws WowParseException like Parse does; the caller keeps the previous animation.
+        /// </summary>
+        public static void ReadAnimationInto(byte[] file, int wantedSequence, M2ParsedModel model,
+                                             byte[] externalAnim = null)
+        {
+            if (model == null)
+                throw new WowParseException("m2: no parsed model to read an animation into");
+            if (file == null || file.Length < 8)
+                throw new WowParseException("m2: asset is empty or too small to hold a header");
+
+            // A skeleton-file model has no bone array of its own to re-read; it was never
+            // animated from this file and still is not.
+            if (model.SkeletonFileDataID != 0)
+            {
+                model.AnimationSkipReason = "its bones and animations live in a separate skeleton file";
+                model.AnimatedSequence = -1;
+                return;
+            }
+
+            var chunks = ReadChunks(file);
+
+            // Reuse the slice the load already cut. Cutting it again is the single biggest
+            // allocation an animation change could make -- megabytes on a large model, every
+            // time the selection changes -- and none of it is needed: the bytes have not moved.
+            byte[] payload = model.Md21Payload;
+            if (payload == null)
+            {
+                int md21Offset = 0, md21Size = file.Length;
+                if (chunks.Count > 0)
+                {
+                    if (!chunks.ContainsKey("MD21"))
+                        throw new WowParseException("m2: chunked asset without an MD21 chunk");
+                    md21Offset = chunks["MD21"].Offset;
+                    md21Size = chunks["MD21"].Count;
+                }
+                if (md21Offset + md21Size > file.Length)
+                    throw new WowParseException("m2: MD21 chunk extends past the end of the asset");
+                payload = new byte[md21Size];
+                Buffer.BlockCopy(file, md21Offset, payload, 0, md21Size);
+                model.Md21Payload = payload;
+            }
+            var c = new ByteCursor(payload, "m2");
+            if (payload.Length < MinHeaderSize)
+                throw new WowParseException(string.Format(
+                    "m2: header is truncated ({0} bytes, need at least {1})", payload.Length, MinHeaderSize));
+
+            c.Seek(OfsBones);
+            M2Array bones = c.ReadArray();
+            c.RequireArray(bones, BoneStride, "bones");
+
+            // Resolve against the sequence table the model already holds -- it does not change
+            // with the selection, and ResolveSequence reads it to decide whether the wanted
+            // sequence's keyframes are in this file at all.
+            model.AnimatedSequence = ResolveSequence(model, externalAnim, wantedSequence,
+                                                     out model.AnimationSkipReason);
+            model.Bones = ReadBones(c, bones, model, ExternalFor(model, externalAnim));
+            model.RequiredAnimFileId = ExternalAnimFileId(model, model.AnimatedSequence);
+        }
+
+        /// <summary>
+        /// The external bytes apply only when the sequence that actually resolved is the external
+        /// one. A request that fell back to the in-file idle must read the .m2, not the .anim that
+        /// was fetched for the sequence it could not play.
+        /// </summary>
+        static byte[] ExternalFor(M2ParsedModel model, byte[] externalAnim)
+        {
+            if (externalAnim == null || model.AnimatedSequence < 0)
+                return null;
+            return model.Sequences[model.AnimatedSequence].PrimarySequence ? null : externalAnim;
         }
 
         /// <summary>
@@ -401,8 +506,17 @@ namespace Wmv.Wow
         /// than left to blow up downstream -- the legacy viewport sanitises the same field for the
         /// same reason, since a bad parent otherwise recurses off the end of its bone vector.
         /// </summary>
-        static M2BoneDef[] ReadBones(ByteCursor c, M2Array arr, M2ParsedModel model)
+        /// <summary>
+        /// externalAnim, when given, holds the .anim file this sequence's keyframes live in. The
+        /// track HEADERS are still read from the .m2 either way -- only the entries they point at
+        /// come from the other buffer. That is exactly the split the legacy viewport makes.
+        /// </summary>
+        static M2BoneDef[] ReadBones(ByteCursor c, M2Array arr, M2ParsedModel model,
+                                     byte[] externalAnim)
         {
+            ByteCursor ext = externalAnim != null
+                ? new ByteCursor(externalAnim, "anim") : default(ByteCursor);
+            bool hasExt = externalAnim != null;
             int seq = model.AnimatedSequence;
             var bones = new M2BoneDef[arr.Count];
             for (int i = 0; i < arr.Count; i++)
@@ -420,11 +534,11 @@ namespace Wmv.Wow
                 if (seq >= 0)
                 {
                     bones[i].Translation = ReadTrack<WowVec3>(c, bone + OfsBoneTranslation, seq,
-                                                              Vec3Stride, ReadVec3);
+                                                              Vec3Stride, ReadVec3, ext, hasExt);
                     bones[i].Rotation = ReadTrack<WowQuat>(c, bone + OfsBoneRotation, seq,
-                                                           PackedQuatStride, ReadPackedQuat);
+                                                           PackedQuatStride, ReadPackedQuat, ext, hasExt);
                     bones[i].Scale = ReadTrack<WowVec3>(c, bone + OfsBoneScale, seq,
-                                                        Vec3Stride, ReadVec3);
+                                                        Vec3Stride, ReadVec3, ext, hasExt);
                 }
             }
 
@@ -482,7 +596,7 @@ namespace Wmv.Wow
         /// already treats an empty track as "hold the rest pose".
         /// </summary>
         static M2Track<T> ReadTrack<T>(ByteCursor c, int offset, int sequence, int valueStride,
-                                       ReadValue<T> readValue)
+                                       ReadValue<T> readValue, ByteCursor ext, bool hasExt)
         {
             M2Track<T> track = new M2Track<T>();
             track.Times = EmptyTimes;
@@ -510,8 +624,14 @@ namespace Wmv.Wow
             c.Seek(values.Offset + entry * NestedStride);
             M2Array keyValues = c.ReadArray();
 
+            // From here the offsets address the KEYFRAME buffer, which is the .anim file when
+            // this sequence's keys live outside the .m2, and the .m2 itself otherwise. Everything
+            // above -- the track header and the per-sequence arrays -- came from the .m2 in both
+            // cases, because that is where they are stored in both cases.
+            ByteCursor k = hasExt ? ext : c;
+
             int n = keyTimes.Count < keyValues.Count ? keyTimes.Count : keyValues.Count;
-            if (n <= 0 || !Fits(c, keyTimes.Offset, n, 4) || !Fits(c, keyValues.Offset, n, valueStride))
+            if (n <= 0 || !Fits(k, keyTimes.Offset, n, 4) || !Fits(k, keyValues.Offset, n, valueStride))
                 return track;
 
             // Hermite and Bezier store three values per key (the value and two tangents); this
@@ -519,7 +639,7 @@ namespace Wmv.Wow
             // to without their tangents. No bone track in the validation data uses either.
             int stride = (track.Interpolation == M2Interpolation.Hermite ||
                           track.Interpolation == M2Interpolation.Bezier) ? valueStride * 3 : valueStride;
-            if (!Fits(c, keyValues.Offset, n, stride))
+            if (!Fits(k, keyValues.Offset, n, stride))
                 return track;
 
             var t = new uint[n];
@@ -528,10 +648,10 @@ namespace Wmv.Wow
             {
                 for (int i = 0; i < n; i++)
                 {
-                    c.Seek(keyTimes.Offset + i * 4);
-                    t[i] = c.ReadUInt32();
-                    c.Seek(keyValues.Offset + i * stride);
-                    v[i] = readValue(c);
+                    k.Seek(keyTimes.Offset + i * 4);
+                    t[i] = k.ReadUInt32();
+                    k.Seek(keyValues.Offset + i * stride);
+                    v[i] = readValue(k);
                 }
             }
             catch (WowParseException)
@@ -590,8 +710,7 @@ namespace Wmv.Wow
         /// file, not this one, and following them here would read whatever happens to sit at those
         /// bytes of the model. Fetching .anim files is a later milestone.
         /// </summary>
-        static int ResolveSequence(M2ParsedModel model, byte[] file,
-                                   Dictionary<string, M2Array> chunks, int wanted,
+        static int ResolveSequence(M2ParsedModel model, byte[] externalAnim, int wanted,
                                    out string skipReason)
         {
             skipReason = null;
@@ -604,7 +723,8 @@ namespace Wmv.Wow
             if (wanted >= 0)
             {
                 string why = "there is no such sequence";
-                if (wanted < model.Sequences.Length && Playable(model.Sequences[wanted], file, chunks, out why))
+                if (wanted < model.Sequences.Length &&
+                    Playable(model.Sequences[wanted], model.AnimFileIds, externalAnim != null, out why))
                     return wanted;
                 skipReason = "the selected sequence " + wanted + " cannot be played (" + why +
                              "); falling back to the default idle";
@@ -621,7 +741,7 @@ namespace Wmv.Wow
             }
 
             string idleWhy;
-            if (!Playable(model.Sequences[idle], file, chunks, out idleWhy))
+            if (!Playable(model.Sequences[idle], model.AnimFileIds, false, out idleWhy))
             {
                 skipReason = (skipReason == null ? "" : skipReason + "; and ") +
                              "the default idle cannot be played either (" + idleWhy + ")";
@@ -639,8 +759,12 @@ namespace Wmv.Wow
         /// them proves nothing and reading them yields noise. The AFID lookup is kept as well
         /// because it can name the file the keys went to, which makes a better message.
         /// </summary>
-        static bool Playable(M2Sequence seq, byte[] file, Dictionary<string, M2Array> chunks,
-                             out string why)
+        /// <summary>
+        /// Can this sequence be played from what we hold? In-file sequences always can. One whose
+        /// keys live in a .anim can too, but only once those bytes have been fetched -- which is
+        /// why haveExternal is an argument rather than something guessed here.
+        /// </summary>
+        static bool Playable(M2Sequence seq, AfidEntry[] afids, bool haveExternal, out string why)
         {
             if (seq.Length == 0)
             {
@@ -649,37 +773,87 @@ namespace Wmv.Wow
             }
             if (!seq.PrimarySequence)
             {
-                why = HasExternalAnimFile(file, chunks, seq)
-                    ? "its keyframes are in a separate .anim file, which this milestone does not fetch"
-                    : "its keyframes are not stored in the .m2 (no 0x20 flag)";
+                if (haveExternal)
+                {
+                    why = null;
+                    return true;
+                }
+                why = HasAfidFor(afids, seq)
+                    ? "its keyframes are in a separate .anim file that has not been fetched yet"
+                    : "its keyframes are not stored in the .m2 (no 0x20 flag) and no .anim file is named for it";
                 return false;
             }
             why = null;
             return true;
         }
 
+        static bool HasAfidFor(AfidEntry[] afids, M2Sequence seq)
+        {
+            foreach (AfidEntry e in afids)
+                if (e.AnimId == seq.AnimId && e.SubAnimId == seq.SubAnimId)
+                    return true;
+            return false;
+        }
+
         /// <summary>Does the AFID chunk name an .anim file for this sequence?</summary>
-        static bool HasExternalAnimFile(byte[] file, Dictionary<string, M2Array> chunks, M2Sequence seq)
+        /// <summary>
+        /// Read AFID: animId(2) subAnimId(2) fileId(4) per entry. Empty when the chunk is absent,
+        /// which is every unchunked and most older models.
+        /// </summary>
+        static AfidEntry[] ReadAnimFileIds(byte[] file, Dictionary<string, M2Array> chunks)
         {
             M2Array afid;
             if (!chunks.TryGetValue("AFID", out afid))
-                return false;
-            // Each entry is animId(2) subAnimId(2) fileId(4).
-            for (int i = 0; i + 8 <= afid.Count; i += 8)
+                return EmptyAfid;
+            int n = afid.Count / 8;
+            if (n <= 0)
+                return EmptyAfid;
+            var list = new List<AfidEntry>(n);
+            for (int i = 0; i < n; i++)
             {
-                int o = afid.Offset + i;
-                if (o + 4 > file.Length)
+                int o = afid.Offset + i * 8;
+                if (o + 8 > file.Length)
                     break;
-                if (ReadUInt16At(file, o) == (ushort)seq.AnimId &&
-                    ReadUInt16At(file, o + 2) == (ushort)seq.SubAnimId)
-                    return true;
+                AfidEntry e;
+                e.AnimId = ReadUInt16At(file, o);
+                e.SubAnimId = ReadUInt16At(file, o + 2);
+                e.FileDataID = (int)ReadUInt32At(file, o + 4);
+                list.Add(e);
             }
-            return false;
+            return list.ToArray();
+        }
+
+        static readonly AfidEntry[] EmptyAfid = new AfidEntry[0];
+
+        /// <summary>
+        /// The external .anim FileDataID holding this sequence's keyframes, or 0 when they are in
+        /// the .m2. Matched on animId AND subAnimId, the way the legacy viewport matches them --
+        /// two sequences routinely share an animId as sub-animations of one action, and they have
+        /// separate .anim files.
+        /// </summary>
+        public static int ExternalAnimFileId(M2ParsedModel model, int sequenceIndex)
+        {
+            if (model == null || model.AnimFileIds.Length == 0 ||
+                sequenceIndex < 0 || sequenceIndex >= model.Sequences.Length)
+                return 0;
+            M2Sequence seq = model.Sequences[sequenceIndex];
+            if (seq.PrimarySequence)
+                return 0;                       // its keyframes are in the .m2
+            foreach (AfidEntry e in model.AnimFileIds)
+                if (e.AnimId == seq.AnimId && e.SubAnimId == seq.SubAnimId)
+                    return e.FileDataID;
+            return 0;
         }
 
         static ushort ReadUInt16At(byte[] file, int offset)
         {
             return (ushort)(file[offset] | (file[offset + 1] << 8));
+        }
+
+        static uint ReadUInt32At(byte[] file, int offset)
+        {
+            return (uint)(file[offset] | (file[offset + 1] << 8) |
+                          (file[offset + 2] << 16) | (file[offset + 3] << 24));
         }
 
         static M2TextureDef[] ReadTextures(ByteCursor c, M2Array arr, M2ParsedModel model)

--- a/Tools/UnityRendererProject/README.md
+++ b/Tools/UnityRendererProject/README.md
@@ -317,6 +317,52 @@ that lives, and `WowParserTests` checks it against the matrix route rather than 
 algebra — a sign error there does not look subtly wrong, it looks like the model turning inside
 out.
 
+**Changing the animation is cheap on purpose.** A selection change re-reads the bone tracks for
+the new sequence into the model already loaded — `M2Parser.ReadAnimationInto` — and does nothing
+else. It does not re-parse the file, rebuild the mesh, rebuild materials or textures, or recreate
+the skeleton; the animator is re-bound to the new tracks. The MD21 slice the tracks are read from is
+cut once at load and kept, because cutting it again is by far the biggest allocation a switch could
+make. Only `loadWoWModel` builds anything.
+
+**And everything it reads is cached, per sequence.** Both the raw tracks (`WmvMain.boneTrackCache`)
+and the tracks converted into renderer space (`WmvM2Animator.convertedBySequence`). Going back to an
+animation already watched costs a dictionary lookup and allocates nothing — measured at 0 ms and 0
+collections — which matters because comparing two animations means switching between them
+repeatedly. The caches are keyed per model and dropped when a different model loads, since a
+sequence index means nothing across models.
+
+**Animations stored in .anim files.** A sequence without flag 0x20 keeps its track headers in the
+.m2 but its keyframe ENTRIES in a separate file, named by the AFID chunk. Those bytes are fetched
+over the ordinary asset channel the first time such a sequence is played and cached per file
+(`WmvMain.animFileCache`), so switching back never refetches. The parser reads the headers from the
+.m2 and the entries from the .anim — the same split the legacy viewport makes. A sequence whose
+.anim cannot be served falls back to the idle, names the file, and leaves the previous animation
+running rather than dropping the model to its rest pose.
+
+**Logging: ordinary lines carry no stack trace, anything wrong still does.** Unity captures and
+formats a full managed stack trace for every `Debug.Log`, on the main thread, before the line is
+written -- and this renderer logs what it decided about every batch, material, skin and animation,
+so that cost lands in the middle of the work it describes. `SetStackTraceLogType` turns it off for
+`LogType.Log` only. Warnings, errors, exceptions and assertions keep their traces, and the failure
+paths that used to report through the status overlay alone -- a .anim that could not be served, a
+track read that threw -- were raised to `LogWarning` so they stay debuggable rather than becoming
+one more untraced line.
+
+**Playback state comes from the app, not from here.** Whether the animation is running, how fast,
+and where it is are WMV's to decide; this renderer keeps its own clock only so the motion is smooth
+between the messages that carry them. Play/pause and speed are applied as given. The TIME is
+treated as a correction rather than an assignment: the app sends its position on a one-per-second
+heartbeat, and a difference under about a frame — 40 ms — is left alone. Snapping to every message
+would replace smooth motion with a stutter once a second; never snapping would let two
+independently-timed renderers drift apart. A scrub or a stop arrives with the app's time already
+far away, so it snaps with no special case. Every correction is logged with its size, because a run
+full of them means the two clocks are not keeping step.
+
+**Global sequences ignore all of it.** They keep running while the animation is paused and are not
+scaled by the speed, because that is what the legacy viewport does: it advances its global clock
+before it decides whether the animation is paused, and the speed multiplier lives inside the
+animation tick alone.
+
 **What is not animated.** Only bones. Texture animation, colour and transparency tracks, particles,
 ribbons and attachments are untouched, as is anything belonging to characters or equipment. A model
 whose idle keeps its keyframes in a separate `.anim` file is not animated and says so; over a
@@ -341,7 +387,7 @@ process inherits the environment:
 | `-wmvNoSkin` | build every model as a static mesh, as before skinning existed — the A/B for "did the skinned path change what I see?" |
 | `-wmvSkinCheck` | bake the skinned result and report the largest distance between a baked vertex and the position the file gave it. Pair it with `-wmvNoAnim`: a moving model is not in its rest pose |
 | `-wmvNoAnim` | do not play anything. The model is still skinned, and still sits in the rest pose the bind poses describe |
-| `-wmvAnimCheck` | sample the idle across its length and report how far the skinned mesh moves from its rest pose, next to the model's own size. Zero everywhere means nothing animates; a number far larger than the model means the rig is being applied wrongly — both look like an ordinary still frame otherwise |
+| `-wmvAnimCheck` | sample the idle across its length and report how far the skinned mesh moves from its rest pose, next to the model's own size. Zero everywhere means nothing animates; a number far larger than the model means the rig is being applied wrongly — both look like an ordinary still frame otherwise. Also logs every playback-state message the app sends, which is how to see what the transport controls actually pushed |
 
 Each model load also logs its UV sample, per-batch material/blend/texture-slot mapping, the alpha
 treatment per texture, which batches are hidden at rest and why, the resolved combiner and per-unit

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -600,6 +600,112 @@ namespace Wmv.Wow.Tests
             Check(M2Parser.Parse(BuildAnimatedM2(new[] { (short)5, (short)0 }, standTrack: true,
                                                  noKeysInM2: 1)).AnimatedSequence == -1,
                   "select: an idle without the 0x20 flag is not played at all");
+
+            // Changing the animation goes through ReadAnimationInto, which re-reads the bone
+            // tracks and NOTHING else. It has to land on exactly what a full parse of the same
+            // sequence would have produced -- that equivalence is the whole basis for using the
+            // cheap path -- and it has to leave the rest of the model untouched, because the skin
+            // path keeps reading it.
+            M2ParsedModel live = M2Parser.Parse(file, 2);
+            M2TextureDef[] texturesBefore = live.Textures;
+            M2Vertex[] verticesBefore = live.Vertices;
+            byte[] payloadBefore = live.Md21Payload;
+
+            M2Parser.ReadAnimationInto(file, 1, live);
+            M2ParsedModel full = M2Parser.Parse(file, 1);
+            Check(live.AnimatedSequence == full.AnimatedSequence,
+                  "readInto: resolves the same sequence a full parse does");
+            Check(live.Bones.Length == full.Bones.Length,
+                  "readInto: reads the same number of bones");
+            Check(live.Bones[1].Rotation.HasData == full.Bones[1].Rotation.HasData &&
+                  live.Bones[2].Translation.HasData == full.Bones[2].Translation.HasData,
+                  "readInto: the tracks it reads match the full parse");
+            Check(ReferenceEquals(live.Textures, texturesBefore) &&
+                  ReferenceEquals(live.Vertices, verticesBefore),
+                  "readInto: leaves the mesh and texture data alone");
+            Check(ReferenceEquals(live.Md21Payload, payloadBefore),
+                  "readInto: reuses the payload rather than slicing a new one");
+
+            // Same fallbacks as the full parse, reported the same way.
+            M2Parser.ReadAnimationInto(file, 99, live);
+            Check(live.AnimatedSequence == 2 && live.AnimationSkipReason != null &&
+                  live.AnimationSkipReason.Contains("99"),
+                  "readInto: an out-of-range request falls back to the idle and says so");
+            M2Parser.ReadAnimationInto(file, 2, live);
+            Check(live.AnimatedSequence == 2 && live.AnimationSkipReason == null,
+                  "readInto: a playable request clears the previous skip reason");
+
+            // EXTERNAL .anim FILES. A sequence without the 0x20 flag keeps its track HEADERS in
+            // the .m2 -- counts and offsets, per sequence, exactly where an in-file sequence keeps
+            // them -- but those offsets address a .anim file's bytes. So the same headers are read
+            // either way, and only the buffer the entries come out of changes. Agronn's
+            // SitGroundDown is the model case: it plays in the legacy viewport and used to fall
+            // back to the idle here.
+            byte[] withAfid = BuildAnimatedM2(new[] { (short)5, (short)0 }, standTrack: true,
+                                              afidAnimId: 5, noKeysInM2: 0);
+            M2ParsedModel afidModel = M2Parser.Parse(withAfid, 1);
+            Check(afidModel.AnimFileIds.Length >= 1, "afid: the chunk is read into the model");
+            Check(M2Parser.ExternalAnimFileId(afidModel, 0) != 0,
+                  "afid: an external sequence reports the file that holds its keys");
+            Check(M2Parser.ExternalAnimFileId(afidModel, 1) == 0,
+                  "afid: an in-file sequence reports no external file");
+
+            // Without the bytes it still falls back, and says why -- now naming the fetch rather
+            // than claiming the milestone cannot do it.
+            M2ParsedModel notFetched = M2Parser.Parse(withAfid, 0);
+            Check(notFetched.AnimatedSequence == 1 && notFetched.AnimationSkipReason != null &&
+                  notFetched.AnimationSkipReason.Contains(".anim"),
+                  "afid: without the bytes the request still falls back to the idle");
+            Check(notFetched.RequiredAnimFileId != 0 ||
+                  M2Parser.ExternalAnimFileId(notFetched, 0) != 0,
+                  "afid: the file that would be needed is reported so it can be fetched");
+
+            // WITH the bytes it plays. The fixture's .anim carries the same keyframe bytes the
+            // .m2 would have, so the sequence resolves to itself rather than the idle.
+            byte[] animBytes = BuildAnimFileFor(withAfid);
+            M2ParsedModel fetched = M2Parser.Parse(withAfid, 0, animBytes);
+            Check(fetched.AnimatedSequence == 0,
+                  "afid: with the .anim bytes the requested sequence plays");
+            Check(fetched.AnimationSkipReason == null,
+                  "afid: and nothing is reported as skipped");
+
+            // ReadAnimationInto takes the same bytes, so switching to an external animation costs
+            // no more than switching to an in-file one.
+            M2ParsedModel live2 = M2Parser.Parse(withAfid, 1);
+            M2Parser.ReadAnimationInto(withAfid, 0, live2, animBytes);
+            Check(live2.AnimatedSequence == 0,
+                  "afid: ReadAnimationInto plays an external sequence too");
+
+            // Bytes fetched for a sequence that then falls back must NOT be read as though they
+            // belonged to the idle -- that would pose the model from the wrong file.
+            M2ParsedModel wrongWay = M2Parser.Parse(withAfid, 99, animBytes);
+            Check(wrongWay.AnimatedSequence == 1,
+                  "afid: an out-of-range request still falls back to the in-file idle");
+
+            // A skeleton-file model has no bone array in THIS file to re-read, so the request is
+            // refused rather than answered from whatever the header's bone array happens to hold.
+            M2ParsedModel skel = M2Parser.Parse(file, 2);
+            skel.SkeletonFileDataID = 4242;
+            M2Parser.ReadAnimationInto(file, 0, skel);
+            Check(skel.AnimatedSequence == -1 && skel.AnimationSkipReason != null &&
+                  skel.AnimationSkipReason.Contains("skeleton file"),
+                  "readInto: a skeleton-file model stays unanimated");
+        }
+
+        /// <summary>
+        /// A stand-in .anim file for the fixture: a copy of the .m2's own bytes.
+        ///
+        /// That is not a shortcut, it is the shape of the thing. A real .anim holds only keyframe
+        /// ENTRIES, addressed by the offsets in the .m2's track headers; copying the .m2 gives a
+        /// buffer where those same offsets resolve to the same keys, which is exactly what the
+        /// reader has to cope with. If the reader wrongly used the .m2 for the entries the test
+        /// would still pass -- so the tests above also check the cases where the two must differ.
+        /// </summary>
+        static byte[] BuildAnimFileFor(byte[] m2)
+        {
+            var copy = new byte[m2.Length];
+            System.Buffer.BlockCopy(m2, 0, copy, 0, m2.Length);
+            return copy;
         }
 
         static void BoneTests()

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -154,6 +154,8 @@ The response carries metadata only; bytes are still fetched with `getAssetByFile
   "geosets": [ 101 ], "hasGeosets": true }
 { "type": "modelAnimation", "fileDataID": 1521037, "sequenceIndex": 2, "animID": 0,
   "durationMs": 2000, "loop": true }
+{ "type": "modelAnimationState", "fileDataID": 1521037, "sequenceIndex": 2, "playing": true,
+  "timeMs": 840, "speed": 1.0, "loop": true }
 ```
 
 Semantics:
@@ -182,6 +184,66 @@ Semantics:
   only one sequence's keyframes are read at a time -- a boss has 109 of them. Nothing else moves:
   the mesh, its materials, its textures and its geoset selection are untouched by which animation
   is playing.
+- **Changing the animation reloads nothing.** `modelAnimation` re-reads one array -- the bone
+  tracks for the new sequence -- into the model already in memory, and touches nothing else. No
+  asset is requested for an in-file sequence, the .m2 is not parsed again, and the mesh, materials,
+  textures, geoset selection and skeleton are all left exactly as they are. `loadWoWModel` remains
+  the only path that builds anything. That split matters for more than tidiness: re-parsing the
+  whole file per selection allocated megabytes each time on a large model, and it was that garbage
+  -- collected a frame or two later -- that the viewport showed as a stutter.
+  **Everything a switch reads is then cached**, per sequence: the raw tracks, and the tracks
+  converted into the renderer's space. Returning to an animation already watched costs a dictionary
+  lookup and no allocation, which is what the user actually does when comparing two animations.
+- **Sequences whose keyframes live in a .anim file play too.** A sequence without flag 0x20 keeps
+  its track HEADERS in the .m2 -- counts and offsets, per sequence, exactly where an in-file
+  sequence keeps them -- but those offsets address a separate .anim file. The AFID chunk says which
+  file: `animId, subAnimId, fileId`, matched on BOTH ids because two sequences routinely share an
+  animId as sub-animations of one action. So playing one needs nothing but the right buffer to read
+  the entries from, which is precisely the split the legacy viewport makes
+  (`WoWModel::readAnimsFromFile` fills a map keyed by animID, and the track reader picks the buffer
+  from it). The bytes come over the existing asset channel and are cached per file, so a sequence is
+  fetched at most once per model. Without them the sequence falls back to the idle and says which
+  file it was waiting for. **This is what made Agronn's SitGroundDown play in the OpenGL viewport
+  and not in this one.**
+  Those files are fetched **when the model loads**, not when an animation first needs one. Fetching
+  on demand cost 16-18 ms of round trip on the first switch to each external animation, during
+  which the PREVIOUS animation stayed on screen -- so picking one did not appear to do anything
+  until it landed. A creature names a handful of them (Agronn 8, ~300 KB), they arrive while the
+  user is looking at the model, and no switch waits on one.
+- **The controls that change an animation also change whether it is RUNNING, and both have to be
+  pushed.** `AnimControl::OnAnim` stops the model, selects, and plays again; so do the loop control
+  and the load path. Only the selection used to push, so the renderer heard "not running" and
+  nothing after it, and held until the next heartbeat -- a half second to a second, on every model.
+  Each of those three now pushes the settled state after `Play()`. When adding a control that
+  touches playback, push after the transport has settled, not in the middle of it.
+- **A selection carries its playback state with it.** `modelAnimation` is followed immediately by
+  a `modelAnimationState` from the same control path, so the renderer knows whether to run the
+  animation it was just given, how fast, and from where -- without waiting on the heartbeat. The
+  heartbeat corrects DRIFT; it is not what starts an animation. Measured end to end, the state
+  arrives 0-2 ms after the selection.
+  The state is also **kept** rather than dropped when it cannot be applied yet. A selection that
+  falls back to the idle, or one still resolving, used to discard it entirely and leave the
+  previous animation's play/pause and speed in force. Play/pause and speed are the app's state, not
+  the sequence's, so they are applied regardless; only the position waits for the sequence it
+  belongs to.
+- `modelAnimationState` is **pushed, not requested**: it carries how that animation is being
+  played -- running or held, how fast, and where in the sequence the app is.
+  Unlike the skin and the animation choice there is **no single funnel** to hook: play, pause,
+  stop, clear, the two step buttons, the speed slider and the frame slider each change it, and the
+  time advances every frame with no control involved at all. So it is pushed two ways -- forced
+  from each of those controls, and on a **one-per-second heartbeat** from the canvas tick while
+  something is playing.
+  The heartbeat is the correction channel for two renderers timing themselves independently. The
+  **player** decides whether a given `timeMs` is worth acting on, because only it knows where its
+  own clock is: a difference under about a frame (40 ms) is ignored, and anything larger snaps. That
+  split is the whole design -- snapping to every message would trade drift for a visible stutter
+  once a second, and never snapping would let the two drift apart. A scrub or a stop arrives with
+  the app's time already far from the player's, so it snaps without needing to be marked special.
+  **Global sequences keep running while the animation is paused, and ignore the speed.** That is
+  the legacy viewport's own behaviour, not an accident: it advances its global clock before it
+  decides whether the animation is paused, and the speed multiplier lives inside the animation
+  tick alone (`ModelCanvas::tick`, `AnimManager::Tick`). A torch keeps flickering on a creature
+  held still.
 - `geosets` / `hasGeosets` ride along with both `modelTextures` and `modelSkin`, because a display
   variant can differ from another by **geometry** rather than texture. `creature/horse3/horse3.m2`
   is the worked example: three of its dropdown entries share one texture and differ only in
@@ -260,11 +322,13 @@ in-process, and shuts the player down. Result lines carry the `[unityipc-test]` 
   the validation models: 3.8e-6 units). Models whose bones live in a separate skeleton file are
   still drawn static, and say so.
 - Animation playback that follows the app: the viewport plays the animation WMV is playing,
-  switching with the dropdown. Bone tracks are evaluated the way the legacy evaluator does,
-  including the global sequences that run on their own clock. With nothing selected yet the
-  model's default idle plays -- the first sequence whose AnimId is "Stand", which is the same
-  choice the OpenGL viewport makes and is not sequence 0. A sequence whose keyframes are not in
-  the .m2 falls back to that idle and says so. `-wmvNoAnim` returns the model to the rest pose.
+  switching with the dropdown, and mirrors how it is being played -- play/pause, speed, and the
+  position in the sequence, including scrubbing the frame slider. Bone tracks are evaluated the
+  way the legacy evaluator does, including the global sequences that run on their own clock and
+  keep running while the animation is held. With nothing selected yet the model's default idle
+  plays -- the first sequence whose AnimId is "Stand", which is the same choice the OpenGL
+  viewport makes and is not sequence 0. A sequence whose keyframes are not in the .m2 falls back
+  to that idle and says so. `-wmvNoAnim` returns the model to the rest pose.
 - Bounds-driven camera framing, so a loaded model is visible immediately.
 
 **Not yet implemented**


### PR DESCRIPTION
The embedded viewport played the animation WMV had selected, but played it its own way: it ran whether or not the app was paused, at its own speed, from its own position. It now mirrors the app's transport controls. Pause holds the Unity pane on the same frame, resume carries on from there, the speed slider changes its speed, and dragging the frame slider scrubs it.

THIS ONE HAD NO FUNNEL. Selected-skin sync had SetSkin and selected-animation sync had SelectAnimation; playback state has neither. Seven controls change it -- play, pause, stop, clear, the two step buttons, the speed slider and the frame slider -- and the time advances every frame with no control involved at all, in ModelCanvas::tick -> WoWModel::update -> AnimManager::Tick, where the frame moves by "int(time*Speed)". So it is pushed both ways: forced from each of those controls through a one-line AnimControl::PushAnimationState, and on a one-per-second heartbeat from the canvas tick while something is playing. The heartbeat suppresses itself while paused (a held model cannot drift) and does nothing at all when the Unity pane was never opened. A full run with four transport changes costs 11-14 messages, not one per frame.

A new modelAnimationState push carries whether the animation is running, how fast, and where in the sequence the app is. WMV is the source of truth; the renderer invents no playback state of its own. It keeps its own clock only so motion is smooth between messages.

THE HEARTBEAT IS A CORRECTION CHANNEL, NOT A STREAM, AND THE PLAYER DECIDES WHAT TO DO WITH IT. Play/pause and speed are applied as given -- they are state. The TIME is a correction: a difference under about a frame (40 ms) is ignored and anything larger snaps, measured the short way round the loop so a wrap is not mistaken for a whole-sequence jump. Snapping to every message would trade drift for a visible stutter once a second; never snapping would let two independently timed renderers walk apart. A scrub or a stop arrives with the app's time already far from the player's, so it snaps with no special case, and every correction is logged with its size -- a run full of them is the symptom, visible as such.

ONE INHERITED BEHAVIOUR IS REPRODUCED RATHER THAN TIDIED: global sequences keep running while the animation is paused, and ignore the speed. ModelCanvas::tick advances globalTime BEFORE it decides whether the animation is paused, and the speed multiplier lives inside AnimManager::Tick alone. A torch keeps flickering on a creature held still, in both viewports.

ANIMATIONS STORED IN .anim FILES NOW PLAY, WHICH IS WHY AGRONN'S SitGroundDown DID NOTHING HERE WHILE PLAYING FINE IN THE OPENGL VIEWPORT. A sequence without flag 0x20 keeps its track HEADERS in the .m2 -- counts and offsets, per sequence, exactly where an in-file sequence keeps them -- but those offsets address a separate .anim file. The AFID chunk names it: animId, subAnimId, fileId, matched on BOTH ids because two sequences routinely share an animId as sub-animations of one action. So playing one needs nothing but the right buffer to read the entries out of, which is precisely the split WoWModel::readAnimsFromFile and the track reader in animated.h make. The bytes travel over the existing asset channel and are cached per file, so a sequence costs at most one fetch per model. creature/agronn/agronn.m2 (984967) gains 6 such animations, valkier 8, chicken2
6. SitGroundDown is sequence 37, animID 96, subAnimID 0, flags 0x81, 3533 ms, and its keys are in 984961 (agronn0096-00.anim); it now moves 42 of 95 bones instead of falling back to the idle. Each of Agronn's six .anim files is fetched exactly once per model, measured, and revisiting an external sequence costs 0 ms, 0 KB and no collection.

Two of Agronn's sequences still fall back, and correctly: 36 and 40 (animIDs 72 and 71) carry neither the 0x20 flag nor an AFID entry, so their keyframes are in no file at all. The legacy viewport has no alias or replacement path either -- NextAnimation is only ever written out to XML, never read -- so it has nothing to play for them. The renderer says which file it wanted and keeps the previous animation running rather than dropping to the rest pose.

SWITCHING ANIMATION NO LONGER STUTTERS, AND FINDING OUT WHY TOOK MEASURING RATHER THAN GUESSING -- TWICE. The first round removed the full re-parse a selection used to trigger: the whole .m2, vertices and textures and materials included, to get at one thing, the bone tracks for the new sequence. M2Parser.ReadAnimationInto reads just those, into the model already in memory, and the MD21 slice it reads them from is cut once at load rather than per switch. That took 2.3-9.4 ms and 1-1.7 MB per switch down to 0.1-1.0 ms and 108-648 KB.

The clock was never the story. What a viewer feels is the COLLECTOR, running a frame or two after the switch on the garbage it made -- which is also why the headless harness could not see it: no frames are rendered there. So the second round removed the allocation rather than the time. Everything a switch reads is now cached per sequence: the raw tracks (WmvMain.boneTrackCache) and the tracks converted into renderer space (WmvM2Animator.convertedBySequence), plus the .anim bytes per file. Returning to an animation already watched -- what comparing two animations actually means -- costs a dictionary lookup, 0 ms and no collection. Debug.Log was also made to stop capturing a full managed stack trace for every ordinary line, which it was doing in the middle of the work it described. That is scoped to LogType.Log alone: warnings, errors, exceptions and assertions keep their traces, verified in the player log. The two failure paths this branch adds -- a .anim that could not be served, a track read that threw -- were raised from a status line to LogWarning for the same reason, so a real fault still arrives with its call chain rather than becoming one more untraced line.

Measured over a full run per model: agronn 20 switches, 0.8 ms avg, 147 KB avg, 0 gen0 collections; chicken2 20, 0.1 ms (worst 1), 63 KB, 1; horse3 12, 0.2 ms (worst 1), 81 KB, 2; valkier 20, 0.9 ms, 189 KB, 4; mininaxx 9, 0.1 ms (worst 1), 109 KB, 0; shaboss_doubt 13, 0.9 ms (worst 2), 460 KB, 6; orcskeleton 19, 0.0 ms, 6 KB, 0. No model reload on any switch (one load per run, measured), no mesh, material, texture or skeleton rebuild. Two runs showed a single 15 ms outlier on an otherwise free cached switch -- no parse, no fetch, 4 KB, no collection -- with 18 of 20 switches at 0 ms; it is not in the parse, the fetch or the allocation, and it has not been chased further.

AND THE VIEWPORT NO LONGER HOLDS FOR ABOUT A SECOND AFTER EVERY ANIMATION CHANGE. That one was not in the renderer at all. AnimControl::OnAnim -- the dropdown the user actually operates -- does three things:

    animManager->Stop();       // Paused = true
    SelectAnimation(...);      // pushes modelAnimation AND its state -- while PAUSED
    animManager->Play();       // Paused = false, and nothing is pushed

so the renderer was told "this animation, and it is not running", and then never told otherwise until the one-per-second heartbeat came round. Hence half a second to a second, on every model, surviving all the parse, fetch and cache work -- and invisible to every headless run, because the harness called SelectAnimation directly, which is not the path the dropdown takes. OnLoop and the load path have the same shape. All three now push the settled state after Play(), and the heartbeat goes back to being drift correction rather than the thing that starts an animation. -unityipctest drives the real handler through the new AnimControl::pickAnimationLikeUser and fails if the state that follows a pick does not say the animation is running.

The player now measures the thing that actually matters, which nothing did before: not how long the switch took, but how long until the model MOVES again (WmvM2Animator.BeginAdvanceWatch, under -wmvAnimCheck). It reports frames as well as milliseconds, so a hold is distinguishable from a stall -- frames counting up while the time stands still is a renderer running fine and an animation being held. Across the validation models every switch now resumes on the SAME FRAME, 0 ms after the switch, and a model the app has paused is not reported as held because standing still is what it was asked to do.

Picking an animation also takes effect at once, which needed the whole path timestamped rather than reasoned about. The selection itself was never the delay: SelectAnimation already pushed modelAnimation and modelAnimationState from the same control path, and the renderer receives them 0-2 ms apart, measured. The heartbeat corrects drift; it was never what started an animation. Two other things were in the way.

A sequence whose keyframes are in a .anim file fetched them on the FIRST switch to it -- 16-18 ms of round trip during which the PREVIOUS animation stayed on screen, so picking one looked like nothing had happened until it landed. Those files are now fetched when the model loads (Agronn: 8 files, ~300 KB); zero switches are deferred now, measured.

And the state that follows a selection was DISCARDED whenever the renderer was not already on the sequence it named -- which is every fallback to the idle and every switch still resolving. Play/pause and speed belong to the app, not to the sequence, so they are applied regardless via SetTransportOnly; the position is applied once it is known which sequence actually plays. Before, a switch in those cases kept the previous animation's transport until a heartbeat corrected it.

The -unityipctest harness drives the transport controls, changes the SKIN while paused and again while running, drives every sequence whose keyframes are in a .anim file, revisits an animation already played so the run shows whether the cache caught it, and asserts that a selection produces its playback state immediately -- both while playing and while paused.

Validated on agronn, chicken2, horse3, mininaxx, valkier, shaboss_doubt and orcskeleton as the unsupported/fallback case: it receives the state, has no animator, ignores it, and says why. All PASS, no exceptions. Skin changes while paused hold the frame exactly and horse3's geoset variants 101/102/103 still switch. chicken2's hidden eye-overlay batch is still skipped and its combiner 12 still active. Under -wmvNoAnim the playback state is inert and no .anim file is fetched at all -- there is nothing to play, so there is nothing worth a round trip. 139/139 parser tests pass, the player scripts type-check under all four input-backend configurations, and the OpenGL viewport renders unchanged.

Known limits: the loop count is always sent as true, so WMV's loop-count machinery is not yet mirrored; mouth and secondary upper-body tracks are not mirrored either. The FIRST visit to a large sequence still allocates its tracks -- shaboss_doubt averages 723 KB and peaked at 1376 KB across a run -- which is inherent to reading keyframes that were not in memory; every later visit allocates nothing. Skeleton-file models
(SKID) remain static, unchanged by this. Under the headless harness the app's canvas barely ticks, so its frame lags the player's and a run ends with one large correction: a harness artefact, not a product behaviour.

Note: the FBX exporter plugin does not build in this tree (glm/std::isnan against the FBX SDK headers). Confirmed pre-existing on a clean develop checkout and untouched here; the app and the renderer build and run.