### PR TITLE
Unity M2 lighting: tuned preview rig with cast and contact shadows

### DIFF
--- a/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
@@ -31,6 +31,11 @@ Shader "WMV/Opaque Textured"
         // Which M2 pixel shader maps to which lives in WmvModelBuilder.PlanCombiner, next to the
         // reasoning; the shader only needs the arithmetic.
         _CombinerMode ("Combiner", Float) = 0
+        // 1 on an additive batch: emitted light, which the preview rig must not dim. Declared
+        // here as a PROPERTY and not only as a uniform -- Material.HasProperty answers from
+        // this block, and the builder's SetFloat is guarded by it. (A first version declared
+        // only the uniform, the guard was false for every material, and the bypass never ran.)
+        _Emissive ("Emissive pass", Float) = 0
         // Where unit 1 samples: 0 = uv set 0, 1 = uv set 1, 2 = environment sphere map.
         _Unit1UV ("Unit 1 UV source", Float) = 2
         // How the M2 combiner builds its "discard alpha": 0 = 1, 1 = unit0.a, 2 = unit1.a,
@@ -82,12 +87,223 @@ Shader "WMV/Opaque Textured"
                 float2 env    : TEXCOORD2;
                 float2 uv1    : TEXCOORD3;
                 half3  viewN  : TEXCOORD4;   // view-space normal: z is the facing ratio
+                float3 wpos   : TEXCOORD5;   // world position, for the cast-shadow lookup
             };
+
+            // ---- PREVIEW RIG CONSTANTS -------------------------------------------------
+            // Every number the look depends on, in one block, so a tuning pass edits numbers
+            // and nothing else. What each one does to the picture is measured by -wmvLightCheck.
+            #define KEY_FLOOR   0.265h    // darkest a surface gets (ambient floor)
+            #define KEY_GAIN    1.644h    // key light; FLOOR+GAIN deliberately exceeds 1.0
+            #define FILL_GAIN   1.5h      // opposite low fill, shadow side only
+            #define RIM_GAIN    0.0h      // edge separation, shadow side only
+            #define SPEC_GAIN   3.0h      // preview highlight strength
+            #define SPEC_TIGHT  49.215h   // preview highlight tightness
+            #define KNEE        0.298h    // where the highlight roll-off starts
+            // What the roll-off approaches. The curve only reaches its asymptote at infinity, so
+            // with CEIL at exactly 1.0 nothing the rig produces can pass white, and a texel lands
+            // on 255 only when it is bright enough to round there anyway. (An earlier value of
+            // 0.97 kept one step of headroom below the point where a channel counts as clipped;
+            // the measured cost of giving it up is 0.000 % clipping on every opaque test model.)
+            #define CEIL        1.0h
+            // Key and fill directions, in VIEW space: x right, y up, z toward the viewer. How far
+            // the key sits off the view axis is what decides whether a model reads as modelled or
+            // as evenly lit -- a key close to the axis lights everything the viewer can see by
+            // roughly the same amount, which is a flat picture however bright it is. Note that
+            // WmvShadowRig anchors the published key fully to the world's vertical (WorldAnchor
+            // 1.0), so these two only shade in the fallback below; the rig's copies must match.
+            #define KEY_DIR     half3(0.081, 0.858, 0.507)
+            #define FILL_DIR    half3(0.059, 0.998, 0.032)
+            // Cast shadows: how much of the key light an occluder removes (0 = shadows off),
+            // and the blur radius of the shadow edge, in shadow-map texels.
+            #define SHADOW_STRENGTH 1.0h
+            #define SHADOW_SOFT     4.0h
+            // Contact shadows: the strength of the screen-space near-field shadow, and how far
+            // it reaches, as a fraction of the model's bounding radius. This is what puts the
+            // hood's shadow ON the face right up to where they touch -- the shadow map's bias
+            // makes it blind for the last few millimetres before a contact, and a shadow that
+            // stops short of the contact line reads as floating.
+            #define CONTACT_STRENGTH 1.0h
+            #define CONTACT_RANGE    0.25h
+            // ----------------------------------------------------------------------------
 
             sampler2D _MainTex;
             float4 _MainTex_ST;
             sampler2D _SecondTex;
             float _CombinerMode, _Unit1UV, _AlphaMode, _AlphaScale, _OpaqueAlpha;
+
+            // 1 on an ADDITIVE batch. An additive pass is light the surface EMITS -- a lantern
+            // flame, an eye glow, rune fire -- and multiplying emitted light by the preview rig
+            // is wrong twice over: dimensionally (the rig models received light), and visibly,
+            // because with the near-vertical anchored key a side-facing glow's lum is barely
+            // above the ambient floor, so lanterns that blaze in the reference footage rendered
+            // here as faint smudges at a fifth of their authored intensity. Emissive passes keep
+            // their authored colour; only the roll-off still applies, so a stacked glow cannot
+            // run away past white.
+            float _Emissive;
+
+            // Which preview light rig to use. A GLOBAL (Shader.SetGlobalFloat), not a material
+            // property, so one draw of one model can be repeated under several rigs without
+            // touching a single material. 0 is the shipped rig, so an unset global -- a player
+            // that never asks -- gets the real thing regardless of initialisation order.
+            float _WmvRig;
+
+            // Replace every surface colour with this flat grey, so a render shows the LIGHT RIG
+            // ALONE with no texture in it. -wmvLightCheck uses it to measure how much shape the
+            // rig actually produces: on a real texture, light and paint arrive as one number and
+            // there is no way to tell a rig that models form from one that lights everything flat.
+            //
+            // A VALUE, not a switch, and 0 means off. It has to be a mid grey: a white albedo is
+            // already at the top of the range before the light touches it, so every rig with any
+            // gain in it saturates and reports no range at all. 0.25 linear -- about sRGB 0.54 --
+            // is a representative WoW texture value and sits where the roll-off does its shaping.
+            float _WmvFlatAlbedo;
+
+            // ---- CAST SHADOWS -----------------------------------------------------------
+            // A depth map rendered from the key light's point of view (WmvShadowRig.cs): one
+            // part of the model in front of another, as seen by the light, is exactly what a
+            // cast shadow is, and no amount of normal-based lighting can produce it -- the
+            // saddle rope across the mount's body needs to know what is BETWEEN the surface
+            // and the light, not which way the surface faces.
+            //
+            // _WmvShadowValid gates everything and an unset global reads 0, so a build where
+            // the rig never ran -- the TestStub, a fallback shader path, an old player --
+            // renders exactly as before. The matrix maps world space to the light's clip
+            // space; the biases are computed by the rig from the map's texel size, not tuned
+            // by hand here.
+            float     _WmvShadowValid;
+            float4x4  _WmvShadowMatrix;
+            sampler2D_float _WmvShadowMap;
+            float     _WmvShadowTexel;        // 1 / map size
+            float     _WmvShadowDepthBias;    // in [0,1] depth units
+            float     _WmvShadowNormalBias;   // world units, along the surface normal
+
+            // 1 = fully lit, 0 = fully occluded (before strength is applied). 3x3 PCF: nine
+            // depth comparisons averaged, spread by "soft" texels, so the edge of the rope's
+            // shadow is a small gradient instead of a hard stairstep.
+            half WmvShadowFactor(float3 wpos, half3 nrmWorld, half soft)
+            {
+                if (_WmvShadowValid < 0.5h)
+                    return 1.0h;
+
+                // Push the sample point out along the normal before projecting: a surface
+                // otherwise compares against its own depth and speckles ("acne"). The offset
+                // scales with the map's texel footprint, so it is as small as it can be.
+                float4 sp = mul(_WmvShadowMatrix,
+                                float4(wpos + nrmWorld * _WmvShadowNormalBias, 1.0));
+                // The light camera is orthographic, so w is 1 -- no divide needed.
+                float2 uv = sp.xy * 0.5 + 0.5;
+                if (uv.x <= 0.0 || uv.x >= 1.0 || uv.y <= 0.0 || uv.y >= 1.0)
+                    return 1.0h;              // outside the map: nothing recorded, so lit
+
+                // No UV flip here -- but only because the matrix was built WITHOUT the
+                // render-into-texture flip (see WmvShadowRig). On D3D the rasteriser's flip and
+                // the sampler's top-down v cancel; a matrix that re-adds the flip mirrors every
+                // lookup vertically, and the artefact is unmistakable once seen: the model's own
+                // silhouette stamped upside-down across itself.
+
+                float lit = 0.0;
+                float r = _WmvShadowTexel * soft;
+                [unroll]
+                for (int y = -1; y <= 1; y++)
+                    [unroll]
+                    for (int x = -1; x <= 1; x++)
+                    {
+                        float stored = tex2D(_WmvShadowMap, uv + float2(x, y) * r).r;
+                        // Depth convention differs per platform; UNITY_REVERSED_Z is the same
+                        // switch the projection matrix was built under (GetGPUProjectionMatrix),
+                        // so the two always agree.
+            #if UNITY_REVERSED_Z
+                        lit += (sp.z >= stored - _WmvShadowDepthBias) ? 1.0 : 0.0;
+            #else
+                        lit += ((sp.z * 0.5 + 0.5) <= stored + _WmvShadowDepthBias) ? 1.0 : 0.0;
+            #endif
+                    }
+                return (half)(lit / 9.0);
+            }
+            // -----------------------------------------------------------------------------
+
+            // ---- CONTACT SHADOWS --------------------------------------------------------
+            // A depth buffer of the CURRENT view (WmvShadowRig renders it alongside the light's
+            // map, from the viewer camera's pose with near/far pinched around the model), plus
+            // the key direction in world space, so a fragment can march toward the light and ask
+            // "is anything I can see standing in the way, within touching distance?".
+            float     _WmvContactValid;
+            float4x4  _WmvViewDepthMatrix;    // world -> the view-depth camera's clip space
+            sampler2D_float _WmvViewDepth;
+            float4    _WmvKeyDirWorld;        // toward the light; w unused
+            float4    _WmvFillDirWorld;       // the sky fill, same handling; w unused
+            float     _WmvModelRadius;        // world units; scales the march to the model
+            float     _WmvContactEps;         // self-hit guard, [0,1] depth units
+            float     _WmvContactThick;       // occluder thickness assumption, [0,1] depth units
+
+            // 1 = unoccluded, down to 0 for a hard nearby occluder -- FRACTIONAL, not a
+            // binary verdict. The first version returned 0 on the first hit, and the result
+            // looked exactly as harsh and as pixelated as a binary function dithered by
+            // per-pixel jitter must: at every shadow boundary, neighbouring pixels flipped
+            // between fully dark and fully lit. Three things make it a gradient instead:
+            //
+            //   * each hit is WEIGHTED -- by a smooth window on the depth test, so there is no
+            //     knife-edge at the guard or the thickness bound, and by how far along the ray
+            //     the occluder sits, so an edge touching the surface darkens fully while one at
+            //     the end of the range barely registers, which is what a real penumbra does;
+            //   * the strongest hit wins (max), so the value varies continuously as an
+            //     occluder recedes from a surface;
+            //   * the jitter now dithers a CONTINUOUS value, which reads as fine shading
+            //     rather than on/off speckle.
+            //
+            // The thickness bound still matters as much as the depth test: a depth buffer
+            // records only front surfaces, and without it anything anywhere in front of the
+            // ray would count as touching.
+            half WmvContactFactor(float3 wpos, half3 nrmWorld, float range)
+            {
+                if (_WmvContactValid < 0.5h)
+                    return 1.0h;
+
+                float3 dir = _WmvKeyDirWorld.xyz;
+
+                // Per-fragment phase for the steps, from the world position: deterministic,
+                // and stable while the camera moves.
+                float jitter = frac(dot(wpos, float3(37.9521, 41.4133, 45.9271)));
+
+                const int STEPS = 12;
+                float occ = 0.0;
+                [loop]
+                for (int s = 0; s < STEPS; s++)
+                {
+                    float t = (s + jitter) / STEPS;
+                    // The normal push keeps the ray off its own surface; it grows with t
+                    // because a surface curving toward the light drifts back under the ray.
+                    // Both pushes scale with `range`, so CONTACT_RANGE also sets the blind
+                    // zone next to a contact: at 0.25 R the clearance is 0.015-0.04 R along
+                    // the normal, four times what the march was first validated with (0.06 R).
+                    // Tightening it means anchoring these fractions to a fixed share of the
+                    // model radius rather than to the reach -- a look change, not a fix.
+                    float3 pw = wpos + nrmWorld * ((0.06 + 0.10 * t) * range)
+                              + dir * (max(t, 0.02) * range);
+                    float4 cp = mul(_WmvViewDepthMatrix, float4(pw, 1.0));
+                    if (cp.w <= 0.001)
+                        break;                       // marched behind the camera: stop
+                    float2 uv = cp.xy / cp.w * 0.5 + 0.5;
+                    if (uv.x <= 0.0 || uv.x >= 1.0 || uv.y <= 0.0 || uv.y >= 1.0)
+                        break;                       // off-screen: nothing recorded out there
+                    float rayZ = cp.z / cp.w;
+                    float stored = tex2D(_WmvViewDepth, uv).r;
+            #if UNITY_REVERSED_Z
+                    // Reversed Z: nearer = larger.
+                    float infront = stored - rayZ;
+            #else
+                    float infront = (rayZ * 0.5 + 0.5) - stored;
+            #endif
+                    float w = smoothstep(_WmvContactEps * 0.5, _WmvContactEps * 1.5, infront)
+                            * (1.0 - smoothstep(_WmvContactThick * 0.6, _WmvContactThick,
+                                                infront));
+                    w *= 1.0 - 0.75 * t;             // near contacts dark, far ones faint
+                    occ = max(occ, w);
+                }
+                return (half)(1.0 - occ);
+            }
+            // -----------------------------------------------------------------------------
             fixed4 _Color;
             fixed _Cutoff;
 
@@ -98,6 +314,7 @@ Shader "WMV/Opaque Textured"
                 o.uv = TRANSFORM_TEX(v.uv, _MainTex);
                 o.uv1 = v.uv2;
                 o.normal = UnityObjectToWorldNormal(v.normal);
+                o.wpos = mul(unity_ObjectToWorld, v.vertex).xyz;
 
                 // ENVIRONMENT UNIT. The M2 vertex shader for a combiner material names where each
                 // texture unit takes its coordinates from, and "Env" means the unit is fed by a
@@ -160,66 +377,197 @@ Shader "WMV/Opaque Textured"
 
                 // PREVIEW LIGHT RIG.
                 //
-                // A model viewer is not a scene. The job here is to show what a texture artist
-                // painted, from a fixed angle, with both sides of the model readable -- not to
-                // simulate a room. So this is three cheap terms with a hard guarantee attached,
-                // and no engine lighting at all (URP and HDRP do not feed the built-in light
-                // uniforms, and a shader that read them would look different per pipeline).
+                // A model viewer is not a scene. The job is to show what a texture artist painted,
+                // from a fixed angle, with both sides of the model readable -- not to simulate a
+                // room. So this is a few cheap terms and no engine lighting at all (URP and HDRP
+                // do not feed the built-in light uniforms, and a shader that read them would look
+                // different per pipeline).
                 //
-                // THE GUARANTEE IS THAT IT CANNOT EXCEED 1. The previous rig was
-                // 0.45 + 0.75*ndl, which peaks at 1.20: every surface pointing within about 40
-                // degrees of the key clipped, so a white tabard or a pale hide came back as a flat
-                // white shape with its painted detail crushed out of it. Ambient and key here sum
-                // to exactly 1.0 at full incidence, and the two additive terms are multiplied by
-                // (1 - key) so they can only ever fill in where the key is not already doing the
-                // work. Nothing can be brighter than its own texture.
-                half3 n  = normalize(i.normal);
-                half3 vn = normalize(i.viewN);
-
-                // Key: upper front-left, the standard three-quarter portrait angle.
-                half ndl  = saturate(dot(n, normalize(half3(0.35, 0.80, -0.50))));
-                // Fill: low and opposite, so the shadow side keeps its shape instead of going
-                // flat. WoW's own textures carry their shading painted in, so this only has to
-                // stop the far side reading as a silhouette.
-                half fill = saturate(dot(n, normalize(half3(-0.55, -0.15, 0.60))));
-                // Rim: edge separation against a dark background, confined to the shadow side so
-                // it never adds to a surface that is already fully lit.
-                half rim  = 1.0h - saturate(vn.z);
-
-                half shadowSide = 1.0h - ndl;
-                half lum = 0.62h                       // floor
-                         + 0.62h * ndl                 // key -- deliberately past 1.0 in sum
-                         + 0.16h * fill * shadowSide
-                         + 0.16h * rim  * rim * shadowSide;
-
-                // PREVIEW HIGHLIGHT, scaled by how bright the texture already is.
+                // WHY THE RIG IS SELECTABLE. Lighting is the one change here whose effect cannot
+                // be read off a log, so it has to be measured -- and a measurement that compares
+                // two SEPARATE BUILDS compares two of everything: two camera framings, two poses,
+                // two pixel sets. That is how a rig carrying strictly more light came back
+                // measuring darker. With the rig behind a global, -wmvLightCheck renders the same
+                // model, at the same instant, through the same camera, and swaps only this one
+                // number between passes; -wmvRig=N forces one rig for a visual A/B in the GUI.
                 //
-                // Not a material property -- nothing in an M2 says "this is metal". But the art
-                // already encodes it: gold trim, gems and polished metal are painted bright, and
-                // leather and fur are not. Weighting a narrow highlight by the texture's own
-                // luminance therefore puts it on the buckles and the gems and leaves the hide
-                // alone, without a specular map and without pretending to be physically based.
-                half3 hv    = normalize(half3(0.30, 0.55, 1.0));      // view-space half vector
-                half  ndh   = saturate(dot(vn, hv));
-                half  texLu = dot(t1.rgb, half3(0.2126h, 0.7152h, 0.0722h));
-                half  spec  = 0.16h * pow(ndh, 26.0h) * texLu * texLu;
+                //   0  shipped     the rig below
+                //   1  legacy      what WMV shipped before this work: 0.45 + 0.75*ndl, nothing
+                //                  else, hard-clipped by the framebuffer at 1.0
+                //
+                // 0 rather than 1 is the shipped rig deliberately: an unset global reads as 0.
+                half3 n  = normalize(i.normal);      // world space -- the legacy rig used this
+                half3 vn = normalize(i.viewN);       // view space  -- the current rig lives here
+                half  rim = 1.0h - saturate(vn.z);
+
+                // Resolve the rig constants once, up here, because rollKnee/rollCeil are needed
+                // by the roll-off further down, outside the rig branch.
+                half  kFloor = KEY_FLOOR,  kGain    = KEY_GAIN;
+                half  fGain  = FILL_GAIN,  rGain    = RIM_GAIN;
+                half  sGain  = SPEC_GAIN,  sTight   = SPEC_TIGHT;
+                half  rollKnee = KNEE,     rollCeil = CEIL;
+                half3 kDir   = KEY_DIR,    fDir     = FILL_DIR;
+                half  shStr  = SHADOW_STRENGTH, shSoft = SHADOW_SOFT;
+                half  cStr   = CONTACT_STRENGTH, cRange = CONTACT_RANGE;
+
+                half  lum;
+                half3 spec = 0.0h;
+                if (_WmvRig > 0.5)
+                {
+                    // LEGACY, untouched: world-fixed key, nothing else.
+                    lum = 0.45h + 0.75h * saturate(dot(n, normalize(half3(0.35, 0.80, -0.50))));
+                }
+                else
+                {
+                    // THE KEY'S VERTICAL IS ANCHORED TO THE WORLD; ONLY ITS TILT FOLLOWS
+                    // THE CAMERA.
+                    //
+                    // The direction arrives from WmvShadowRig, which blends the camera-relative
+                    // KEY_DIR toward world-up each frame -- one vector feeding the shading, the
+                    // shadow camera and the contact march, so they cannot disagree. The blend is
+                    // what the reference viewers measurably do (frame analysis of preview
+                    // footage): orbiting a model there never flips its lit side, and a
+                    // camera looking up from below finds the belly still dark. A fully
+                    // camera-relative key -- this shader's previous behaviour -- passes the
+                    // first test but fails the second: it swings under with the camera and
+                    // lights the underside. A near-vertical world anchor passes both, and it is
+                    // also why preview lighting looks so still: yaw barely changes any surface's
+                    // angle to a vertical light.
+                    //
+                    // The view-space fallback below is for a player where the rig never ran (the
+                    // TestStub, -wmvPlaceholder before a model): the world globals read zero
+                    // there, and normalize(0) would paint the model black.
+                    // The fill is a WRAP term -- a sky hemisphere, not a second sun. A plain
+                    // dot(n, up) is zero on every vertical surface and every belly, which is
+                    // exactly where the anchored key is also zero: the surfaces that need fill
+                    // most were the only ones not getting it, and measured against reference
+                    // footage of the same model our under-side sat at 0.163 versus their 0.208
+                    // with everything else already matched. Half-wrapped, the fill grades from
+                    // full strength on up-facing surfaces to half on vertical ones to nothing
+                    // only on surfaces facing straight down.
+                    half  ndl, fill;
+                    half3 kw = _WmvKeyDirWorld.xyz;
+                    if (dot(kw, kw) > 0.5h)
+                    {
+                        ndl  = saturate(dot(n, kw));
+                        fill = saturate(0.5h + 0.5h * dot(n, _WmvFillDirWorld.xyz));
+                    }
+                    else
+                    {
+                        ndl  = saturate(dot(vn, normalize(kDir)));
+                        fill = saturate(0.5h + 0.5h * dot(vn, normalize(fDir)));
+                    }
+                    half shadowSide = 1.0h - ndl;
+
+                    // CAST SHADOWS.
+                    //
+                    // Two estimators, one question. The map sees the whole model but is blind
+                    // for the last few millimetres before a contact (its bias); the screen-space
+                    // march is exact at contact range but sees only what is on screen. Each has
+                    // its own strength, and where both claim occlusion the darker verdict wins
+                    // -- min(), not a product, because they are measuring the same light and an
+                    // area both can see would otherwise be double-darkened along a rim.
+                    // WHAT EACH SHADOW IS ALLOWED TO REMOVE -- a split that took three
+                    // versions to get right.
+                    //
+                    // Key only (version one) went invisible when the light was anchored
+                    // near-vertical: a face is a vertical surface, its ndl against an overhead
+                    // key is ~0, and blocking a light a surface never received changes nothing
+                    // -- the under-hood face stopped darkening at all. Both-shadows-take-
+                    // everything (version two) restored it and then flattened whole models: an
+                    // overhead light puts the MAP's shadow across everything below a cloak's
+                    // shoulders, and removing sky fill and ambient over that whole span dropped
+                    // a boss model's mean by a third.
+                    //
+                    // The split that works follows what each estimator actually knows. The map
+                    // answers "does the KEY reach this point" -- a directional question, so it
+                    // attenuates the key (and the key-driven highlight) and nothing else. The
+                    // contact march answers "is something within touching distance overhead" --
+                    // a NEAR-FIELD question, which is precisely what sky-and-ambient occlusion
+                    // is, so it takes the fill and half the floor as well, but only within its
+                    // short range. An under-hood face darkens because the hood is near it; a
+                    // torso under a distant cloak keeps its sky light. The floor's half-bound
+                    // means no shadow can push a surface below half ambient -- readable, never
+                    // black. This matches how the reference viewers read: their under-hood
+                    // darkness is local occlusion, not a blocked sun.
+                    half castKey = 1.0h;                // the key's directional shadow
+                    half occ = 1.0h;                    // near-field sky/ambient occlusion
+                    if (shStr > 0.0h)
+                        castKey = 1.0h - shStr * (1.0h - WmvShadowFactor(i.wpos, n, shSoft));
+                    if (cStr > 0.0h)
+                    {
+                        half contact = WmvContactFactor(i.wpos, n, cRange * _WmvModelRadius);
+                        occ = 1.0h - cStr * (1.0h - contact);
+                        castKey = min(castKey, occ);    // whatever is that close blocks the key too
+                    }
+
+                    lum = kFloor * (0.5h + 0.5h * occ)
+                        + kGain * ndl * castKey
+                        + fGain * fill * shadowSide * occ
+                        + rGain * rim  * rim * shadowSide;
+
+                    // PREVIEW HIGHLIGHT, scaled by how bright the texture already is.
+                    //
+                    // Not a material property -- nothing in an M2 says "this is metal". But the
+                    // art already encodes it: gold trim, gems and polished metal are painted
+                    // bright, and leather and fur are not. Weighting a narrow highlight by the
+                    // texture luminance therefore puts it on the buckles and the gems and leaves
+                    // the hide alone, without a specular map and without pretending to be
+                    // physically based.
+                    // Tinted by the surface, not white. A white highlight is achromatic light
+                    // added on top of a colour, which drags it toward grey -- measurably, and
+                    // worst on the saturated gold and red trim the highlight is meant to show
+                    // off. Multiplying by the texture colour instead keeps the glint the colour
+                    // of the metal it is sitting on, so brightness goes up and saturation does
+                    // not go down.
+                    half3 alb   = _WmvFlatAlbedo > 0.0 ? (half3)_WmvFlatAlbedo : t1.rgb;
+                    half3 hv    = normalize(half3(0.30, 0.55, 1.0));   // view-space half vector
+                    half  ndh   = saturate(dot(vn, hv));
+                    half  texLu = dot(alb, half3(0.2126h, 0.7152h, 0.0722h));
+                    spec = sGain * pow(ndh, sTight) * texLu * alb * castKey;
+                }
+
+                if (_WmvFlatAlbedo > 0.0)
+                    c.rgb = (half3)_WmvFlatAlbedo;
+
+                // Shipped rig only: the legacy rig is a record of what WMV drew before this
+                // work, additive batches included, and must stay byte-identical to it. (The
+                // bypass leaking into the legacy path was measurable -- a model with glow
+                // batches moved by +0.002 mean under -wmvRig=1 -- and it was also the proof
+                // that the property finally reached the material.)
+                if (_Emissive > 0.5h && _WmvRig < 0.5)
+                {
+                    lum  = 1.0h;
+                    spec = 0.0h;
+                }
 
                 c.rgb = c.rgb * lum + spec;
 
-                // SHOULDER, not a ceiling.
-                //
-                // The previous rig kept everything at or below 1.0 by never letting the light sum
-                // past it, which does stop whites blowing out -- by making sure nothing is ever
-                // brighter than its own texture. White fur then reads grey, because that is what
-                // a white texture at 70% looks like. So the light now goes past 1.0 and the top
-                // end is rolled off instead: everything below the knee is untouched, which is
-                // where the painted colour lives, and above it the curve bends over and only
-                // approaches 1.0 asymptotically. Bright things get bright; nothing reaches white.
-                // Applied per channel, so a saturated red lifts its red without dragging the other
-                // two up with it -- the colour stays the colour.
-                const half knee = 0.72h;
-                half3 over = max(c.rgb - knee, 0.0h);
-                c.rgb = min(c.rgb, knee) + (1.0h - knee) * (1.0h - exp(-over / (1.0h - knee)));
+                if (_WmvRig < 0.5)
+                {
+                    // SHOULDER, not a ceiling.
+                    //
+                    // Capping the light so the product can never pass 1.0 does stop whites blowing
+                    // out -- by guaranteeing nothing is ever brighter than its own texture. White
+                    // fur then reads grey, because that is what a white texture at 70 % light IS.
+                    // So the light goes well past 1.0 and the top end is rolled off instead:
+                    // below the knee nothing is touched, which is where the painted colour lives,
+                    // and above it the curve bends over and approaches CEIL asymptotically.
+                    //
+                    // ON THE BRIGHTEST CHANNEL, NOT PER CHANNEL. Rolling each channel off
+                    // separately compresses a bright channel harder than a dim one, which pulls
+                    // the three together -- so the roll-off itself desaturates, worst exactly on
+                    // the saturated reds and golds that are supposed to be the ones that pop.
+                    // Rolling off the maximum and scaling all three by the same factor keeps
+                    // every channel ratio, so hue and saturation come out untouched and only
+                    // brightness is shaped. Measured: the per-channel form cost 0.008-0.012
+                    // chroma against the old rig; this form does not.
+                    half mx  = max(c.r, max(c.g, c.b));
+                    half ov  = max(mx - rollKnee, 0.0h);
+                    half rolled = min(mx, rollKnee)
+                                + (rollCeil - rollKnee) * (1.0h - exp(-ov / (rollCeil - rollKnee)));
+                    c.rgb *= mx > 0.0001h ? rolled / mx : 1.0h;
+                }
 
                 c.a = (_OpaqueAlpha > 0.5) ? 1.0 : a;
                 return c;

--- a/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
@@ -81,6 +81,7 @@ Shader "WMV/Opaque Textured"
                 float3 normal : TEXCOORD1;
                 float2 env    : TEXCOORD2;
                 float2 uv1    : TEXCOORD3;
+                half3  viewN  : TEXCOORD4;   // view-space normal: z is the facing ratio
             };
 
             sampler2D _MainTex;
@@ -111,6 +112,11 @@ Shader "WMV/Opaque Textured"
                 // that ordinary Unity UVs work, which puts this generated coordinate the other way
                 // up from the OpenGL viewport's. Without the flip the sheen sits on the wrong side.
                 o.env = float2(r.x / m + 0.5, 0.5 - r.y / m);
+
+                // Free: viewNrm is already here for the sphere map. Its z is how square-on the
+                // surface is to the camera (the rim), and the vector itself gives the highlight a
+                // stable frame that does not move when the model is orbited.
+                o.viewN = viewNrm;
                 return o;
             }
 
@@ -152,11 +158,68 @@ Shader "WMV/Opaque Textured"
                     clip(a - _Cutoff);
                 #endif
 
-                // Fixed key light + ambient. Engine light data is unavailable across pipelines,
-                // so this is a viewer light, not the scene's -- it only has to read as shape.
-                half3 n = normalize(i.normal);
-                half ndl = saturate(dot(n, normalize(half3(0.35, 0.80, -0.50))));
-                c.rgb *= 0.45h + 0.75h * ndl;
+                // PREVIEW LIGHT RIG.
+                //
+                // A model viewer is not a scene. The job here is to show what a texture artist
+                // painted, from a fixed angle, with both sides of the model readable -- not to
+                // simulate a room. So this is three cheap terms with a hard guarantee attached,
+                // and no engine lighting at all (URP and HDRP do not feed the built-in light
+                // uniforms, and a shader that read them would look different per pipeline).
+                //
+                // THE GUARANTEE IS THAT IT CANNOT EXCEED 1. The previous rig was
+                // 0.45 + 0.75*ndl, which peaks at 1.20: every surface pointing within about 40
+                // degrees of the key clipped, so a white tabard or a pale hide came back as a flat
+                // white shape with its painted detail crushed out of it. Ambient and key here sum
+                // to exactly 1.0 at full incidence, and the two additive terms are multiplied by
+                // (1 - key) so they can only ever fill in where the key is not already doing the
+                // work. Nothing can be brighter than its own texture.
+                half3 n  = normalize(i.normal);
+                half3 vn = normalize(i.viewN);
+
+                // Key: upper front-left, the standard three-quarter portrait angle.
+                half ndl  = saturate(dot(n, normalize(half3(0.35, 0.80, -0.50))));
+                // Fill: low and opposite, so the shadow side keeps its shape instead of going
+                // flat. WoW's own textures carry their shading painted in, so this only has to
+                // stop the far side reading as a silhouette.
+                half fill = saturate(dot(n, normalize(half3(-0.55, -0.15, 0.60))));
+                // Rim: edge separation against a dark background, confined to the shadow side so
+                // it never adds to a surface that is already fully lit.
+                half rim  = 1.0h - saturate(vn.z);
+
+                half shadowSide = 1.0h - ndl;
+                half lum = 0.62h                       // floor
+                         + 0.62h * ndl                 // key -- deliberately past 1.0 in sum
+                         + 0.16h * fill * shadowSide
+                         + 0.16h * rim  * rim * shadowSide;
+
+                // PREVIEW HIGHLIGHT, scaled by how bright the texture already is.
+                //
+                // Not a material property -- nothing in an M2 says "this is metal". But the art
+                // already encodes it: gold trim, gems and polished metal are painted bright, and
+                // leather and fur are not. Weighting a narrow highlight by the texture's own
+                // luminance therefore puts it on the buckles and the gems and leaves the hide
+                // alone, without a specular map and without pretending to be physically based.
+                half3 hv    = normalize(half3(0.30, 0.55, 1.0));      // view-space half vector
+                half  ndh   = saturate(dot(vn, hv));
+                half  texLu = dot(t1.rgb, half3(0.2126h, 0.7152h, 0.0722h));
+                half  spec  = 0.16h * pow(ndh, 26.0h) * texLu * texLu;
+
+                c.rgb = c.rgb * lum + spec;
+
+                // SHOULDER, not a ceiling.
+                //
+                // The previous rig kept everything at or below 1.0 by never letting the light sum
+                // past it, which does stop whites blowing out -- by making sure nothing is ever
+                // brighter than its own texture. White fur then reads grey, because that is what
+                // a white texture at 70% looks like. So the light now goes past 1.0 and the top
+                // end is rolled off instead: everything below the knee is untouched, which is
+                // where the painted colour lives, and above it the curve bends over and only
+                // approaches 1.0 asymptotically. Bright things get bright; nothing reaches white.
+                // Applied per channel, so a saturated red lifts its red without dragging the other
+                // two up with it -- the colour stays the colour.
+                const half knee = 0.72h;
+                half3 over = max(c.rgb - knee, 0.0h);
+                c.rgb = min(c.rgb, knee) + (1.0h - knee) * (1.0h - exp(-over / (1.0h - knee)));
 
                 c.a = (_OpaqueAlpha > 0.5) ? 1.0 : a;
                 return c;

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -36,6 +36,7 @@ public class WmvMain : MonoBehaviour
     WmvOrbitCamera orbit;
 
     WmvRuntimeModel current;          // the model on screen (disposed when replaced)
+    WmvShadowRig shadowRig;           // renders the cast-shadow depth map (see WmvShadowRig.cs)
 
     /// <summary>
     /// The .m2 bytes of the model on screen. Kept because only ONE animation's keyframes are
@@ -166,6 +167,16 @@ public class WmvMain : MonoBehaviour
         // different per pipeline. These exist so that a build which somehow has to fall back to a
         // pipeline Lit shader (-wmvLitShader, or a player with no Resources) is not lit by nothing
         // at all. Their angle matches the shader's key so the two do not disagree wildly.
+        // -wmvRig=N draws the viewport with a different preview light rig (0 shipped,
+        // 1 legacy). The global is the only thing that changes; every material and every
+        // combiner stays exactly as it was.
+        Shader.SetGlobalFloat("_WmvRig", WmvModelBuilder.Debug_.Rig);
+
+        // Cast shadows: the model occluding its own key light (a rein across the mount's body).
+        // The rig renders a depth map from the key's viewpoint each frame; the shader attenuates
+        // the key term where the map says something stands in the way. See WmvShadowRig.cs.
+        shadowRig = gameObject.AddComponent<WmvShadowRig>();
+
         var lightGo = new GameObject("Directional Light");
         var light = lightGo.AddComponent<Light>();
         light.type = LightType.Directional;
@@ -425,9 +436,12 @@ public class WmvMain : MonoBehaviour
             PrefetchAnimFiles();
 
             orbit.Frame(built.Bounds);
+            if (shadowRig != null)
+                shadowRig.SetBounds(built.Bounds);
 
-            // AFTER framing, not before: measuring the lighting on a model the camera has not
-            // pointed at yet reports a handful of stray pixels and calls it a reading.
+            // The light check brings its own camera and frames the model itself, so it no longer
+            // depends on this call having happened -- an earlier version measured before framing
+            // and reported a few stray pixels as a reading.
             if (WmvModelBuilder.Debug_.LightCheck)
                 ReportLighting();
 
@@ -547,112 +561,429 @@ public class WmvMain : MonoBehaviour
     }
 
     /// <summary>
-    /// Render the model offscreen and say what the lighting did to it.
+    /// Render the model offscreen and report what the light rig did to it -- measured on a set of
+    /// pixels that the light rig cannot move.
     ///
-    /// Lighting work is the one thing here that cannot be checked by reading a log: "readable",
-    /// "not blown out", "not crushed" are all statements about pixels. So this renders one frame
-    /// into a texture and measures it, which turns each of those into a number that a run either
-    /// meets or does not:
+    /// WHY THE OLD VERSION WAS NOT TRUSTWORTHY. It picked the model out of the frame with
+    /// "brighter than the background plus 0.02", which defines the sample in terms of the very
+    /// quantity being measured. Brighten the shader and dim model pixels -- silhouette
+    /// antialiasing, the shadow side, dark texture regions -- cross that line and join the sample.
+    /// They join it at the bottom, so the reported mean can FALL while every single pixel got
+    /// brighter. That is a selection effect, not a lighting result, and it is why a rig carrying
+    /// strictly more light measured darker on the pale models.
     ///
-    ///   coverage   -- how much of the frame the model occupies (that it rendered at all)
-    ///   mean       -- overall brightness of the model against the background
-    ///   clipped    -- fraction of model pixels at full white in any channel. This is the one the
-    ///                 old rig failed: it peaked at 1.20, so pale surfaces facing the key light
-    ///                 came back as flat white with the painted detail gone.
-    ///   p05        -- the 5th-percentile luminance, i.e. how dark the darkest real parts are.
-    ///                 A shadow side that reads as a black silhouette shows up here.
+    /// WHAT REPLACES IT. The model is separated from the background geometrically: the same frame
+    /// is drawn twice, once cleared to black and once to white, and a pixel counts as model where
+    /// the two agree exactly. Only geometry that fully covers a pixel with opaque, depth-writing
+    /// material can be independent of what was cleared behind it, so the mask depends on the mesh,
+    /// the blend states and the camera -- and on nothing the light rig does. Additive and blended
+    /// batches, and antialiased silhouette pixels, fall outside it by construction, which is the
+    /// point: those are exactly the pixels whose value is part background.
     ///
-    /// Diagnostics only, and it renders to its own texture -- nothing is written to disk and the
-    /// viewport is untouched.
+    /// Everything else is pinned too: a camera of its own (the viewport orbit cannot leak in),
+    /// framing derived from the bounds alone, and -wmvNoAnim for a fixed pose. Every rig is then
+    /// measured through that one camera, over that one mask, in one process, so the only thing
+    /// that differs between the numbers is the rig.
+    ///
+    /// The old threshold number is still printed beside the new one, because the gap between them
+    /// IS the artefact, and it is worth being able to see it rather than take it on trust.
+    ///
+    /// Diagnostics only: its own camera and its own render texture, nothing written to disk, the
+    /// viewport untouched.
     /// </summary>
     void ReportLighting()
     {
-        var cam = Camera.main;
-        if (cam == null || current == null)
+        Camera src = Camera.main;
+        if (src == null || current == null)
+        {
+            Debug.Log("WMV: lightcheck: no camera or no model -- nothing measured");
             return;
+        }
 
-        const int W = 256, H = 256;
+        const int W = 512, H = 512;
+        const float Fov = 60f;
+        float Yaw = WmvModelBuilder.Debug_.LightYaw;
+        float Pitch = WmvModelBuilder.Debug_.LightPitch;
+
+        // FRAMING, from the bounds and two fixed angles. Not from the orbit: the viewport camera
+        // may have been moved by a Frame() call, a drag or a wheel, and a measurement that moves
+        // with it compares two different pictures.
+        Bounds b = current.Bounds;
+        Quaternion rot = Quaternion.Euler(Pitch, Yaw, 0f);
+        Vector3 up = rot * Vector3.up, right = rot * Vector3.right, fwd = rot * Vector3.forward;
+        Vector3 e = b.extents;
+        float halfUp = Mathf.Abs(e.x * up.x) + Mathf.Abs(e.y * up.y) + Mathf.Abs(e.z * up.z);
+        float halfRt = Mathf.Abs(e.x * right.x) + Mathf.Abs(e.y * right.y) + Mathf.Abs(e.z * right.z);
+        float halfFw = Mathf.Abs(e.x * fwd.x) + Mathf.Abs(e.y * fwd.y) + Mathf.Abs(e.z * fwd.z);
+        // Square frame, so the vertical field of view governs both axes.
+        float need = Mathf.Max(Mathf.Max(halfUp, halfRt), 0.01f);
+        float dist = need / Mathf.Tan(Fov * 0.5f * Mathf.Deg2Rad) * 1.08f + halfFw;
+
+        var go = new GameObject("WmvLightCheckCamera");
+        Camera cam = go.AddComponent<Camera>();
+        cam.enabled = false;                         // only ever rendered by hand, below
+        cam.clearFlags = CameraClearFlags.SolidColor;
+        cam.fieldOfView = Fov;
+        cam.cullingMask = src.cullingMask;
+        cam.allowHDR = false;
+        cam.allowMSAA = false;
+        cam.transform.rotation = rot;
+        cam.transform.position = b.center - fwd * dist;
+        cam.nearClipPlane = Mathf.Max(0.01f, dist * 0.01f);
+        cam.farClipPlane = dist * 10f + 100f;
+
         RenderTexture rt = RenderTexture.GetTemporary(W, H, 24, RenderTextureFormat.ARGB32,
                                                       RenderTextureReadWrite.Default);
-        RenderTexture prevTarget = cam.targetTexture;
         RenderTexture prevActive = RenderTexture.active;
-        Vector3 prevPos = cam.transform.position;
-        Quaternion prevRot = cam.transform.rotation;
-        Texture2D shot = null;
+        float restoreRig = WmvModelBuilder.Debug_.Rig;
         try
         {
-            // Frame the model from a FIXED angle and distance for the measurement, then put the
-            // camera back. Reading whatever the orbit happened to be showing made the numbers
-            // wander between runs -- coverage moved by a fifth on repeats of the same build --
-            // and a measurement that disagrees with itself cannot say whether a change helped.
-            Bounds modelBounds = current.Bounds;
-            float radius = Mathf.Max(modelBounds.extents.magnitude, 0.001f);
-            Vector3 dir = new Vector3(0.45f, 0.35f, -1f).normalized;
-            cam.transform.position = modelBounds.center - dir * (radius * 2.6f);
-            cam.transform.rotation = Quaternion.LookRotation(dir, Vector3.up);
+            // The shadow map must belong to THIS camera, not to wherever the viewport was
+            // pointing: the key is view-relative, so the map's light direction follows the
+            // camera it was rendered for, and a measurement taken with someone else's map
+            // would move when the viewport moved.
+            if (shadowRig != null)
+                shadowRig.RenderFor(cam);
 
-            cam.targetTexture = rt;
-            cam.Render();
-            RenderTexture.active = rt;
-            shot = new Texture2D(W, H, TextureFormat.RGBA32, false);
-            shot.ReadPixels(new Rect(0, 0, W, H), 0, 0);
-            shot.Apply(false);
-
-            Color bg = cam.backgroundColor;
-            float bgLum = 0.2126f * bg.r + 0.7152f * bg.g + 0.0722f * bg.b;
-
-            var lums = new List<float>(W * H);
-            int clipped = 0;
-            // Mean over the WHOLE frame as well. The model-only figures below depend on a
-            // threshold to separate model from background, and a brighter model pulls previously
-            // excluded dark pixels above it -- which can drag the model-only mean DOWN while every
-            // pixel got brighter. This one has no threshold in it and cannot do that, so the two
-            // together say whether a change actually brightened anything.
-            float frameSum = 0f;
-            Color32[] px = shot.GetPixels32();
-            foreach (Color32 c in px)
+            // ---- the mask: geometry decides, not brightness ---------------------------------
+            //
+            // Built under the LEGACY rig specifically. Byte-equality between the two clears is a
+            // near-perfect stand-in for "opaque geometry covered this pixel", but not a perfect
+            // one: where an additive batch is bright enough to saturate the result over BOTH
+            // clears, the two agree for a reason that has nothing to do with coverage, and the
+            // pixel joins the mask. Which pixels those are depends on how bright the rig is --
+            // so a mask built under the rig being measured would drift as the rig is tuned, and
+            // it did, by a few pixels on the two models with big additive passes. The legacy rig
+            // is the one rig that is finished and will not be tuned again, so building the mask
+            // under it pins the pixel set across every candidate and every build.
+            Shader.SetGlobalFloat("_WmvRig", 1);
+            Color32[] onBlack = GrabFrame(cam, rt, Color.black, W, H);
+            Color32[] onWhite = GrabFrame(cam, rt, Color.white, W, H);
+            var mask = new bool[W * H];
+            int covered = 0, saturated = 0;
+            for (int i = 0; i < mask.Length; i++)
             {
-                float r = c.r / 255f, g = c.g / 255f, b = c.b / 255f;
-                float lum = 0.2126f * r + 0.7152f * g + 0.0722f * b;
-                frameSum += lum;
-                // Anything meaningfully brighter than the background is the model. The clear
-                // colour is flat, so this separates the two without needing a mask pass.
-                if (lum <= bgLum + 0.02f)
-                    continue;
-                lums.Add(lum);
-                if (c.r >= 253 || c.g >= 253 || c.b >= 253)
-                    clipped++;
+                Color32 p = onBlack[i], q = onWhite[i];
+                bool same = p.r == q.r && p.g == q.g && p.b == q.b;
+                // ...but not if it agreed only because it ran out of range. An additive batch
+                // bright enough to saturate over a black clear saturates over a white one too,
+                // so the two agree for a reason that has nothing to do with coverage -- valkier,
+                // which is 99 % additive, smuggled in 1676 such pixels and then reported 12 %
+                // of its own mask as clipped. A pixel pinned at the top of the range carries no
+                // luminance to measure either way, so it is not part of the sample.
+                bool pinned = p.r >= 255 || p.g >= 255 || p.b >= 255;
+                if (same && pinned) { saturated++; same = false; }
+                mask[i] = same;
+                if (same) covered++;
             }
 
-            if (lums.Count == 0)
+            // Determinism is a claim, so check it rather than assert it: build the mask a second
+            // time and report whether the two agree pixel for pixel.
+            Color32[] onBlack2 = GrabFrame(cam, rt, Color.black, W, H);
+            Color32[] onWhite2 = GrabFrame(cam, rt, Color.white, W, H);
+            int maskDrift = 0;
+            for (int i = 0; i < mask.Length; i++)
             {
-                Debug.Log("WMV: light check: nothing brighter than the background was drawn");
+                bool same2 = onBlack2[i].r == onWhite2[i].r && onBlack2[i].g == onWhite2[i].g
+                             && onBlack2[i].b == onWhite2[i].b;
+                if (same2 && (onBlack2[i].r >= 255 || onBlack2[i].g >= 255 || onBlack2[i].b >= 255))
+                    same2 = false;
+                if (same2 != mask[i]) maskDrift++;
+            }
+
+            Color bg = src.backgroundColor;
+            float bgLum = 0.2126f * bg.r + 0.7152f * bg.g + 0.0722f * bg.b;
+            // WHICH SKIN WAS MEASURED, spelled out. WMV picks a random skin per load unless
+            // Session/RandomLooks is off, and a creature can carry skins that differ in brightness
+            // by more than any light rig ever will -- chicken2 spans 2.4x across its four. A
+            // before/after pair taken in two processes is therefore not comparable unless this
+            // line matches, and until it was printed there was no way to notice that it did not.
+            var skinIds = new List<string>();
+            foreach (var kv in currentTextureIds) skinIds.Add(kv.Key + ":" + kv.Value);
+            skinIds.Sort();
+            Debug.Log(string.Format(
+                "WMV: lightcheck: {0} | camera yaw {1} pitch {2} fov {3} dist {4:F3} "
+                + "| bounds extents ({5:F2},{6:F2},{7:F2}) | background {8:F4} | textures {9}",
+                currentName, Yaw, Pitch, Fov, dist, e.x, e.y, e.z, bgLum,
+                skinIds.Count > 0 ? string.Join(",", skinIds.ToArray()) : "(none recorded)"));
+            Debug.Log(string.Format(
+                "WMV: lightcheck: mask {0} px ({1:P2} of frame), {2} px dropped as saturated, "
+                + "drift on rebuild {3} px -- {4}",
+                covered, covered / (float)(W * H), saturated, maskDrift,
+                maskDrift == 0 ? "deterministic" : "NOT DETERMINISTIC, numbers below are suspect"));
+
+            // A model that is nearly all additive or alpha-blended has almost no opaque core
+            // to measure, so say so rather than quietly reporting a number from a sliver of it.
+            if (covered > 0 && covered < (W * H) / 100)
+                Debug.Log(string.Format(
+                    "WMV: lightcheck: WARNING -- only {0:P2} of the frame is opaque geometry; this "
+                    + "model is mostly blended/additive and the figures below describe a small "
+                    + "opaque core, not what the viewer shows", covered / (float)(W * H)));
+
+            if (covered == 0)
+            {
+                Debug.Log("WMV: lightcheck: no opaque depth-writing geometry covered a pixel -- "
+                          + "nothing to measure (a fully blended model, or nothing drawn)");
                 return;
             }
-            lums.Sort();
-            float sum = 0f;
-            foreach (float l in lums) sum += l;
-            float p05 = lums[Mathf.Clamp(Mathf.RoundToInt(lums.Count * 0.05f), 0, lums.Count - 1)];
-            float p95 = lums[Mathf.Clamp(Mathf.RoundToInt(lums.Count * 0.95f), 0, lums.Count - 1)];
-            Debug.Log(string.Format(
-                "WMV: light check: coverage {0:P1} of frame | background {1:F3} | frame mean {7:F4} "
-                + "| model mean {2:F3} p05 {3:F3} p95 {4:F3} max {5:F3} | clipped {6:P2}",
-                lums.Count / (float)(W * H), bgLum, sum / lums.Count, p05, p95,
-                lums[lums.Count - 1], clipped / (float)lums.Count, frameSum / (W * H)));
+
+            // ---- every rig, same camera, same mask, same process -----------------------------
+            for (int rig = 0; rig <= 1; rig++)
+            {
+                Shader.SetGlobalFloat("_WmvRig", rig);
+                Color32[] shot = GrabFrame(cam, rt, bg, W, H);
+                ReportOneRig(rig, shot, mask, covered, bgLum, W, H);
+
+                // CAST SHADOWS, measured by subtraction -- and PER CONTRIBUTOR, because the
+                // map and the contact march compose with min() and a joint measurement hides
+                // whichever one the other already covers (an early version disabled only the
+                // map in the reference frame and reported the contact march's entire output as
+                // a REDUCTION in shadow). Three frames: everything on, map only, neither.
+                if (rig == 0 && shadowRig != null)
+                {
+                    Shader.SetGlobalFloat("_WmvContactValid", 0f);
+                    Color32[] mapOnly = GrabFrame(cam, rt, bg, W, H);
+                    Shader.SetGlobalFloat("_WmvShadowValid", 0f);
+                    Color32[] unshadowed = GrabFrame(cam, rt, bg, W, H);
+                    shadowRig.RenderFor(cam);            // restores both maps and both flags
+                    ReportShadow("map", mapOnly, unshadowed, mask, W, H);
+                    ReportShadow("map+contact", shot, unshadowed, mask, W, H);
+                    ReportShadow("contact adds", shot, mapOnly, mask, W, H);
+                }
+
+                // ...and again with the texture taken out of it. On a real model, paint and light
+                // arrive as one number: a rig that models form and a rig that lights everything
+                // flat can produce the same mean, the same percentiles and the same contrast,
+                // because the spread being measured is mostly the texture. White albedo leaves
+                // only the rig, so "does this have shadows in it" becomes a ratio instead of an
+                // opinion. The shipped rig measured FLATTER than the legacy one here while every
+                // other number said it was better, which is exactly the failure this catches.
+                const float FlatAlbedo = 0.25f;   // linear, ~sRGB 0.54: a typical WoW texel
+                Shader.SetGlobalFloat("_WmvFlatAlbedo", FlatAlbedo);
+                Color32[] flat = GrabFrame(cam, rt, bg, W, H);
+                Shader.SetGlobalFloat("_WmvFlatAlbedo", 0f);
+                ReportShading(rig, flat, mask, covered);
+            }
         }
-        catch (System.Exception e)
+        catch (System.Exception ex)
         {
-            Debug.LogWarning("WMV: light check could not render: " + e.Message);
+            Debug.LogWarning("WMV: lightcheck could not render: " + ex.Message);
         }
         finally
         {
-            cam.targetTexture = prevTarget;
+            Shader.SetGlobalFloat("_WmvRig", restoreRig);
             RenderTexture.active = prevActive;
-            cam.transform.position = prevPos;
-            cam.transform.rotation = prevRot;
             RenderTexture.ReleaseTemporary(rt);
-            if (shot != null) Destroy(shot);
+            Destroy(go);
         }
+    }
+
+    /// <summary>
+    /// Render one frame of the measurement camera into rt with the given clear colour and read it
+    /// back. Its own texture each call, so the caller can hold several frames side by side.
+    /// </summary>
+    Color32[] GrabFrame(Camera cam, RenderTexture rt, Color clear, int w, int h)
+    {
+        cam.backgroundColor = clear;
+        cam.targetTexture = rt;
+        cam.Render();
+        cam.targetTexture = null;
+        RenderTexture prev = RenderTexture.active;
+        RenderTexture.active = rt;
+        var tex = new Texture2D(w, h, TextureFormat.RGBA32, false);
+        tex.ReadPixels(new Rect(0, 0, w, h), 0, 0);
+        tex.Apply(false);
+        RenderTexture.active = prev;
+        Color32[] px = tex.GetPixels32();
+        Destroy(tex);
+        return px;
+    }
+
+    /// <summary>
+    /// Statistics for one rig over the geometric mask, plus -- deliberately -- the number the old
+    /// threshold rule would have printed for the same frame, so the two can be compared directly.
+    /// </summary>
+    void ReportOneRig(int rig, Color32[] shot, bool[] mask, int covered, float bgLum, int w, int h)
+    {
+        var lums = new List<float>(covered);
+        int clipped = 0;
+        double chroma = 0.0;
+        int threshCount = 0;
+        double threshSum = 0.0;
+        float threshold = bgLum + 0.02f;
+
+        for (int i = 0; i < shot.Length; i++)
+        {
+            Color32 c = shot[i];
+            float r = c.r / 255f, g = c.g / 255f, bl = c.b / 255f;
+            float lum = 0.2126f * r + 0.7152f * g + 0.0722f * bl;
+
+            // The old rule, over the WHOLE frame, exactly as it used to be applied.
+            if (lum > threshold) { threshCount++; threshSum += lum; }
+
+            if (!mask[i]) continue;
+            lums.Add(lum);
+            if (c.r >= 253 || c.g >= 253 || c.b >= 253) clipped++;
+
+            // Chroma IN LINEAR LIGHT, not on the sRGB bytes. (max-min)/max is invariant under a
+            // scale factor only in the space the scaling happens in; computed on sRGB values it
+            // falls whenever the picture gets brighter, because the encoding curve is concave.
+            // Measured on the bytes, a pure exposure change looked like a loss of saturation --
+            // which is exactly the question this number is supposed to answer, so it has to be
+            // free of it. Linearised, a rig that only changes exposure leaves it untouched and
+            // only a real desaturation moves it.
+            float lr = Srgb2Linear(r), lg = Srgb2Linear(g), lb = Srgb2Linear(bl);
+            float mx = Mathf.Max(lr, Mathf.Max(lg, lb)), mn = Mathf.Min(lr, Mathf.Min(lg, lb));
+            if (mx > 0.0001f) chroma += (mx - mn) / mx;      // saturation, a colour-pop proxy
+        }
+
+        lums.Sort();
+        double sum = 0.0;
+        for (int i = 0; i < lums.Count; i++) sum += lums[i];
+        float mean = (float)(sum / lums.Count);
+        // Michelson contrast of the model against the background it sits on.
+        float contrast = (mean + bgLum) > 0.0001f ? (mean - bgLum) / (mean + bgLum) : 0f;
+
+        Debug.Log(string.Format(
+            "WMV: lightcheck rig={0} ({1}) | mask {2} px | mean {3:F4} p05 {4:F4} p50 {5:F4} "
+            + "p95 {6:F4} max {7:F4} | clipped {8:F3} % | chroma {9:F4} | contrast {10:F4} "
+            + "|| old-threshold mask: {11} px mean {12:F4}",
+            rig,
+            rig == 0 ? "shipped" : "legacy",
+            lums.Count, mean,
+            Pct(lums, 0.05f), Pct(lums, 0.50f), Pct(lums, 0.95f), lums[lums.Count - 1],
+            100f * clipped / lums.Count, (float)(chroma / lums.Count), contrast,
+            threshCount, threshCount > 0 ? (float)(threshSum / threshCount) : 0f));
+    }
+
+    /// <summary>sRGB byte value (0..1) to linear light.</summary>
+    static float Srgb2Linear(float c)
+    {
+        return c <= 0.04045f ? c / 12.92f : Mathf.Pow((c + 0.055f) / 1.055f, 2.4f);
+    }
+
+    /// <summary>
+    /// What the cast shadows did: how much of the model they touch, how hard they darken it,
+    /// and where their centre of mass sits. The centroid line is DESCRIPTIVE, not a verdict.
+    ///
+    /// The full story is a cautionary one. The first shadow build had a vertically mirrored
+    /// map (the render-into-texture flip counted twice -- see WmvShadowRig), and every check
+    /// here let it through: coverage looked plausible, darkening looked plausible, and when
+    /// the centroid flagged "shadows sit ABOVE the model" on two of three models, that was
+    /// explained away as receiver geometry. Even the dumped difference images were misread as
+    /// sensible. What caught it was someone LOOKING AT THE VIEWPORT and saying the shadow
+    /// looked like a whole copy of the model stamped across itself -- which is precisely what
+    /// a mirrored map does. The lesson stands in both directions: -wmvLightDump plus the
+    /// criterion "with a high key, darkening belongs on UNDER-surfaces and the top of the back
+    /// must be clean" is what verified the fix, and no summary statistic here should ever be
+    /// trusted over that picture.
+    /// </summary>
+    void ReportShadow(string what, Color32[] withShadow, Color32[] without, bool[] mask,
+                      int w, int h)
+    {
+        int touched = 0, maskCount = 0;
+        double deltaSum = 0.0;
+        double ySum = 0.0, yShadowSum = 0.0;
+        for (int i = 0; i < withShadow.Length; i++)
+        {
+            if (!mask[i]) continue;
+            maskCount++;
+            int y = i / w;                              // ReadPixels rows run bottom-up
+            ySum += y;
+            float on = 0.2126f * withShadow[i].r + 0.7152f * withShadow[i].g
+                       + 0.0722f * withShadow[i].b;
+            float off = 0.2126f * without[i].r + 0.7152f * without[i].g
+                        + 0.0722f * without[i].b;
+            float delta = (off - on) / 255f;            // positive where the shadow darkened
+            if (delta > 1.5f / 255f)
+            {
+                touched++;
+                deltaSum += delta;
+                yShadowSum += y;
+            }
+        }
+        if (WmvModelBuilder.Debug_.LightDump)
+        {
+            DumpPng(withShadow, w, h, "wmv-lightcheck-" + what + "-on.png");
+            DumpPng(without, w, h, "wmv-lightcheck-" + what + "-off.png");
+            // The difference, amplified: white = where the shadow darkened the frame.
+            var diff = new Color32[withShadow.Length];
+            for (int i = 0; i < diff.Length; i++)
+            {
+                float on = 0.2126f * withShadow[i].r + 0.7152f * withShadow[i].g
+                           + 0.0722f * withShadow[i].b;
+                float off = 0.2126f * without[i].r + 0.7152f * without[i].g
+                            + 0.0722f * without[i].b;
+                byte v = (byte)Mathf.Clamp((off - on) * 8f, 0f, 255f);
+                diff[i] = new Color32(v, v, v, 255);
+            }
+            DumpPng(diff, w, h, "wmv-lightcheck-" + what + "-diff.png");
+        }
+
+        if (maskCount == 0) return;
+        if (touched == 0)
+        {
+            Debug.Log("WMV: lightcheck shadows [" + what + "]: touch 0.0 % of the model");
+            return;
+        }
+        float centroidDy = (float)(yShadowSum / touched - ySum / maskCount);
+        Debug.Log(string.Format(
+            "WMV: lightcheck shadows [{4}]: touch {0:P1} of the model | mean darkening {1:F4} "
+            + "over touched px | shadow centroid {2:F1} px {3} the model centroid",
+            touched / (float)maskCount, deltaSum / touched,
+            Mathf.Abs(centroidDy), centroidDy < 0f ? "below" : "above", what));
+    }
+
+    /// <summary>Write one readback frame as a PNG next to the player (-wmvLightDump).</summary>
+    void DumpPng(Color32[] px, int w, int h, string name)
+    {
+        try
+        {
+            var tex = new Texture2D(w, h, TextureFormat.RGBA32, false);
+            tex.SetPixels32(px);
+            tex.Apply(false);
+            string path = System.IO.Path.Combine(Application.dataPath, "../" + name);
+            System.IO.File.WriteAllBytes(path, ImageConversion.EncodeToPNG(tex));
+            Destroy(tex);
+            Debug.Log("WMV: lightcheck dump: " + path);
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogWarning("WMV: lightcheck dump failed: " + e.Message);
+        }
+    }
+
+    /// <summary>
+    /// How much light-to-dark range the rig itself puts on a model, with no texture in the way.
+    /// The ratio of the bright end to the dark end is the number that says whether the thing has
+    /// shadows: around 1.2 is a flat, evenly-lit figure; 1.8 upwards reads as modelled form.
+    /// </summary>
+    void ReportShading(int rig, Color32[] shot, bool[] mask, int covered)
+    {
+        var lums = new List<float>(covered);
+        for (int i = 0; i < shot.Length; i++)
+        {
+            if (!mask[i]) continue;
+            Color32 c = shot[i];
+            lums.Add(0.2126f * c.r / 255f + 0.7152f * c.g / 255f + 0.0722f * c.b / 255f);
+        }
+        if (lums.Count == 0) return;
+        lums.Sort();
+        float p05 = Pct(lums, 0.05f), p50 = Pct(lums, 0.50f), p95 = Pct(lums, 0.95f);
+        double sum = 0.0;
+        for (int i = 0; i < lums.Count; i++) sum += lums[i];
+        Debug.Log(string.Format(
+            "WMV: lightcheck rig={0} SHADING (flat albedo) | mean {1:F4} p05 {2:F4} p50 {3:F4} "
+            + "p95 {4:F4} min {5:F4} max {6:F4} | range p95/p05 {7:F2}x | full {8:F2}x",
+            rig, sum / lums.Count, p05, p50, p95, lums[0], lums[lums.Count - 1],
+            p05 > 0.0001f ? p95 / p05 : 0f,
+            lums[0] > 0.0001f ? lums[lums.Count - 1] / lums[0] : 0f));
+    }
+
+    static float Pct(List<float> sorted, float q)
+    {
+        int i = Mathf.Clamp(Mathf.RoundToInt((sorted.Count - 1) * q), 0, sorted.Count - 1);
+        return sorted[i];
     }
 
     /// <summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -159,6 +159,13 @@ public class WmvMain : MonoBehaviour
         cam.nearClipPlane = 0.01f;
         orbit = cam.gameObject.GetComponent<WmvOrbitCamera>() ?? cam.gameObject.AddComponent<WmvOrbitCamera>();
 
+        // A scene light and ambient, for the FALLBACK shaders only.
+        //
+        // The renderer's own shader ignores both -- it carries its own preview rig, because URP and
+        // HDRP do not feed the built-in light uniforms and a shader that read them would look
+        // different per pipeline. These exist so that a build which somehow has to fall back to a
+        // pipeline Lit shader (-wmvLitShader, or a player with no Resources) is not lit by nothing
+        // at all. Their angle matches the shader's key so the two do not disagree wildly.
         var lightGo = new GameObject("Directional Light");
         var light = lightGo.AddComponent<Light>();
         light.type = LightType.Directional;
@@ -419,6 +426,11 @@ public class WmvMain : MonoBehaviour
 
             orbit.Frame(built.Bounds);
 
+            // AFTER framing, not before: measuring the lighting on a model the camera has not
+            // pointed at yet reports a handful of stray pixels and calls it a reading.
+            if (WmvModelBuilder.Debug_.LightCheck)
+                ReportLighting();
+
             status.Set("Loaded " + job.Path);
             status.Set(string.Format("Vertices {0}  Triangles {1}  Submeshes {2}  Textures {3}",
                                      built.VertexCount, built.TriangleCount, built.SubmeshCount, job.Textures.Count));
@@ -532,6 +544,115 @@ public class WmvMain : MonoBehaviour
         }
 
         ReadAndApplySequence(sequenceIndex, external, animFileId == 0 ? "in-file" : "from .anim");
+    }
+
+    /// <summary>
+    /// Render the model offscreen and say what the lighting did to it.
+    ///
+    /// Lighting work is the one thing here that cannot be checked by reading a log: "readable",
+    /// "not blown out", "not crushed" are all statements about pixels. So this renders one frame
+    /// into a texture and measures it, which turns each of those into a number that a run either
+    /// meets or does not:
+    ///
+    ///   coverage   -- how much of the frame the model occupies (that it rendered at all)
+    ///   mean       -- overall brightness of the model against the background
+    ///   clipped    -- fraction of model pixels at full white in any channel. This is the one the
+    ///                 old rig failed: it peaked at 1.20, so pale surfaces facing the key light
+    ///                 came back as flat white with the painted detail gone.
+    ///   p05        -- the 5th-percentile luminance, i.e. how dark the darkest real parts are.
+    ///                 A shadow side that reads as a black silhouette shows up here.
+    ///
+    /// Diagnostics only, and it renders to its own texture -- nothing is written to disk and the
+    /// viewport is untouched.
+    /// </summary>
+    void ReportLighting()
+    {
+        var cam = Camera.main;
+        if (cam == null || current == null)
+            return;
+
+        const int W = 256, H = 256;
+        RenderTexture rt = RenderTexture.GetTemporary(W, H, 24, RenderTextureFormat.ARGB32,
+                                                      RenderTextureReadWrite.Default);
+        RenderTexture prevTarget = cam.targetTexture;
+        RenderTexture prevActive = RenderTexture.active;
+        Vector3 prevPos = cam.transform.position;
+        Quaternion prevRot = cam.transform.rotation;
+        Texture2D shot = null;
+        try
+        {
+            // Frame the model from a FIXED angle and distance for the measurement, then put the
+            // camera back. Reading whatever the orbit happened to be showing made the numbers
+            // wander between runs -- coverage moved by a fifth on repeats of the same build --
+            // and a measurement that disagrees with itself cannot say whether a change helped.
+            Bounds modelBounds = current.Bounds;
+            float radius = Mathf.Max(modelBounds.extents.magnitude, 0.001f);
+            Vector3 dir = new Vector3(0.45f, 0.35f, -1f).normalized;
+            cam.transform.position = modelBounds.center - dir * (radius * 2.6f);
+            cam.transform.rotation = Quaternion.LookRotation(dir, Vector3.up);
+
+            cam.targetTexture = rt;
+            cam.Render();
+            RenderTexture.active = rt;
+            shot = new Texture2D(W, H, TextureFormat.RGBA32, false);
+            shot.ReadPixels(new Rect(0, 0, W, H), 0, 0);
+            shot.Apply(false);
+
+            Color bg = cam.backgroundColor;
+            float bgLum = 0.2126f * bg.r + 0.7152f * bg.g + 0.0722f * bg.b;
+
+            var lums = new List<float>(W * H);
+            int clipped = 0;
+            // Mean over the WHOLE frame as well. The model-only figures below depend on a
+            // threshold to separate model from background, and a brighter model pulls previously
+            // excluded dark pixels above it -- which can drag the model-only mean DOWN while every
+            // pixel got brighter. This one has no threshold in it and cannot do that, so the two
+            // together say whether a change actually brightened anything.
+            float frameSum = 0f;
+            Color32[] px = shot.GetPixels32();
+            foreach (Color32 c in px)
+            {
+                float r = c.r / 255f, g = c.g / 255f, b = c.b / 255f;
+                float lum = 0.2126f * r + 0.7152f * g + 0.0722f * b;
+                frameSum += lum;
+                // Anything meaningfully brighter than the background is the model. The clear
+                // colour is flat, so this separates the two without needing a mask pass.
+                if (lum <= bgLum + 0.02f)
+                    continue;
+                lums.Add(lum);
+                if (c.r >= 253 || c.g >= 253 || c.b >= 253)
+                    clipped++;
+            }
+
+            if (lums.Count == 0)
+            {
+                Debug.Log("WMV: light check: nothing brighter than the background was drawn");
+                return;
+            }
+            lums.Sort();
+            float sum = 0f;
+            foreach (float l in lums) sum += l;
+            float p05 = lums[Mathf.Clamp(Mathf.RoundToInt(lums.Count * 0.05f), 0, lums.Count - 1)];
+            float p95 = lums[Mathf.Clamp(Mathf.RoundToInt(lums.Count * 0.95f), 0, lums.Count - 1)];
+            Debug.Log(string.Format(
+                "WMV: light check: coverage {0:P1} of frame | background {1:F3} | frame mean {7:F4} "
+                + "| model mean {2:F3} p05 {3:F3} p95 {4:F3} max {5:F3} | clipped {6:P2}",
+                lums.Count / (float)(W * H), bgLum, sum / lums.Count, p05, p95,
+                lums[lums.Count - 1], clipped / (float)lums.Count, frameSum / (W * H)));
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogWarning("WMV: light check could not render: " + e.Message);
+        }
+        finally
+        {
+            cam.targetTexture = prevTarget;
+            RenderTexture.active = prevActive;
+            cam.transform.position = prevPos;
+            cam.transform.rotation = prevRot;
+            RenderTexture.ReleaseTemporary(rt);
+            if (shot != null) Destroy(shot);
+        }
     }
 
     /// <summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -138,6 +138,10 @@ public static class WmvModelBuilder
         static bool flipV, forceOpaque, forceSolid, matColors, showHidden, ownShader;
         static bool noSkin, skinCheck, noAnim, animCheck, placeholder, overlay, litShader;
         static bool lightCheck;
+        static int rig;
+        static bool lightDump;
+        static float lightYaw = 30f;
+        static float lightPitch = 15f;
 
         static void Parse()
         {
@@ -158,6 +162,28 @@ public static class WmvModelBuilder
                 else if (a == "-wmvOwnShader") ownShader = true;   // kept: now the default
                 else if (a == "-wmvLitShader") litShader = true;
                 else if (a == "-wmvLightCheck") lightCheck = true;
+                else if (a == "-wmvLightDump") lightDump = true;
+                else if (a.StartsWith("-wmvLightYaw="))
+                {
+                    float y;
+                    if (float.TryParse(a.Substring("-wmvLightYaw=".Length),
+                                       System.Globalization.NumberStyles.Float,
+                                       System.Globalization.CultureInfo.InvariantCulture, out y))
+                        lightYaw = y;
+                }
+                else if (a.StartsWith("-wmvLightPitch="))
+                {
+                    float pv;
+                    if (float.TryParse(a.Substring("-wmvLightPitch=".Length),
+                                       System.Globalization.NumberStyles.Float,
+                                       System.Globalization.CultureInfo.InvariantCulture, out pv))
+                        lightPitch = pv;
+                }
+                else if (a.StartsWith("-wmvRig="))
+                {
+                    int r;
+                    if (int.TryParse(a.Substring("-wmvRig=".Length), out r)) rig = r;
+                }
                 else if (a == "-wmvNoSkin") noSkin = true;
                 else if (a == "-wmvSkinCheck") skinCheck = true;
                 else if (a == "-wmvNoAnim") noAnim = true;
@@ -195,6 +221,36 @@ public static class WmvModelBuilder
         /// parts are. "Looks right" is not checkable from a log; those numbers are.
         /// </summary>
         public static bool LightCheck { get { Parse(); return lightCheck; } }
+
+        /// <summary>
+        /// Which preview light rig the viewport draws with (-wmvRig=N), for a visual A/B:
+        /// 0 shipped, 1 legacy (what WMV drew with before this work). Defaults to 0.
+        /// The numeric comparison is -wmvLightCheck, which measures both in one run.
+        /// </summary>
+        public static int Rig { get { Parse(); return rig; } }
+
+        /// <summary>
+        /// Save the light check's frames as PNGs next to the player (-wmvLightDump), so a
+        /// headless run can be inspected by eye. Some lighting questions -- WHERE a shadow
+        /// falls, whether darkening is a shadow or acne speckle -- are spatial, and no summary
+        /// statistic answers them faster than the picture does.
+        /// </summary>
+        public static bool LightDump { get { Parse(); return lightDump; } }
+
+        /// <summary>
+        /// The light check camera's yaw (-wmvLightYaw=N, default 30). Models face where their
+        /// author pointed them, and a hood's shadow on a face can only be inspected from the
+        /// front -- the default three-quarter view happens to be this model's back.
+        /// </summary>
+        public static float LightYaw { get { Parse(); return lightYaw; } }
+
+        /// <summary>
+        /// The light check camera's pitch (-wmvLightPitch=N, default 15; negative looks UP from
+        /// below). Pitch is the axis that separates a camera-relative light from a
+        /// world-anchored one -- under yaw the two are indistinguishable when the light is
+        /// near-vertical -- so the world-anchor work is verified from down here.
+        /// </summary>
+        public static float LightPitch { get { Parse(); return lightPitch; } }
         public static bool NoSkin { get { Parse(); return noSkin; } }
         public static bool SkinCheck { get { Parse(); return skinCheck; } }
         public static bool NoAnim { get { Parse(); return noAnim; } }
@@ -1155,6 +1211,10 @@ public static class WmvModelBuilder
         int queue = (int)UnityEngine.Rendering.RenderQueue.Geometry;
         string renderType = "Opaque";
         bool alphaTest = false, opaqueAlpha = true;
+        // Additive batches are emissive: the preview rig must not dim them (see _Emissive in
+        // WmvOpaque.shader). Alpha-blended batches are ordinary lit surfaces seen through
+        // transparency and stay lit.
+        bool emissive = false;
 
         switch (mode)
         {
@@ -1188,6 +1248,7 @@ public static class WmvModelBuilder
                 opaqueAlpha = false;
                 queue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
                 renderType = "Transparent";
+                emissive = true;
                 described = "additive";
                 break;
 
@@ -1197,6 +1258,7 @@ public static class WmvModelBuilder
                 opaqueAlpha = false;
                 queue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
                 renderType = "Transparent";
+                emissive = true;
                 described = "additive (alpha-weighted)";
                 break;
 
@@ -1240,6 +1302,7 @@ public static class WmvModelBuilder
         if (m.HasProperty("_AlphaClip")) m.SetFloat("_AlphaClip", alphaTest ? 1f : 0f);
         if (m.HasProperty("_SrcBlend")) m.SetInt("_SrcBlend", (int)src);
         if (m.HasProperty("_DstBlend")) m.SetInt("_DstBlend", (int)dst);
+        if (m.HasProperty("_Emissive")) m.SetFloat("_Emissive", emissive ? 1f : 0f);
         if (m.HasProperty("_ZWrite")) m.SetInt("_ZWrite", zwrite ? 1 : 0);
         if (m.HasProperty("_OpaqueAlpha")) m.SetFloat("_OpaqueAlpha", opaqueAlpha ? 1f : 0f);
         if (m.HasProperty("_Cutoff")) m.SetFloat("_Cutoff", cutoff);

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -136,7 +136,8 @@ public static class WmvModelBuilder
     {
         static bool parsed;
         static bool flipV, forceOpaque, forceSolid, matColors, showHidden, ownShader;
-        static bool noSkin, skinCheck, noAnim, animCheck, placeholder, overlay;
+        static bool noSkin, skinCheck, noAnim, animCheck, placeholder, overlay, litShader;
+        static bool lightCheck;
 
         static void Parse()
         {
@@ -154,7 +155,9 @@ public static class WmvModelBuilder
                 else if (a == "-wmvForceSolid") forceSolid = true;
                 else if (a == "-wmvMatColors") matColors = true;
                 else if (a == "-wmvShowHidden") showHidden = true;
-                else if (a == "-wmvOwnShader") ownShader = true;
+                else if (a == "-wmvOwnShader") ownShader = true;   // kept: now the default
+                else if (a == "-wmvLitShader") litShader = true;
+                else if (a == "-wmvLightCheck") lightCheck = true;
                 else if (a == "-wmvNoSkin") noSkin = true;
                 else if (a == "-wmvSkinCheck") skinCheck = true;
                 else if (a == "-wmvNoAnim") noAnim = true;
@@ -177,6 +180,21 @@ public static class WmvModelBuilder
         public static bool MatColors { get { Parse(); return matColors; } }
         public static bool ShowHidden { get { Parse(); return showHidden; } }
         public static bool OwnShader { get { Parse(); return ownShader; } }
+
+        /// <summary>
+        /// Use the pipeline's Lit shader instead of the viewer's own (-wmvLitShader).
+        ///
+        /// For comparing against physically-based shading, and nothing else: it cannot run the M2
+        /// combiners, so every material that needs one renders as its base texture alone.
+        /// </summary>
+        public static bool LitShader { get { Parse(); return litShader; } }
+
+        /// <summary>
+        /// Render the loaded model offscreen and report what the lighting actually did
+        /// (-wmvLightCheck): how bright it came out, how much of it clipped, how dark its darkest
+        /// parts are. "Looks right" is not checkable from a log; those numbers are.
+        /// </summary>
+        public static bool LightCheck { get { Parse(); return lightCheck; } }
         public static bool NoSkin { get { Parse(); return noSkin; } }
         public static bool SkinCheck { get { Parse(); return skinCheck; } }
         public static bool NoAnim { get { Parse(); return noAnim; } }
@@ -1553,16 +1571,37 @@ public static class WmvModelBuilder
         // decides which names may even be tried. null here means the built-in pipeline.
         bool builtIn = UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline == null;
 
-        // The pipeline's Lit shaders cannot run the M2 combiner, so -wmvOwnShader exists to make
-        // the renderer's own shader win the search and show what the combiner does.
-        if (Debug_.OwnShader &&
+        // THE VIEWER'S OWN SHADER IS THE FIRST CHOICE, not the last resort.
+        //
+        // It used to be the bottom rung, tried only once every pipeline Lit shader had been
+        // stripped out of the build -- which is what happens in practice, so this is the shader
+        // that has been drawing every model all along. That made two things accidental that
+        // should not be:
+        //
+        //   THE M2 COMBINER. A pipeline Lit shader cannot run it. Every combiner case this
+        //   renderer implements -- chicken2's pixel shader 12, the environment sheen on metal,
+        //   the masked modulates -- worked only because URP/Lit happened to be absent. A build
+        //   that kept it would have rendered those materials plainly and silently.
+        //
+        //   THE LOOK. Lit means physically-based: specular response, tonemapping, scene lights.
+        //   WoW's textures are hand-painted with their shading already in them, so PBR relights
+        //   what is effectively an already-lit painting, and the result is shiny where it should
+        //   be matte and dark where the artist put mid-tones. It also made the viewer's
+        //   appearance depend on what a given build stripped.
+        //
+        // So the choice is now deliberate and identical everywhere. The Lit and Unlit rungs
+        // below are kept as a real fallback for a build where Resources somehow did not ship,
+        // and -wmvLitShader asks for the pipeline's Lit shader explicitly for comparison.
+        if (!Debug_.LitShader &&
             Accept(Resources.Load<Shader>(OpaqueShaderResource),
-                   "using the renderer's own '" + OpaqueShaderResource + "' shader (-wmvOwnShader)", log))
+                   "using the renderer's own '" + OpaqueShaderResource + "' shader (M2 combiners "
+                   + "and the preview light rig; pass -wmvLitShader for the pipeline's Lit shader)",
+                   log))
             return cachedShader;
 
-        // Best case: a real lit shader for the pipeline in use. Shader.Find only sees what
-        // survived build stripping, and a runtime-built material references nothing at build
-        // time, so any of these can come back null in a player that looks fine in the editor.
+        // Fallback only, or -wmvLitShader. Shader.Find only sees what survived build stripping,
+        // and a runtime-built material references nothing at build time, so any of these can come
+        // back null in a player that looks fine in the editor.
         string[] lit = builtIn
             ? new[] { "Standard", "Legacy Shaders/Diffuse", "Mobile/Diffuse" }
             : new[] { "Universal Render Pipeline/Lit", "Universal Render Pipeline/Simple Lit",
@@ -1589,10 +1628,7 @@ public static class WmvModelBuilder
         // stripped away like the named lookups above. Unlit, but opaque, textured and with its
         // render state exposed as real properties -- which is what actually matters here.
         if (Accept(Resources.Load<Shader>(OpaqueShaderResource),
-                   "no pipeline shader survived build stripping -- using the renderer's own " +
-                   "'" + OpaqueShaderResource + "' shader. Lighting is a fixed viewer key light " +
-                   "rather than the scene's; add a Lit shader to Project Settings > Graphics > " +
-                   "Always Included Shaders and rebuild the player for full lighting.", log))
+                   "falling back to the renderer's own '" + OpaqueShaderResource + "' shader", log))
             return cachedShader;
 
         // Unlit but still opaque: flat lighting, correct solidity.

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvShadowRig.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvShadowRig.cs
@@ -1,0 +1,304 @@
+// WmvShadowRig.cs
+//
+// CAST SHADOWS for the preview light rig: the model occluding its own key light. A saddle rope
+// falling across a mount's body, a horn across a face -- effects the rig's normal-based terms
+// cannot produce, because they only know which way a surface faces, not what stands between it
+// and the light.
+//
+// The machinery is one orthographic camera parked at the key light's position, rendering the
+// model's depth into a texture every frame. WmvOpaque.shader projects each fragment into that
+// map and compares depths: something nearer to the light than the fragment means the key is
+// blocked there (see WmvShadowFactor). The pipeline's own shadow system is deliberately not
+// used -- this renderer's shader has no LightMode tags and carries its own lighting, so it
+// would never receive engine shadow data; a map it renders itself works identically under the
+// built-in pipeline and URP, which is the same portability bargain the rest of the shader makes.
+//
+// Two properties fall out of the design and are worth naming:
+//
+//   * THE SHADOW FOLLOWS THE KEY, AND THE KEY IS ANCHORED TO THE WORLD VERTICAL. The rig
+//     blends the camera-relative key direction toward world-up (WorldAnchor) and publishes the
+//     result as _WmvKeyDirWorld each frame -- the one vector that feeds the shading, this
+//     shadow camera and the contact march, so none of them can disagree. The anchor is what
+//     the reference viewers measurably do (frame analysis of preview footage):
+//     orbiting never flips a model's lit side there, and a camera under the model finds the
+//     belly still dark, which a fully camera-relative key gets wrong.
+//
+//   * THE DEPTH PASS IS THE ORDINARY RENDER. The shadow camera draws the model with its normal
+//     materials and simply keeps the depth buffer. That means alpha-keyed batches (hair cards,
+//     fur flaps) clip in the shadow pass exactly as they clip on screen, so they cast shaped
+//     shadows rather than solid slabs -- and blended or additive batches, which write no depth,
+//     cast nothing, which is right for glows.
+//
+// Everything is gated by the _WmvShadowValid global, which unset reads 0: a player where this
+// component never ran renders exactly as before.
+
+using UnityEngine;
+
+public class WmvShadowRig : MonoBehaviour
+{
+    /// <summary>
+    /// The key light's direction in VIEW space, before the world anchor: x right, y up, z
+    /// toward the viewer. MUST match KEY_DIR in WmvOpaque.shader -- the shader falls back to
+    /// its copy in a player where this rig never ran, and if the two drift the fallback stops
+    /// matching the real thing. With WorldAnchor at 1.0 this vector only decides that fallback:
+    /// the anchored direction is world-up regardless of it.
+    /// </summary>
+    public static readonly Vector3 KeyDirView = new Vector3(0.081f, 0.858f, 0.507f);
+
+    /// <summary>The sky fill, same handling. MUST match FILL_DIR in WmvOpaque.shader.</summary>
+    public static readonly Vector3 FillDirView = new Vector3(0.059f, 0.998f, 0.032f);
+
+    /// <summary>
+    /// How much of the light direction is pinned to the world's vertical rather than the
+    /// camera: 0 is the old fully camera-relative behaviour, 1 is a light pointing straight
+    /// down from the world's sky regardless of the camera. Shipped at 1.0: the key is the
+    /// world's vertical, full stop, so neither orbiting nor pitching moves a model's lit side,
+    /// and the view-space tilt in KeyDirView is inert except in the shader's fallback. (Settled
+    /// by eye on a live tuning panel that has since been removed; 0.7 was the earlier value.)
+    /// </summary>
+    public static readonly float WorldAnchor = 1.0f;
+
+    // 4096 over a bounds-tight orthographic window puts a texel around 2.5 mm on a mount and
+    // under 1 mm on a humanoid. Resolution is not cosmetic here: the depth and normal biases
+    // scale with the texel, so doubling the map HALVES the distance below which an occluder
+    // casts nothing -- the difference between a hood shadow that reaches the brow line and one
+    // that stops a centimetre short of it.
+    const int MapSize = 4096;
+    // The view-depth buffer for the contact march. Screen-ish resolution is enough: the march
+    // asks "is a surface in front of this ray", not "where exactly is its edge".
+    const int ViewDepthSize = 2048;
+    // The window is fitted to the model bounds at load; animation moves limbs outside the rest
+    // pose, so give it margin rather than chase the pose every frame.
+    const float Padding = 1.4f;
+
+    Camera shadowCam;
+    RenderTexture map;
+    Camera depthCam;
+    RenderTexture viewDepth;
+    Bounds bounds;
+    bool hasBounds;
+
+    /// <summary>A model was (re)built: fit the shadow window around it.</summary>
+    public void SetBounds(Bounds b)
+    {
+        bounds = b;
+        hasBounds = true;
+    }
+
+    void EnsureResources()
+    {
+        if (shadowCam == null)
+        {
+            var go = new GameObject("WmvShadowCamera");
+            go.transform.SetParent(transform, false);
+            shadowCam = go.AddComponent<Camera>();
+            shadowCam.enabled = false;               // rendered by hand, below
+            shadowCam.orthographic = true;
+            shadowCam.clearFlags = CameraClearFlags.SolidColor;
+            shadowCam.backgroundColor = Color.black; // irrelevant: only depth is kept
+            shadowCam.allowHDR = false;
+            shadowCam.allowMSAA = false;
+            shadowCam.aspect = 1f;
+        }
+        if (map == null)
+        {
+            // A depth-format target IS the shadow map: the colour result is discarded and the
+            // depth buffer is sampled directly (sampler2D_float in the shader).
+            map = new RenderTexture(MapSize, MapSize, 24, RenderTextureFormat.Depth)
+            {
+                name = "WmvShadowMap",
+                filterMode = FilterMode.Point,
+                wrapMode = TextureWrapMode.Clamp,
+            };
+        }
+        if (depthCam == null)
+        {
+            // The contact march's eyes: the same scene from the VIEWER's pose, depth only. A
+            // second camera rather than the pipeline's depth texture because the pipeline is
+            // not guaranteed to make one (URP's is a project-asset setting this repo does not
+            // control), and this renderer already lives by rendering its own.
+            var go = new GameObject("WmvViewDepthCamera");
+            go.transform.SetParent(transform, false);
+            depthCam = go.AddComponent<Camera>();
+            depthCam.enabled = false;
+            depthCam.clearFlags = CameraClearFlags.SolidColor;
+            depthCam.backgroundColor = Color.black;
+            depthCam.allowHDR = false;
+            depthCam.allowMSAA = false;
+        }
+        if (viewDepth == null)
+        {
+            viewDepth = new RenderTexture(ViewDepthSize, ViewDepthSize, 24,
+                                          RenderTextureFormat.Depth)
+            {
+                name = "WmvViewDepth",
+                filterMode = FilterMode.Point,
+                wrapMode = TextureWrapMode.Clamp,
+            };
+        }
+    }
+
+    void LateUpdate()
+    {
+        // After every Update (the orbit camera moves in Update), before rendering: the map is
+        // always in step with this frame's camera.
+        Camera view = Camera.main;
+        if (view != null)
+            RenderFor(view);
+    }
+
+    /// <summary>
+    /// Render the shadow map for the key light as seen from this camera, and publish the
+    /// globals the shader samples with. Public so the light check can render the map for ITS
+    /// camera -- a deterministic pose -- instead of measuring under whatever orientation the
+    /// viewport happened to have.
+    /// </summary>
+    public void RenderFor(Camera view)
+    {
+        if (!hasBounds)
+        {
+            Shader.SetGlobalFloat("_WmvShadowValid", 0f);
+            Shader.SetGlobalFloat("_WmvContactValid", 0f);
+            return;
+        }
+        EnsureResources();
+
+        // The key direction: view space -> world space through the viewer camera's rotation,
+        // then blended toward the world's own up. The anchor is why preview lighting holds
+        // still while the model is orbited, and why looking up from below does not drag the
+        // light under the model.
+        float anchor = WorldAnchor;
+        Vector3 dirWorld = AnchoredDir(view, KeyDirView, anchor);
+        Vector3 fillWorld = AnchoredDir(view, FillDirView, anchor);
+
+        // A tight orthographic window around the model, looking back down the light direction.
+        // Tight matters twice: texels cover the model rather than empty space, and the depth
+        // range stays short, which is what keeps a fixed depth bias small.
+        float r = Mathf.Max(bounds.extents.magnitude, 0.01f) * Padding;
+        float dist = 2f * r;
+        shadowCam.transform.position = bounds.center + dirWorld * dist;
+        shadowCam.transform.rotation = Quaternion.LookRotation(-dirWorld);
+        shadowCam.orthographicSize = r;
+        shadowCam.nearClipPlane = dist - r;
+        shadowCam.farClipPlane = dist + r;
+        shadowCam.cullingMask = view.cullingMask;
+
+        // The depth pass draws the model with its NORMAL materials, whose shader samples
+        // _WmvShadowMap -- the very texture this render writes. Reading and writing one
+        // resource in the same pass is a hazard D3D11 resolves by silently unbinding the read,
+        // which happens to give the right answer but spams runtime warnings and is undefined
+        // by contract. So the shadow path is switched off for the duration: the shader
+        // early-outs on _WmvShadowValid and samples nothing.
+        Shader.SetGlobalFloat("_WmvShadowValid", 0f);
+        Shader.SetGlobalTexture("_WmvShadowMap", Texture2D.whiteTexture);
+        shadowCam.targetTexture = map;
+        shadowCam.Render();
+        shadowCam.targetTexture = null;
+
+        // World -> the light's clip space. renderIntoTexture must be FALSE here, and the
+        // reason is subtle enough to have shipped wrong once: on D3D the camera rasterises
+        // into the texture with a y-FLIPPED projection (rows land top-down), and a texture
+        // sample's v=0 also addresses the top row -- the two flips cancel. Building the
+        // sampling matrix WITH the flip (true) re-introduces it, and every lookup lands on the
+        // vertically mirrored texel: the whole model's silhouette stamped upside-down across
+        // itself, shadows on the top of the back where a high key can never put them. The z
+        // row is identical either way, so the reversed-Z depth comparison is unaffected.
+        Matrix4x4 gpuProj = GL.GetGPUProjectionMatrix(shadowCam.projectionMatrix, false);
+        Shader.SetGlobalMatrix("_WmvShadowMatrix", gpuProj * shadowCam.worldToCameraMatrix);
+        Shader.SetGlobalTexture("_WmvShadowMap", map);
+        Shader.SetGlobalFloat("_WmvShadowTexel", 1f / MapSize);
+
+        // Both biases derive from the map's footprint instead of being tuned by hand: the
+        // normal offset is one texel of world size (enough that a surface never samples its
+        // own depth), and the depth bias is one texel of the [0,1] depth range. The bias IS
+        // the map's contact blind zone, so it is kept as small as stability allows and the
+        // screen-space march below covers what remains.
+        float texelWorld = 2f * r / MapSize;
+        Shader.SetGlobalFloat("_WmvShadowNormalBias", 1.0f * texelWorld);
+        Shader.SetGlobalFloat("_WmvShadowDepthBias", 1.0f / MapSize);
+        Shader.SetGlobalFloat("_WmvShadowValid", 1f);
+
+        // ---- the view-depth buffer, for the contact march --------------------------------
+        //
+        // The viewer camera's pose, but near/far PINCHED around the model: hardware depth
+        // spends its precision near the near plane, and a preview camera's own far plane is
+        // wildly generous. With the range tight the [0,1] depth units the march compares in
+        // correspond to a roughly constant world thickness across the model.
+        Vector3 toCenter = bounds.center - view.transform.position;
+        float viewDist = toCenter.magnitude;
+        float modelR = Mathf.Max(bounds.extents.magnitude, 0.01f) * Padding;
+        depthCam.transform.position = view.transform.position;
+        depthCam.transform.rotation = view.transform.rotation;
+        depthCam.orthographic = false;
+        depthCam.fieldOfView = view.fieldOfView;
+        depthCam.aspect = view.aspect;
+        depthCam.nearClipPlane = Mathf.Max(0.01f, viewDist - modelR);
+        depthCam.farClipPlane = viewDist + modelR;
+        depthCam.cullingMask = view.cullingMask;
+
+        Shader.SetGlobalFloat("_WmvContactValid", 0f);   // same read-write hazard as the map
+        Shader.SetGlobalTexture("_WmvViewDepth", Texture2D.whiteTexture);
+        depthCam.targetTexture = viewDepth;
+        depthCam.Render();
+        depthCam.targetTexture = null;
+
+        Matrix4x4 viewProj = GL.GetGPUProjectionMatrix(depthCam.projectionMatrix, false)
+                             * depthCam.worldToCameraMatrix;
+        Shader.SetGlobalMatrix("_WmvViewDepthMatrix", viewProj);
+        Shader.SetGlobalTexture("_WmvViewDepth", viewDepth);
+        Shader.SetGlobalVector("_WmvKeyDirWorld",
+                               new Vector4(dirWorld.x, dirWorld.y, dirWorld.z, 0f));
+        Shader.SetGlobalVector("_WmvFillDirWorld",
+                               new Vector4(fillWorld.x, fillWorld.y, fillWorld.z, 0f));
+        Shader.SetGlobalFloat("_WmvModelRadius", modelR);
+        // Self-hit guard and thickness, in the pinched camera's [0,1] depth units (the range
+        // spans ~2 model radii of world, so world-relative values divide by that).
+        //
+        // THICKNESS IS THE KNIFE-EDGE OF THIS TECHNIQUE. A first version assumed occluders
+        // 0.20 R thick, and the result was a faint even wash over every large surface: any
+        // geometry anywhere within a fifth of the model IN FRONT of the ray -- the far side of
+        // a fold, the silhouette of the cloak -- counted as touching. Contact shadows are about
+        // the near field, so the assumed thickness matches the march range itself: an occluder
+        // matters only if the ray passes within touching distance BEHIND it. The guard against
+        // a fragment finding its own surface is ~1 % of the model, paired with the ray's
+        // starting push off the surface in the shader.
+        float depthRange = 2f * modelR;
+        Shader.SetGlobalFloat("_WmvContactEps", 0.010f * modelR / depthRange);
+        Shader.SetGlobalFloat("_WmvContactThick", 0.08f * modelR / depthRange);
+        Shader.SetGlobalFloat("_WmvContactValid", 1f);
+    }
+
+    /// <summary>
+    /// A view-space light direction, made world: rotate it out through the camera, then pull
+    /// it toward world-up by the anchor. The guard covers the one degenerate pose -- a camera
+    /// pitched so far that the rotated direction opposes up and the blend cancels out.
+    /// </summary>
+    static Vector3 AnchoredDir(Camera view, Vector3 dirView, float anchor)
+    {
+        Vector3 w = view.transform.rotation * dirView;
+        Vector3 blended = w * (1f - anchor) + Vector3.up * anchor;
+        if (blended.sqrMagnitude < 1e-6f)
+            return Vector3.up;
+        return blended.normalized;
+    }
+
+    void OnDisable()
+    {
+        Shader.SetGlobalFloat("_WmvShadowValid", 0f);
+        Shader.SetGlobalFloat("_WmvContactValid", 0f);
+        Shader.SetGlobalVector("_WmvKeyDirWorld", new Vector4(0f, 0f, 0f, 0f));
+        Shader.SetGlobalVector("_WmvFillDirWorld", new Vector4(0f, 0f, 0f, 0f));
+        if (map != null)
+        {
+            map.Release();
+            Destroy(map);
+            map = null;
+        }
+        if (viewDepth != null)
+        {
+            viewDepth.Release();
+            Destroy(viewDepth);
+            viewDepth = null;
+        }
+    }
+}

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -44,49 +44,229 @@ dark, flat surfaces pick up specular they were never meant to have, and the hand
 of the art is exactly what gets lost. A model viewer wants the texture legible from a fixed angle,
 which is a different job from simulating a room.
 
-**The rig.** Three terms, in `Assets/Resources/WmvOpaque.shader`:
+**The key is the world's vertical.** `KEY_DIR` and `FILL_DIR` are view-space directions, but
+`WmvShadowRig` blends them toward world-up by `WorldAnchor` every frame and publishes the result as
+the one world vector that feeds the shading, the shadow map and the contact march. `WorldAnchor`
+ships at 1.0, so the published direction is straight down from the sky whatever the camera does,
+and the view-space tilt in `KEY_DIR` only decides the shader's fallback (below). An anchored key
+is what the reference viewers measurably do:
+frame analysis of a reference viewer's preview footage shows that orbiting a model there never flips
+its lit side (opposite profiles at 3:40 and 4:01 shade identically) and that a camera looking up
+from below finds the belly still dark (4:11—4:17) — which falsifies a fully camera-relative key,
+the previous behaviour here, since that swings under with the camera and lights the underside.
+Verified on ratmount2 from pitch −60 with the shipped constants: masked mean 0.189 against 0.326
+from the normal angle, the belly dark as it should be; `-wmvLightPitch=N` exists because pitch is
+the one axis that separates the two schemes (a vertical light is yaw-invariant under both, and the
+alpaca measures 0.219—0.239 across four yaws). The shader keeps a pure view-space fallback for a
+player where the rig never ran.
 
-| term | what it does |
-|---|---|
-| ambient `0.62` | floor: the darkest any surface gets |
-| key `0.62 * ndl` | upper front-left three-quarter angle |
-| fill `0.16 * ndl_fill * (1-key)` | low and opposite, keeps the shadow side in shape |
-| rim `0.16 * rim^2 * (1-key)` | edge separation against the dark background |
-| highlight `0.16 * ndh^26 * texLuma^2` | a narrow preview glint, weighted by how bright the texture already is |
+A lesson from the first version of this rig, before the anchor: it put the key at 53 degrees of
+elevation in world space with a high floor, and almost every surface on a standing humanoid is
+vertical, so they all caught it at the same shallow angle and the figure came out brighter but
+completely flat, with a lit-to-shadow ratio of **1.06x** where even the old rig managed 1.55x.
+The shipped key is fully vertical, which is the same geometry, and it reads as modelled anyway
+because the range now comes from the floor-to-key ratio and the cast shadows rather than from the
+key's angle: measured light-only ranges are 1.7—2.9x on the nine test models.
 
-**A SHOULDER, NOT A CEILING.** The light deliberately sums past 1.0 (to 1.24), and the top end is
-rolled off instead of clamped: below a knee of `0.72` nothing is touched — that is where the painted
-colour lives — and above it the curve bends over and only approaches 1.0 asymptotically. The
-absolute maximum any pixel can reach is **0.975**.
+**The rig.** Every number is a `#define` at the top of `Assets/Resources/WmvOpaque.shader`, in one
+block, so a tuning pass edits constants and nothing else:
 
-That replaced a rig which kept everything at or below 1.0 by never letting the light sum past it.
-It did prevent blow-out, but by guaranteeing nothing could ever be brighter than its own texture,
-so white fur read grey: a white texture at 70% light *is* grey. Rolling off the top instead lets a
-white read white (0.96 at full key) while still never reaching 1.0. The roll-off is per channel, so
-a saturated red lifts its red without dragging the other two up with it and the colour stays the
-colour.
+| term | value | what it does |
+|---|---|---|
+| `KEY_DIR` | `(0.081, 0.858, 0.507)` | view space, 9 degrees round and 59 up: the fallback direction only, since the anchor is 1.0 |
+| `FILL_DIR` | `(0.059, 0.998, 0.032)` | very nearly straight up: a sky fill on the shadow side |
+| `KEY_FLOOR` | `0.265` | floor: the darkest any surface gets |
+| `KEY_GAIN` | `1.644 * ndl` | key |
+| `FILL_GAIN` | `1.5 * wrap * (1-key)` | sky-hemisphere fill (see below) |
+| `RIM_GAIN` | `0.0` | off |
+| `SPEC_GAIN` / `SPEC_TIGHT` | `3.0` / `49.2` | a tight preview highlight |
+| `KNEE` | `0.298` | where the top end starts rolling off |
+| `CEIL` | `1.0` | what the roll-off approaches |
+| `SHADOW_STRENGTH` / `SHADOW_SOFT` | `1.0` / `4.0` | the map's key shadow, full strength, 4-texel blur |
+| `CONTACT_STRENGTH` / `CONTACT_RANGE` | `1.0` / `0.25` | near-field occlusion, full strength, a quarter-radius reach |
+| `WorldAnchor` (in `WmvShadowRig`) | `1.0` | the key is world-vertical |
 
-**The highlight is weighted by the texture, not by a material flag.** Nothing in an M2 says "this
-is metal", but the art already encodes it: gold trim, gems and polished metal are painted bright,
-leather and fur are not. Weighting a narrow glint by the texture's own luminance therefore lands it
-on the buckles and the gems and leaves the hide alone, with no specular map and no pretence of being
-physically based.
+**These values were settled by eye, on a live slider panel that has since been removed, and they
+choose form over parity.** A footage-calibrated set preceded them (floor 0.85, key 0.46, shadows
+0.20 and 0.30): measured over a background-free mask it matched a reference viewer's preview of
+the same alpaca to three decimals on the masked mean, and on screen it read as lighting that had
+not been switched on. The shipped set is the opposite bargain — a low floor under a strong key,
+shadows at full strength — and against the same footage it is still close: alpaca mean 0.234
+against 0.257, and nearer on the tails than the calibrated set ever got (p05 0.080 against 0.089,
+p95 0.482 against 0.507; the held-out white rat 0.376 against 0.402, p05 0.114 against 0.118). Two
+pieces of the recipe are measured rather than chosen: the anchored key above, and the FILL AS A
+WRAP TERM — `0.5 + 0.5 * dot(n, up)`, a sky hemisphere rather than a second sun, because a
+one-sided fill is zero on vertical surfaces and bellies, which under a vertical key are exactly
+the surfaces nothing else lights.
 
-**Checking it.** `-wmvLightCheck` renders one frame offscreen and reports coverage, background and
-model luminance, the 5th/95th percentiles, the fraction of clipped pixels, and the mean over the
-whole frame. "Readable" and "not blown out" are claims about pixels, so they are measured rather
-than asserted; nothing is written to disk and the viewport is not disturbed. It renders from a
-FIXED camera and is normally run with `-wmvNoAnim`, because a measurement taken from wherever the
-orbit happened to be, of whatever pose the animation happened to be in, disagrees with itself
-between runs.
+**Additive batches are emissive and skip the rig** (shipped rig only; the legacy rig stays a
+record of what drew before). An additive pass is light the surface emits, and multiplying emitted
+light by received-light maths is wrong in principle: with the floor at 0.265, a lantern facing
+away from the key would be drawn at about a quarter of its authored intensity. Note the gate:
+`_Emissive` must
+be a shader PROPERTY, not just a uniform, because the builder's SetFloat is guarded by
+`Material.HasProperty` -- a first version declared only the uniform and the bypass never ran.
 
-**Read the frame mean, not just the model mean.** The model-only figures separate model from
-background with a brightness threshold, and that makes them treacherous for before/after work: a
-brighter model pushes more of its own dark pixels above the threshold, those pixels join the
-sample, and the model-only average can FALL while every pixel got brighter. That is not
-hypothetical — tuning this rig showed two models apparently darkening by a third when the
-threshold-free frame mean showed chicken2 up 14%. The frame mean has no threshold in it and cannot
-do that.
+What the numbers encode: a low ambient floor (0.265) under a strong vertical key (1.644), a
+lit-to-unlit ratio of 7.2x before the roll-off, with the wrap fill (1.5) keeping vertical surfaces
+and undersides readable. `KNEE` at 0.298 puts most of the tonal range inside the roll-off, which
+shapes it toward `CEIL` at exactly 1.0 without arriving, so whites read as white; measured
+light-only shading ranges on the nine test models are 1.7—2.9x (the footage-calibrated set gave
+1.2—1.3x), full renders 3.5—5.0x, and clipping is 0.000 % on every opaque model (the only
+non-zero figures are additive pile-ups: valkier 0.14 %, the alpaca's lantern at most 0.2 %). The
+cast shadows are at full strength (map 1.0, contact 1.0): an occluded key contributes nothing, and
+the half-floor rule below is what keeps a shadowed strap-line readable rather than black.
+
+`RIM_GAIN` is zero, so the rim term contributes nothing; it stays in the shader as the one knob
+not yet needed. The highlight is on (gain 3.0, tightness 49), a small tight catch-light that the
+map shadow removes along with the key.
+
+### Cast shadows
+
+The model occludes its own key light: a rein across the mount's body, a horn across a face. The
+rig's dot-product terms cannot produce that — they know which way a surface faces, not what stands
+between it and the light — so `WmvShadowRig` renders a depth map from the key's point of view every
+frame (one orthographic camera, fitted to the model bounds, 4096 px) and `WmvShadowFactor` in the
+shader compares each fragment against it with a 3x3 PCF kernel. `SHADOW_STRENGTH` says how much of
+the key an occluder removes and `SHADOW_SOFT` blurs the edge; both are in the constants block.
+
+Design points worth knowing:
+
+- **The map attenuates the key only; the contact march also takes the fill and half the
+  floor.** Each estimator removes what it actually knows about (see the split below), and the
+  floor can never drop below half, so a shadowed strap-line stays readable instead of black.
+- **The shadow follows the key, and the key is the world's vertical.** The rig blends the
+  camera-relative key toward world-up (`WorldAnchor`, shipped at 1.0, so fully) and re-renders
+  the map from that direction each frame; orbiting the model does not move the lit side, and
+  looking up from below does not carry the light under it.
+- **The depth pass is the ordinary render.** The shadow camera draws the model with its normal
+  materials and keeps the depth buffer: alpha-keyed batches clip in the shadow pass exactly as on
+  screen (hair casts shaped shadows, not slabs), and blended/additive batches write no depth and
+  cast nothing, which is right for glows.
+- **`WmvShadowRig.KeyDirView` must match the shader's `KEY_DIR`** — the shader's fallback
+  shades with its copy, the rig places the camera with its own. There is no tool keeping them in
+  step any more; change one, change the other (the `FillDirView`/`FILL_DIR` pair likewise).
+- Everything is gated by `_WmvShadowValid`, which unset reads 0: a player where the rig never ran
+  renders exactly as before, and the legacy rig (`-wmvRig=1`) never samples the map at all.
+
+**Contact shadows** close the gap the map cannot: its bias is a blind zone of a few millimetres
+(one texel of the map's window), so a map shadow always stops just short of the line where two
+surfaces meet, and a hood whose shadow starts a centimetre below the brim reads as pasted on
+rather than worn. `WmvShadowRig` therefore renders a second depth buffer each frame — the scene
+from the VIEWER's pose, near/far pinched around the model — and `WmvContactFactor` marches a short
+ray from each fragment toward the key light through it: any on-screen surface standing in front
+of the ray within touching distance is a contact occluder, found with no bias and no texel
+footprint. The two estimators answer the same question from opposite sides — the map sees the
+whole model but not the near field, the march sees only the near field and only what is on
+screen — and the darker verdict wins (`min`, not a product, so a rim both can see is not
+double-darkened). `CONTACT_STRENGTH` and `CONTACT_RANGE` (a fraction of the model's radius) are
+in the constants block.
+
+**What each shadow removes follows what each estimator knows.** The map answers a directional
+question ("does the key reach this point"), so it attenuates the key and the highlight and nothing
+else. The march answers a near-field one ("is something within touching distance overhead"), which
+is what sky-and-ambient occlusion is — so it also takes the sky fill and half the ambient floor,
+but only within its short range. Both other assignments were tried and failed measurably: key-only
+went invisible when the light was anchored near-vertical (a face's ndl against an overhead key is
+~0, and blocking a light a surface never received changes nothing), and letting the map take the
+fill dropped a cloaked boss model's mean by a third, because an overhead light puts the map's
+shadow across everything below the shoulders. The floor can never fall below half — a shadowed
+face stays readable, never black.
+
+**The march's verdict is fractional, not binary.** A first version returned fully-occluded on
+the first hit, and looked exactly as harsh and as pixelated as a binary function dithered by
+per-pixel jitter must: at every shadow boundary, neighbouring pixels flipped between fully dark
+and fully lit. Each hit is now weighted — by a smooth window on the depth test and by how far
+along the ray the occluder sits, so a touching edge darkens fully while one at the end of the
+range barely registers — and the strongest hit wins, so the value varies continuously as an
+occluder recedes. Measured on the hooded test model at contact strength 0.3, the fraction of
+shadowed pixels sitting on a hard edge halved (21 % to 10 %) and the mean local gradient dropped
+22 %. At the shipped strength of 1.0 the same profile is scaled up three-fold, and half the
+touched pixels sit on a step the metric counts as hard — so `CONTACT_STRENGTH` is the knob to
+lower if contact shadows read harsh, not the march.
+
+The parameter that makes or breaks the march is the assumed occluder THICKNESS. A depth buffer
+records only front surfaces; without a bound on their assumed depth, any geometry anywhere in
+front of the ray counts as blocking, and the first cut of this (thickness 0.20 R) draped a faint
+grey wash over every large surface. Thickness is 0.08 R and stays fixed while the march reach is a
+constant (`CONTACT_RANGE`, shipped at 0.25 R, so the ray now travels further than the window is
+thick): an occluder matters only if the ray passes within touching distance behind it, however far
+along the ray that happens. Verified per contributor on the hooded Saurfang (`-wmvLightYaw=210`
+turns the check camera to his face): the map-only pass, the combined pass and the contact-only
+difference are dumped separately. With the shipped constants the map touches 56 % of the model,
+the two together 84 %, and the contact march alone adds 30 % — the face under the hood rim, the
+mantle under the collar, the neck under the jaw, the belt lines.
+
+`-wmvLightCheck` reports what the shadows did (coverage, mean darkening, centroid), and
+`-wmvLightDump` writes the check's frames — shadowed, unshadowed, and the amplified difference —
+as PNGs next to the player. WHERE a shadow falls is a spatial question, and the difference image
+is the only reliable way to answer it: the first build shipped with a vertically mirrored map
+(the D3D render-into-texture flip counted twice) and every statistic looked plausible — it took
+eyes on the viewport to catch the model's own silhouette stamped across itself. The criterion
+that verified the fix: with a high key, darkening belongs on UNDER-surfaces (the flank below a
+saddle rim, a neck below the head, feet below the body) and the top of the back must be clean.
+
+### How the values were settled
+
+During this work the player carried a live slider panel over the viewport (one slider per constant
+above, plus the light directions), which is how the numbers were judged on real models rather than
+guessed and rebuilt. Once they were settled they were written into the `#define` block and the rig,
+and the panel, its `-wmvLightPanel` flag, the override uniforms it drove and the bake script that
+kept the copies in step were all removed: the shipped shader path never depended on any of it
+having run, and a normal run renders from the constants alone. Tuning again means editing the
+block at the top of `WmvOpaque.shader` (and the matching direction pair in `WmvShadowRig`) and
+rebuilding; the measurement flags below are what says whether a change did what it looked like.
+
+### Measuring it
+
+`-wmvLightCheck` renders the model offscreen and reports, for every rig, mask coverage, mean, p05,
+p50, p95, max, the clipped fraction, a saturation proxy and model/background contrast. Nothing is
+written to disk and the viewport is not disturbed. `-wmvRig=1` draws the viewport itself with the
+legacy rig for a visual A/B.
+
+**It also measures the rig on its own.** Every figure above is taken on a real model, where paint
+and light arrive as one number — and a rig that models form and a rig that lights everything flat
+can produce the same mean, the same percentiles and the same contrast, because most of the spread
+being measured is the texture. So each rig is rendered a second time with `_WmvFlatAlbedo` set,
+which replaces every surface colour with a flat mid grey and leaves only the light. The ratio of
+the bright end to the dark end of that render is the number that says whether the thing has shadows
+in it: around 1.2 is an evenly-lit figure, 1.6 upwards reads as modelled form. The albedo has to be
+a mid grey and not white — white is already at the top of the range before the light touches it, so
+every rig with any gain saturates and reports no range at all.
+
+This is the check that caught a rig which was better on *every other measure* — brighter at every
+percentile, more contrast against the background, saturation preserved — and was flat.
+
+Getting a number that means something took more care than the tuning did, so the guarantees are
+worth spelling out:
+
+- **The pixel set is geometric, not photometric.** The frame is drawn twice, once cleared to black
+  and once to white, and a pixel counts as model where the two agree exactly — only opaque,
+  depth-writing geometry can be independent of what was cleared behind it. A pixel that agrees only
+  because it saturated over both clears is dropped, since an additive pile-up agrees for a reason
+  that has nothing to do with coverage.
+- **The mask is built under the legacy rig**, which is finished and will not be tuned again, so the
+  pixel set is pinned across every candidate and every build.
+- **The measurement has its own camera**, framed from the bounds alone, so viewport orbit state
+  cannot leak in. Run it with `-wmvNoAnim` to pin the pose.
+- **Every rig is measured in one process**, through that one camera, over that one mask.
+- **Saturation is computed in linear light.** `(max-min)/max` is invariant under a scale factor only
+  in the space the scaling happens in; computed on sRGB bytes it falls whenever the picture gets
+  brighter, so a pure exposure change looks like a loss of colour.
+- **Pin the skin.** WMV picks a random skin per load unless `Session/RandomLooks` is off in
+  `userSettings/Config.ini`. The light check prints the texture FileDataIDs it measured so a
+  mismatched pair is visible rather than silent.
+
+**Why all of that.** An earlier pass concluded from measurements that a rig carrying strictly more
+light at every angle had made two models *darker*. Both halves of that were measurement error.
+chicken2 carries four skins spanning **2.4x** in brightness (mean 0.209 to 0.493) and a
+before/after taken in two separate builds is two separate processes, so it was two different
+chickens — a difference an order of magnitude larger than anything the rig does. Underneath that,
+the old brightness-threshold mask defined its sample in terms of the quantity being measured: a
+brighter model pushes its own dark pixels over the line, they join the sample at the bottom of it,
+and the reported average falls. Measured on the real models, that mask understated the legacy-to-
+shipped gain by 11 % to **98 %**, while its sample size moved by up to 63 %. With the skin pinned
+and the mask geometric, three consecutive runs of the same model now agree to every printed digit.
 
 ## Which viewport owns the centre
 
@@ -461,14 +641,12 @@ in-process, and shuts the player down. Result lines carry the `[unityipc-test]` 
 
 **Not yet implemented**
 
-- Animation UI of the renderer's own: the viewport follows WMV's selector and has no controls.
-  Blending between sequences, and following a queued "next animation" chain, play/pause or
-  playback speed, are not synced -- those change what the canvas shows without a selection
-  happening.
-- Keyframes stored outside the .m2: the .anim files named by the AFID chunk, and bones from a
-  separate skeleton file (the SKID chunk and the SKPD parent it can defer to). A model that
-  needs either is drawn from what it does have -- unskinned, or skinned but still -- and says
-  which.
+- Animation UI of the renderer's own: the viewport follows WMV's selector and transport
+  (play/pause, speed, current time and looping are synced) and has no controls of its own.
+  Blending between sequences and following a queued "next animation" chain are not synced.
+- Bones from a separate skeleton file (the SKID chunk and the SKPD parent it can defer to). A
+  model that needs one is drawn from what it does have -- unskinned, or skinned but still -- and
+  says which. (Keyframes in external .anim files named by the AFID chunk ARE read.)
 - Animation of anything but bones: texture animation, colour and transparency tracks beyond the
   rest-pose visibility gate, particles, ribbons and attachments.
 - The rest of the WoW material system: texture animation, colour and transparency tracks beyond

--- a/docs/unity-renderer/README.md
+++ b/docs/unity-renderer/README.md
@@ -25,6 +25,69 @@ Concretely:
   message while the app — and the legacy OpenGL viewport — carry on unchanged. "Optional"
   describes the current migration stage, not the destination.
 
+## Lighting
+
+The viewport lights models with a **fixed preview rig in the renderer's own shader**, not with the
+engine's lighting. That is a deliberate choice twice over.
+
+**The shader is chosen on purpose, not by accident.** `WmvOpaque` used to be the last rung of a
+search that preferred the pipeline's Lit shader, and it won only because URP/Lit gets stripped out
+of a player build. Two things were riding on that accident: the M2 combiners (a Lit shader cannot
+run them, so chicken2's pixel shader 12 and every environment sheen worked only while Lit was
+absent), and the entire look of the application. It is now the first choice, so both are the same
+everywhere. `-wmvLitShader` asks for the pipeline's Lit shader when you want to compare — with the
+combiners disabled, which is the honest comparison.
+
+**Why not physically-based shading.** WoW's textures are hand-painted with their light and shade
+already in them. PBR relights an image that has already been lit: mid-tones the artist painted go
+dark, flat surfaces pick up specular they were never meant to have, and the hand-painted character
+of the art is exactly what gets lost. A model viewer wants the texture legible from a fixed angle,
+which is a different job from simulating a room.
+
+**The rig.** Three terms, in `Assets/Resources/WmvOpaque.shader`:
+
+| term | what it does |
+|---|---|
+| ambient `0.62` | floor: the darkest any surface gets |
+| key `0.62 * ndl` | upper front-left three-quarter angle |
+| fill `0.16 * ndl_fill * (1-key)` | low and opposite, keeps the shadow side in shape |
+| rim `0.16 * rim^2 * (1-key)` | edge separation against the dark background |
+| highlight `0.16 * ndh^26 * texLuma^2` | a narrow preview glint, weighted by how bright the texture already is |
+
+**A SHOULDER, NOT A CEILING.** The light deliberately sums past 1.0 (to 1.24), and the top end is
+rolled off instead of clamped: below a knee of `0.72` nothing is touched — that is where the painted
+colour lives — and above it the curve bends over and only approaches 1.0 asymptotically. The
+absolute maximum any pixel can reach is **0.975**.
+
+That replaced a rig which kept everything at or below 1.0 by never letting the light sum past it.
+It did prevent blow-out, but by guaranteeing nothing could ever be brighter than its own texture,
+so white fur read grey: a white texture at 70% light *is* grey. Rolling off the top instead lets a
+white read white (0.96 at full key) while still never reaching 1.0. The roll-off is per channel, so
+a saturated red lifts its red without dragging the other two up with it and the colour stays the
+colour.
+
+**The highlight is weighted by the texture, not by a material flag.** Nothing in an M2 says "this
+is metal", but the art already encodes it: gold trim, gems and polished metal are painted bright,
+leather and fur are not. Weighting a narrow glint by the texture's own luminance therefore lands it
+on the buckles and the gems and leaves the hide alone, with no specular map and no pretence of being
+physically based.
+
+**Checking it.** `-wmvLightCheck` renders one frame offscreen and reports coverage, background and
+model luminance, the 5th/95th percentiles, the fraction of clipped pixels, and the mean over the
+whole frame. "Readable" and "not blown out" are claims about pixels, so they are measured rather
+than asserted; nothing is written to disk and the viewport is not disturbed. It renders from a
+FIXED camera and is normally run with `-wmvNoAnim`, because a measurement taken from wherever the
+orbit happened to be, of whatever pose the animation happened to be in, disagrees with itself
+between runs.
+
+**Read the frame mean, not just the model mean.** The model-only figures separate model from
+background with a brightness threshold, and that makes them treacherous for before/after work: a
+brighter model pushes more of its own dark pixels above the threshold, those pixels join the
+sample, and the model-only average can FALL while every pixel got brighter. That is not
+hypothetical — tuning this rig showed two models apparently darkening by a third when the
+threshold-free frame mean showed chicken2 up 14%. The frame mean has no threshold in it and cannot
+do that.
+
 ## Which viewport owns the centre
 
 The Unity renderer is the **main viewport for the models it supports** -- creature M2s. Loading one


### PR DESCRIPTION
## Summary

- **Preview light rig, settled and hardcoded.** `WmvOpaque.shader` carries its constants in one block: a low ambient floor under a strong key, a sky-hemisphere wrap fill, a tight highlight, and a ratio-preserving roll-off to a 1.0 ceiling. The key is anchored to the world vertical (`WmvShadowRig.WorldAnchor = 1.0`), so orbiting never flips the lit side and looking up from below finds the belly still dark.
- **Cast shadows.** `WmvShadowRig` renders a 4096 px orthographic depth map from the key each frame; the shader attenuates the key and highlight with a 3x3 PCF lookup. The depth pass is the ordinary render, so alpha-keyed batches cast shaped shadows and blended/additive batches cast nothing.
- **Contact shadows.** A second, view-space depth buffer feeds a 12-step fractional screen-space march toward the key, closing the gap the map bias leaves at contact lines (hood on face, rope on body). Map and march combine by `min`, and each removes only what it knows about (map: key; march: fill and half the floor).
- **Emissive batches bypass the rig** on the shipped rig only, so a lantern is never dimmed by received-light maths. Declared as a shader property so the builder guard actually sets it.
- **Measurement instrument.** `-wmvLightCheck` now uses a deterministic geometric mask (black/white clears, saturated pixels dropped, built under the frozen legacy rig), prints per-rig statistics and a flat-albedo shading range, measures each shadow contributor separately, dumps PNGs with `-wmvLightDump`, and takes `-wmvLightYaw` / `-wmvLightPitch`. The legacy rig stays behind `-wmvRig=1` for A/B.
- **Scaffolding removed.** The temporary tuning panel, its flag, the live-override uniforms and the bake script are gone; a normal run draws from the constants alone.
- `docs/unity-renderer/README.md` documents the rig, the shadows, how the values were settled, and the guarantees of the measurement.

No OpenGL changes, no export workflows, no character/equipment or map work.

## Test plan

- [x] 4-way Roslyn type-check of the player scripts (0 errors); headless Unity build succeeds
- [x] Nine-model light check: light-only shading range 1.7-2.9x, clipping 0.000 % on every opaque model
- [x] Legacy rig bit-identical to its recorded reference (ratmount2 mean 0.2790, p50 0.2578, p95 0.4865)
- [x] Three consecutive runs of the same model agree to every printed digit; yaw sweep stable; pitch -60 keeps the underside dark
- [x] Shadow contributors verified on the hooded Saurfang (map 56 %, map+contact 84 %, contact adds 30 % of the model), difference images inspected
- [x] Regression checks 14/14, framework parser tests pass, shader/rig direction constants agree
- [x] Manual: open a creature in the Unity viewport, orbit and pitch, confirm the lit side stays put and reins/hoods cast shadows

