### PR TITLE
Fix Unity M2 index and default geoset integrity

### DIFF
--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -296,10 +296,30 @@ public static class WmvModelBuilder
     /// which is exactly what the viewport does for a display with no geoset data. A null set means
     /// the host had nothing to say (no creature selection at all), and then nothing is hidden.
     /// </summary>
+    /// <summary>
+    /// Is this submesh's geoset switched on?
+    ///
+    /// Geoset 0 is the always-drawn part of a model -- the body under the options -- and every
+    /// other number is a variant a creature display turns on. Three cases, and the middle one is
+    /// the one that used to be wrong:
+    ///
+    ///   * a set was reported: draw geoset 0 and whatever the set names;
+    ///   * NO set was reported (null): draw geoset 0 alone. This is the legacy viewport's default
+    ///     -- it builds every submesh with display = (id == 0)
+    ///     (Source/games/wow/WoWModel.cpp:1607) and leaves it that way when nothing selects
+    ///     otherwise (Source/games/wow/WoWModel.cpp:2845-2847). Drawing everything instead, which
+    ///     is what this returned before, shows a model wearing all of its mutually exclusive
+    ///     variants at once: every helmet, every fur option, every alternative limb, overlapping.
+    ///   * an EMPTY set was reported: also geoset 0 alone, which the previous code already got
+    ///     right -- an empty set is a known selection that switches nothing on, and is not the
+    ///     same as silence.
+    /// </summary>
     public static bool GeosetVisible(int submeshId, HashSet<int> geosets)
     {
-        if (geosets == null || submeshId == 0)
+        if (submeshId == 0)
             return true;
+        if (geosets == null)
+            return false;
         return geosets.Contains(submeshId);
     }
 
@@ -678,9 +698,41 @@ public static class WmvModelBuilder
         // variant does not make the camera jump.
         mesh.bounds = BoundsOfAll(positions, triangleSets);
 
-        if (log != null && hiddenByGeoset > 0)
-            log(string.Format("geosets: {0} of {1} submesh(es) hidden by the displayed variant [{2}]",
-                              hiddenByGeoset, triangleSets.Count, GeosetList(geosets)));
+        if (log != null)
+        {
+            // What the skin's index starts looked like. Printed on every load, not only when
+            // something is odd, because "no model I tried exercised this" is itself a result and
+            // only a line that always prints can establish it.
+            M2SkinIndexSurvey ix = skin.IndexSurvey;
+            log(string.Format(
+                "skin indices: {0} submesh(es) over {1} index/es; {2} carry a Level word; " +
+                "largest start {3}{4}",
+                ix.Submeshes, ix.TotalIndices, ix.NonZeroLevel, ix.MaxIndexStart,
+                ix.ExercisesWideStarts ? " -- this model needs starts wider than 16 bits" : ""));
+            if (ix.CumulativeChecked && !ix.CumulativeAgrees)
+                log(string.Format(
+                    "skin indices: WARNING the format's start and the legacy viewport's running " +
+                    "sum disagree, first at submesh {0} (format {1}, running sum {2}). One of the " +
+                    "two renderers is drawing the wrong triangles here.",
+                    ix.DisagreeAt, ix.DisagreeExpanded, ix.DisagreeCumulative));
+
+            // Which geoset rule decided what is on screen. See GeosetVisible.
+            int shownSets = 0;
+            for (int i = 0; i < submeshGeosets.Count; i++)
+                if (GeosetVisible(submeshGeosets[i], geosets))
+                    shownSets++;
+            string how = geosets != null
+                ? "the displayed variant [" + GeosetList(geosets) + "]"
+                : "no variant reported -- geoset 0 only, as the legacy viewport defaults";
+            log(string.Format("geosets: {0} of {1} submesh(es) drawn, {2} hidden, by {3}; " +
+                              "{4} of the skin's submeshes carry geoset 0",
+                              shownSets, triangleSets.Count, hiddenByGeoset, how, ix.GeosetZero));
+            if (shownSets == 0 && triangleSets.Count > 0)
+                log("geosets: NOTHING is drawn -- this model has no geoset 0 submesh and no " +
+                    "variant switched anything on. The legacy viewport shows nothing here too; " +
+                    "reported rather than worked around, because a fallback would be a guess at " +
+                    "what the model meant.");
+        }
 
         // ---- scene object -------------------------------------------------------------
         // Skinned when the model carries a rig this renderer can reproduce, static otherwise. The

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -319,9 +319,68 @@ namespace Wmv.Wow
         /// switches that number on. See WmvModelBuilder.GeosetVisible.
         /// </summary>
         public ushort Id;
+
+        /// <summary>
+        /// The HIGH HALF of this submesh's first triangle index.
+        ///
+        /// The skin format stores that start in a 16-bit field, which cannot address a skin
+        /// holding more than 65535 indices, so the bits above 65535 live here and the real start
+        /// is RawIndexStart + (Level &lt;&lt; 16). The legacy viewport does not read this word at
+        /// all -- it reads the two together as one 32-bit id and masks the whole thing to 15 bits
+        /// (Source/games/wow/modelheaders.h:226, :252) -- and sidesteps the problem by recomputing
+        /// each start as a running sum of the counts before it instead
+        /// (Source/games/wow/WoWModel.cpp:1601-1606). Its own comment says why that class of file
+        /// exists: "to handle index &gt; 65535 (present in HD models)"
+        /// (Source/games/wow/modelheaders.h:239).
+        /// </summary>
         public ushort Level;
+
         public ushort VertexStart, VertexCount;
-        public ushort IndexStart, IndexCount;   // into the skin's triangle-index array
+
+        /// <summary>The first triangle index AS STORED -- the low 16 bits alone. Kept so the
+        /// diagnostic can show what the file said; never use it to address the triangle array.
+        /// IndexStart is the whole value.</summary>
+        public ushort RawIndexStart;
+
+        /// <summary>The first triangle index, whole: RawIndexStart + (Level &lt;&lt; 16). This is
+        /// the one to index with. It is an int, not a ushort, precisely because the value it
+        /// carries does not fit in one.</summary>
+        public int IndexStart;
+
+        public ushort IndexCount;
+    }
+
+    /// <summary>
+    /// What a skin's index starts look like, gathered while parsing so that the renderer can
+    /// report them and a run can be believed rather than assumed.
+    ///
+    /// It records TWO independent readings of the same quantity: the format's own (the stored
+    /// start plus the Level word) and the legacy viewport's (a running sum of the index counts,
+    /// which is how it reaches a 32-bit start without reading Level -- see M2Submesh.Level). If
+    /// the two ever disagree, one of the renderers is drawing the wrong triangles and no amount
+    /// of looking at the picture will say which, so the disagreement is recorded rather than
+    /// resolved by preference.
+    /// </summary>
+    public struct M2SkinIndexSurvey
+    {
+        public int Submeshes;
+        public int NonZeroLevel;        // submeshes whose Level word is set
+        public int MaxIndexStart;       // the largest expanded start in this skin
+        public int TotalIndices;        // entries in the triangle array
+        public int GeosetZero;          // submeshes whose Id is 0, the always-drawn geoset
+
+        /// <summary>Whether the legacy's running-sum reading was computable for every submesh.
+        /// It always is; the flag exists so a false reading cannot be mistaken for agreement.</summary>
+        public bool CumulativeChecked;
+        public bool CumulativeAgrees;
+
+        /// <summary>The first submesh where the two readings differ, or -1.</summary>
+        public int DisagreeAt;
+        public int DisagreeExpanded, DisagreeCumulative;
+
+        /// <summary>True when any start needed more than 16 bits -- i.e. when this model is one
+        /// of the files the fix exists for.</summary>
+        public bool ExercisesWideStarts { get { return MaxIndexStart > 0xFFFF || NonZeroLevel > 0; } }
     }
 
     /// <summary>A draw call: which submesh with which material/texture.</summary>
@@ -359,6 +418,10 @@ namespace Wmv.Wow
         public ushort[] VertexLookup = new ushort[0];   // skin vertex -> M2 vertex index
         public ushort[] Triangles = new ushort[0];      // indices into VertexLookup
         public M2Submesh[] Submeshes = new M2Submesh[0];
+
+        /// <summary>How this skin's index starts read, and whether the two independent readings
+        /// of them agree. See M2SkinIndexSurvey.</summary>
+        public M2SkinIndexSurvey IndexSurvey;
         public M2Batch[] Batches = new M2Batch[0];
 
         public int TriangleCount { get { return Triangles.Length / 3; } }

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2SkinParser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2SkinParser.cs
@@ -69,6 +69,16 @@ namespace Wmv.Wow
             }
 
             skin.Submeshes = new M2Submesh[submeshes.Count];
+            // The legacy viewport's reading of the same starts, for comparison: it ignores the
+            // Level word and makes each start the sum of the counts before it
+            // (Source/games/wow/WoWModel.cpp:1601-1606). Tracked alongside so the two can be
+            // checked against each other on real files instead of one being assumed correct.
+            long cumulative = 0;
+            skin.IndexSurvey.Submeshes = submeshes.Count;
+            skin.IndexSurvey.TotalIndices = skin.Triangles.Length;
+            skin.IndexSurvey.CumulativeChecked = true;
+            skin.IndexSurvey.CumulativeAgrees = true;
+            skin.IndexSurvey.DisagreeAt = -1;
             for (int i = 0; i < submeshes.Count; i++)
             {
                 c.Seek(submeshes.Offset + i * SubmeshStride);
@@ -80,17 +90,39 @@ namespace Wmv.Wow
                 s.Level = c.ReadUInt16();
                 s.VertexStart = c.ReadUInt16();
                 s.VertexCount = c.ReadUInt16();
-                s.IndexStart = c.ReadUInt16();
+                s.RawIndexStart = c.ReadUInt16();
                 s.IndexCount = c.ReadUInt16();
                 // remaining fields (bone counts, centre/sort positions, radius) are not needed here
+
+                // THE WHOLE START. Reading the stored half alone is not a smaller number, it is a
+                // WRONG one: past 65535 the field wraps, and a wrapped start is a small in-range
+                // value, so the bounds check below passes and the submesh quietly draws somebody
+                // else's triangles. See M2Submesh.Level.
+                s.IndexStart = s.RawIndexStart + (s.Level << 16);
+                if (s.Level != 0)
+                    skin.IndexSurvey.NonZeroLevel++;
+                if (s.IndexStart > skin.IndexSurvey.MaxIndexStart)
+                    skin.IndexSurvey.MaxIndexStart = s.IndexStart;
+                if (s.Id == 0)
+                    skin.IndexSurvey.GeosetZero++;
+                if (skin.IndexSurvey.CumulativeAgrees && s.IndexStart != cumulative)
+                {
+                    skin.IndexSurvey.CumulativeAgrees = false;
+                    skin.IndexSurvey.DisagreeAt = i;
+                    skin.IndexSurvey.DisagreeExpanded = s.IndexStart;
+                    skin.IndexSurvey.DisagreeCumulative = (int)cumulative;
+                }
+                cumulative += s.IndexCount;
 
                 if (s.IndexCount % 3 != 0)
                     throw new WowParseException(string.Format(
                         "skin: submesh {0} has {1} indices, not a multiple of 3", i, s.IndexCount));
                 if ((long)s.IndexStart + s.IndexCount > skin.Triangles.Length)
                     throw new WowParseException(string.Format(
-                        "skin: submesh {0} spans indices [{1},{2}) beyond the {3} available",
-                        i, s.IndexStart, s.IndexStart + s.IndexCount, skin.Triangles.Length));
+                        "skin: submesh {0} spans indices [{1},{2}) beyond the {3} available " +
+                        "(start {4} + level {5} << 16)",
+                        i, s.IndexStart, (long)s.IndexStart + s.IndexCount, skin.Triangles.Length,
+                        s.RawIndexStart, s.Level));
                 if ((long)s.VertexStart + s.VertexCount > skin.VertexLookup.Length)
                     throw new WowParseException(string.Format(
                         "skin: submesh {0} spans vertices [{1},{2}) beyond the {3} available",

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -259,7 +259,8 @@ namespace Wmv.Wow.Tests
         /// <summary>Skin with `vertexCount` lookup entries and one submesh covering `triangles`.</summary>
         static byte[] BuildSkin(int vertexCount, ushort[] triangles, ushort submeshIndexCount = 0xFFFF,
                                 ushort lookupOverride = 0xFFFF, ushort batchColorIndex = 0xFFFF,
-                                ushort batchTextureCount = 1, ushort submeshId = 0)
+                                ushort batchTextureCount = 1, ushort submeshId = 0,
+                                ushort submeshLevel = 0, ushort submeshIndexStart = 0)
         {
             const int headerSize = 0x30;
             int vertOffset = headerSize;
@@ -282,10 +283,10 @@ namespace Wmv.Wow.Tests
                 PutU16(b, triOffset + i * 2, triangles[i]);
 
             PutU16(b, subOffset + 0, submeshId);             // id (geoset number)
-            PutU16(b, subOffset + 2, 0);                     // level
+            PutU16(b, subOffset + 2, submeshLevel);          // level: the high half of indexStart
             PutU16(b, subOffset + 4, 0);                     // vertexStart
             PutU16(b, subOffset + 6, (ushort)vertexCount);   // vertexCount
-            PutU16(b, subOffset + 8, 0);                     // indexStart
+            PutU16(b, subOffset + 8, submeshIndexStart);     // indexStart: the low half
             PutU16(b, subOffset + 10, submeshIndexCount == 0xFFFF ? (ushort)triangles.Length : submeshIndexCount);
 
             b[batchOffset] = 0;                              // flags
@@ -335,6 +336,7 @@ namespace Wmv.Wow.Tests
             M2Tests();
             log.Add("M2SkinParser");
             SkinTests();
+            WideIndexStartTests();
             log.Add("BlpDecoder");
             BlpTests();
             log.Add("WowCoordinateConverter");
@@ -772,6 +774,54 @@ namespace Wmv.Wow.Tests
             PutU32(truncatedBones, 0x2C, 64);
             Throws<WowParseException>(() => M2Parser.Parse(truncatedBones),
                                       "bones: truncated bone array rejected");
+        }
+
+        /// <summary>
+        /// A skin whose triangle array runs past 65535. The submesh's first index does not fit in
+        /// the field that holds it, so the format puts the overflow in the Level word; reading the
+        /// stored half alone lands on a different submesh's triangles and every bounds check still
+        /// passes, because a wrapped start is a small in-range number. That is the whole bug, and
+        /// this is the case that proves it either way.
+        /// </summary>
+        static void WideIndexStartTests()
+        {
+            const int total = 65541;            // 21847 triangles: past the 16-bit ceiling
+            var tris = new ushort[total];
+            for (int i = 0; i < total; i++)
+                tris[i] = (ushort)(i % 3);
+            // The triangle the submesh should draw, and a decoy at the wrapped start.
+            tris[65538] = 0; tris[65539] = 1; tris[65540] = 2;
+            tris[2] = 2; tris[3] = 2; tris[4] = 2;
+
+            // level 1, stored start 2  ->  whole start 65538
+            M2ParsedSkin skin = M2SkinParser.Parse(
+                BuildSkin(3, tris, 3, 0xFFFF, 0xFFFF, 1, 0, 1, 2));
+            M2Submesh s = skin.Submeshes[0];
+            Check(s.Level == 1, "wide index: the level word is read");
+            Check(s.RawIndexStart == 2, "wide index: the stored half is kept as stored");
+            Check(s.IndexStart == 65538, "wide index: the start is expanded past 16 bits");
+
+            int[] drawn = M2SkinParser.BuildTriangles(skin, s, 3);
+            Check(drawn.Length == 3 && drawn[0] == 0 && drawn[1] == 1 && drawn[2] == 2,
+                  "wide index: triangles come from the expanded start, not the wrapped one");
+
+            Check(skin.IndexSurvey.NonZeroLevel == 1, "wide index: survey counts the level word");
+            Check(skin.IndexSurvey.MaxIndexStart == 65538, "wide index: survey records the start");
+            Check(skin.IndexSurvey.ExercisesWideStarts, "wide index: survey flags the model");
+            // This fixture has one submesh starting at 65538, so the legacy viewport's running-sum
+            // reading (which would say 0) disagrees -- exactly what the cross-check is for.
+            Check(!skin.IndexSurvey.CumulativeAgrees && skin.IndexSurvey.DisagreeAt == 0,
+                  "wide index: the running-sum cross-check notices the difference");
+
+            // An ordinary skin: the two readings agree and nothing is flagged.
+            var small = new ushort[] { 0, 1, 2, 0, 1, 2 };
+            M2ParsedSkin plain = M2SkinParser.Parse(BuildSkin(3, small));
+            Check(plain.Submeshes[0].IndexStart == 0, "wide index: an ordinary start is unchanged");
+            Check(plain.IndexSurvey.NonZeroLevel == 0 && !plain.IndexSurvey.ExercisesWideStarts,
+                  "wide index: an ordinary skin is not flagged");
+            Check(plain.IndexSurvey.CumulativeAgrees && plain.IndexSurvey.DisagreeAt == -1,
+                  "wide index: the two readings agree on an ordinary skin");
+            Check(plain.IndexSurvey.GeosetZero == 1, "wide index: survey counts geoset 0 submeshes");
         }
 
         static void SkinTests()


### PR DESCRIPTION
Two ways the renderer could draw the wrong triangles without saying so. Both decide WHICH geometry appears, so they had to be settled before anything that judges materials or effects.

Skin index starts are 32 bits, not 16. A submesh's first triangle index is stored in a 16-bit field with the bits above 65535 in the neighbouring Level word, and only the low half was read. Past 65535 that field wraps, and a wrapped start is a small in-range number, so every bounds check passed and the submesh quietly drew somebody else's triangles.

The legacy viewport never reads Level -- it takes those four bytes as one 32-bit id and masks to 15 bits (modelheaders.h:226, :252) -- and sidesteps the problem by recomputing each start as a running sum of the counts before it (WoWModel.cpp:1601-1606). Its own comment says why the case exists: "to handle index > 65535 (present in HD models)" (modelheaders.h:239).

Rather than assume the format's rule matches that, the parser now computes BOTH readings and records whether they agree, on every model loaded. They agreed on all seven validation models, so this is one fix with two independent confirmations rather than a preference between them.

This is a real repair, not insurance: three of the seven models carry non-zero Level words -- drustvarbeastman 10 of 16 submeshes, ethereal2_m 62 of 102, dragonelementium 14 of 26, with starts up to 232,959. Their geometry changes; the four models with no Level word measure byte-identical before and after.

Default geoset visibility now matches the legacy viewport. When the host reports no creature selection at all, geoset 0 alone is drawn, as the legacy does (WoWModel.cpp:1607, and 2845-2847 where it leaves that default alone). Drawing every submesh instead, which is what happened before, shows a model wearing all of its mutually exclusive variants at once. Only the null path changes: an empty reported selection is a known answer that switches nothing on, and already behaved correctly.

No fallback was invented for a model with no geoset 0. One validation model, drustvarbeastman, has none -- it still draws, because its host selection switches a variant on, but under a null selection it would draw nothing. The renderer logs that case in those words instead of guessing at what the model meant.

The synthetic parser test builds a skin with 65,541 indices and a submesh at level 1, stored start 2, with a decoy planted at the wrapped position, so it fails if the old reading returns. Twelve new cases; parser suite 152 passing, type-check clean across four input configurations, headless regression 14 of 14 before and after.