### PR TITLE
Fix Unity M2 surface state parity

### DIFF
--- a/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
@@ -38,6 +38,17 @@ Shader "WMV/Opaque Textured"
         _Emissive ("Emissive pass", Float) = 0
         // Where unit 1 samples: 0 = uv set 0, 1 = uv set 1, 2 = environment sphere map.
         _Unit1UV ("Unit 1 UV source", Float) = 2
+
+        // The same question for UNIT 0, which used to have no answer: it always sampled mesh UV
+        // set 0. A material whose vertex program is named Diffuse_Env, Diffuse_Env_T1,
+        // Diffuse_Env_Env or Diffuse_EdgeFade_Env puts the ENVIRONMENT on unit 0, and sampling
+        // that texture with mesh coordinates pins a reflection to the surface: the sheen slides
+        // with the model instead of staying put as the view turns. The sphere map was already
+        // generated for unit 1's sake; this lets unit 0 reach it.
+        //
+        // Default 0 (mesh UV set 0), NOT 2 like _Unit1UV, so a material that never sets this --
+        // any pipeline fallback, any older path -- keeps exactly today's behaviour.
+        _Unit0UV ("Unit 0 UV source", Float) = 0
         // How the M2 combiner builds its "discard alpha": 0 = 1, 1 = unit0.a, 2 = unit1.a,
         // 3 = unit0.a * unit1.a, 4 = unit0.a + unit1.a. Scaled by _AlphaScale (the x2 combiners).
         _AlphaMode ("Alpha source", Float) = 0
@@ -130,7 +141,7 @@ Shader "WMV/Opaque Textured"
             sampler2D _MainTex;
             float4 _MainTex_ST;
             sampler2D _SecondTex;
-            float _CombinerMode, _Unit1UV, _AlphaMode, _AlphaScale, _OpaqueAlpha;
+            float _CombinerMode, _Unit1UV, _Unit0UV, _AlphaMode, _AlphaScale, _OpaqueAlpha;
 
             // 1 on an ADDITIVE batch. An additive pass is light the surface EMITS -- a lantern
             // flame, an eye glow, rune fire -- and multiplying emitted light by the preview rig
@@ -339,7 +350,13 @@ Shader "WMV/Opaque Textured"
 
             fixed4 frag (v2f i) : SV_Target
             {
-                fixed4 t1 = tex2D(_MainTex, i.uv);
+                // Unit 0's coordinate. Anything outside the three cases below falls back to mesh
+                // UV set 0, which is what this sampled before the choice existed -- an unknown
+                // source must not invent a coordinate.
+                float2 uv0 = i.uv;
+                if (_Unit0UV > 1.5 && _Unit0UV < 2.5)       uv0 = i.env;   // environment sphere map
+                else if (_Unit0UV > 0.5 && _Unit0UV < 1.5)  uv0 = i.uv1;   // mesh UV set 1
+                fixed4 t1 = tex2D(_MainTex, uv0);
 
                 // Unit 1's coordinates, per the material's vertex shader name.
                 float2 uv1 = (_Unit1UV < 0.5) ? i.uv : ((_Unit1UV < 1.5) ? i.uv1 : i.env);

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -445,6 +445,11 @@ public class WmvMain : MonoBehaviour
             if (WmvModelBuilder.Debug_.LightCheck)
                 ReportLighting();
 
+            // Independent of the model just loaded -- it brings its own geometry, materials and
+            // camera -- but hung off the same hook so one headless run produces both readings.
+            if (WmvModelBuilder.Debug_.QueueProof)
+                ReportQueueOrder();
+
             status.Set("Loaded " + job.Path);
             status.Set(string.Format("Vertices {0}  Triangles {1}  Submeshes {2}  Textures {3}",
                                      built.VertexCount, built.TriangleCount, built.SubmeshCount, job.Textures.Count));
@@ -797,6 +802,313 @@ public class WmvMain : MonoBehaviour
         Color32[] px = tex.GetPixels32();
         Destroy(tex);
         return px;
+    }
+
+    /// <summary>
+    /// Does a per-material render queue actually order the SUBMESHES OF ONE RENDERER?
+    /// (-wmvQueueProof)
+    ///
+    /// The transparent draw order in WmvModelBuilder rests entirely on this. A model is one
+    /// renderer with one submesh per batch, so the only place an order can be expressed without
+    /// rebuilding the mesh is the material's render queue -- and whether Unity honours that
+    /// BETWEEN SUBMESHES OF THE SAME RENDERER, rather than drawing them in submesh order
+    /// regardless, is a question about the engine. Reading how the render loop sorts draw calls
+    /// suggests an answer; it does not establish one, and a real model cannot settle it either:
+    /// additive blending is commutative, so a model whose blended batches are additive looks
+    /// identical whichever order they draw in, and a null result there would mean nothing.
+    ///
+    /// So the case is synthetic and fully determined. Two coplanar quads in one mesh, one submesh
+    /// each, both with depth writes off and an output alpha of exactly 1, blended SrcAlpha /
+    /// OneMinusSrcAlpha. Nothing about the geometry, the depth buffer or the winding can decide
+    /// what survives: the pixel that comes out IS the identity of whichever material drew SECOND.
+    /// Submesh 0 is red, submesh 1 is blue, and the queues are set both ways round --
+    ///
+    ///   equal queues     : records what the engine does with no queue to go on (submesh order)
+    ///   A 3000, B 3001   : expect BLUE, which agrees with submesh order
+    ///   A 3001, B 3000   : expect RED, which CONTRADICTS submesh order
+    ///
+    /// -- and it is the third case that carries the proof. Both renderer types are measured,
+    /// because models take both paths (WmvModelBuilder builds a SkinnedMeshRenderer when the file
+    /// can be skinned and a MeshRenderer when it cannot) and a skinned draw is submitted
+    /// differently.
+    /// </summary>
+    void ReportQueueOrder()
+    {
+        // Same 512 square the light check uses, so a saved frame from here sits beside a saved
+        // frame of a model at the same size and neither has to be scaled to be looked at.
+        const int W = 512, H = 512;
+        Shader sh = WmvModelBuilder.ResolveShader(null);
+        if (sh == null)
+        {
+            Debug.Log("WMV: queueproof: no render shader resolved -- nothing to measure");
+            return;
+        }
+
+        // Far from anything the viewport can see. The proof objects are destroyed before this
+        // method returns, but Destroy is deferred to the end of the frame, and 10 km away with a
+        // 20-unit far plane on the measuring camera means neither camera can see the other's
+        // subject even for that one frame.
+        Vector3 origin = new Vector3(10000f, 10000f, 10000f);
+        Color clear = new Color(0.25f, 0.25f, 0.25f, 1f);   // neither red- nor blue-dominant
+
+        var camGo = new GameObject("WmvQueueProofCamera");
+        Camera cam = camGo.AddComponent<Camera>();
+        cam.enabled = false;                        // only ever rendered by hand, below
+        cam.clearFlags = CameraClearFlags.SolidColor;
+        cam.orthographic = true;
+        cam.orthographicSize = 0.5f;                // the quads are 2 units across: they overfill
+        cam.nearClipPlane = 0.1f;
+        cam.farClipPlane = 20f;
+        cam.allowHDR = false;
+        cam.allowMSAA = false;
+        cam.transform.position = origin + new Vector3(0f, 0f, -5f);
+        cam.transform.rotation = Quaternion.identity;
+
+        RenderTexture rt = RenderTexture.GetTemporary(W, H, 24, RenderTextureFormat.ARGB32,
+                                                      RenderTextureReadWrite.Default);
+
+        // WHAT THIS DIAGNOSTIC BORROWS FROM GLOBAL SHADER STATE, AND HOW IT GIVES IT BACK.
+        //
+        // Two globals decide how the proof materials shade. _WmvRig, because the emissive bypass
+        // the proof depends on is gated on the shipped rig and the legacy rig deliberately
+        // ignores it; and _WmvFlatAlbedo, because the light check's white-albedo override would
+        // repaint both quads the same colour and destroy the very reading being taken.
+        //
+        // Both are READ FIRST and put back exactly as they were FOUND -- not put back to the
+        // value they ought to have had. An earlier version of this method restored _WmvRig to
+        // Debug_.Rig and did not restore _WmvFlatAlbedo at all, reasoning that ReportLighting is
+        // its only other writer and always leaves it at 0. That reasoning happens to be true of
+        // today's code and is still the wrong rule: it makes the diagnostic's cleanup depend on
+        // a fact about a different method, and it leaves the switch able to change what the
+        // viewport draws after it has finished measuring. Ask, do not assume -- and say in the
+        // log what was found and what was left, so the claim is checkable instead of asserted.
+        float prevRig = Shader.GetGlobalFloat("_WmvRig");
+        float prevFlatAlbedo = Shader.GetGlobalFloat("_WmvFlatAlbedo");
+        // THE RENDER TARGET, AND WHY RECORDING IT IS NOT ENOUGH.
+        //
+        // GrabFrame does put RenderTexture.active back -- but only on the path where nothing
+        // throws. It sets cam.targetTexture = rt, renders, clears it, then sets
+        // RenderTexture.active = rt and restores it after ReadPixels. A throw anywhere between
+        // those pairs leaves the process pointing at THIS method's temporary, and the release
+        // below would then hand the rest of the frame a freed render target. Depending on
+        // GrabFrame's internal cleanup is therefore fine for the happy path and not good enough
+        // for a finally block, so both are put back here as well, before the release.
+        //
+        // GrabFrame is left alone: twelve of its thirteen callers are the light check's, and
+        // rewriting it to be exception-safe is a change to that measurement, not to this
+        // diagnostic's cleanup. (The Texture2D it allocates does leak on a throw; that is
+        // GrabFrame's own business and not shared state.) cam.backgroundColor is also written
+        // and never restored, and that one does not matter: the camera belongs to this method
+        // and is destroyed below.
+        RenderTexture prevActive = RenderTexture.active;
+        try
+        {
+            Shader.SetGlobalFloat("_WmvRig", 0f);
+            Shader.SetGlobalFloat("_WmvFlatAlbedo", 0f);
+
+            bool allProven = true;
+            for (int p = 0; p < 2; p++)
+            {
+                bool skinned = p == 1;
+                string path = skinned ? "SkinnedMeshRenderer" : "MeshRenderer";
+                Material matA = QueueProofMaterial(sh, new Color(1f, 0f, 0f, 1f), "queueProofA");
+                Material matB = QueueProofMaterial(sh, new Color(0f, 0f, 1f, 1f), "queueProofB");
+                Mesh mesh;
+                GameObject go = BuildQueueProofCase(sh, origin, skinned,
+                                                    new[] { matA, matB }, out mesh);
+
+                char wEqual, wBlast, wAlast;
+                matA.renderQueue = 3000; matB.renderQueue = 3000;
+                Color32[] fEqual = GrabFrame(cam, rt, clear, W, H);
+                string sEqual = QueueProofRead(fEqual, out wEqual);
+                matA.renderQueue = 3000; matB.renderQueue = 3001;
+                Color32[] fBlast = GrabFrame(cam, rt, clear, W, H);
+                string sBlast = QueueProofRead(fBlast, out wBlast);
+                matA.renderQueue = 3001; matB.renderQueue = 3000;
+                Color32[] fAlast = GrabFrame(cam, rt, clear, W, H);
+                string sAlast = QueueProofRead(fAlast, out wAlast);
+
+                // Repeat the decisive case to show the reading is not a one-off.
+                char wAlast2;
+                string sAlast2 = QueueProofRead(GrabFrame(cam, rt, clear, W, H), out wAlast2);
+
+                // The frames themselves, under the switch that already saves the light check's
+                // pictures. A count of red and blue pixels is the measurement; the picture is
+                // what a reviewer can check the measurement against without running anything.
+                if (WmvModelBuilder.Debug_.LightDump)
+                {
+                    string tag = skinned ? "skinned" : "static";
+                    DumpPng(fEqual, W, H, "wmv-queueproof-" + tag + "-equal-3000-3000.png");
+                    DumpPng(fBlast, W, H, "wmv-queueproof-" + tag + "-A3000-B3001.png");
+                    DumpPng(fAlast, W, H, "wmv-queueproof-" + tag + "-A3001-B3000.png");
+                }
+
+                bool proven = wBlast == 'B' && wAlast == 'A' && wAlast2 == 'A';
+                if (!proven) allProven = false;
+
+                Debug.Log(string.Format(
+                    "WMV: queueproof: {0}: submesh 0 = red material A, submesh 1 = blue material B, "
+                    + "coplanar, ZWrite off, alpha 1 -- the frame shows whichever drew last", path));
+                Debug.Log(string.Format(
+                    "WMV: queueproof: {0}: queues equal (3000/3000), no queue to go on -> {1}",
+                    path, sEqual));
+                Debug.Log(string.Format(
+                    "WMV: queueproof: {0}: A=3000 B=3001, expect B/blue last -> {1} [{2}]",
+                    path, sBlast, wBlast == 'B' ? "as expected" : "NOT AS EXPECTED"));
+                Debug.Log(string.Format(
+                    "WMV: queueproof: {0}: A=3001 B=3000, expect A/red last, which CONTRADICTS "
+                    + "submesh order -> {1} [{2}]",
+                    path, sAlast, wAlast == 'A' ? "as expected" : "NOT AS EXPECTED"));
+                Debug.Log(string.Format(
+                    "WMV: queueproof: {0}: same case rendered again -> {1} [{2}]",
+                    path, sAlast2, wAlast2 == wAlast ? "repeatable" : "NOT REPEATABLE"));
+                Debug.Log(string.Format("WMV: queueproof: {0}: {1}", path, proven
+                    ? "PROVEN -- the frame follows the render queue, including when the queue "
+                      + "contradicts submesh order"
+                    : "NOT PROVEN -- the frame did not follow the render queue; the transparent "
+                      + "draw order has no effect and should be removed"));
+
+                go.SetActive(false);
+                Destroy(go);
+                Destroy(mesh);
+                Destroy(matA);
+                Destroy(matB);
+            }
+
+            Debug.Log("WMV: queueproof: verdict -- " + (allProven
+                ? "a per-material render queue orders the submeshes of one renderer on BOTH "
+                  + "renderer paths, so ranking transparent batches by queue does what it claims"
+                : "the render queue did NOT order the submeshes of one renderer on at least one "
+                  + "path -- see the lines above"));
+        }
+        finally
+        {
+            // ORDER MATTERS HERE. The render target goes back FIRST, so the temporary is neither
+            // the active target nor a camera's target at the moment it is released -- releasing
+            // one that is still bound is how a freed render target reaches the next frame.
+            RenderTexture.active = prevActive;
+            if (cam != null)
+                cam.targetTexture = null;
+            Shader.SetGlobalFloat("_WmvRig", prevRig);
+            Shader.SetGlobalFloat("_WmvFlatAlbedo", prevFlatAlbedo);
+            RenderTexture.ReleaseTemporary(rt);
+            Destroy(camGo);
+
+            // Read the globals back rather than trust the writes, and print entry and exit side
+            // by side. A diagnostic that quietly changes what the viewport draws after it has
+            // finished measuring is worse than no diagnostic, so this line exists to be looked at.
+            float nowRig = Shader.GetGlobalFloat("_WmvRig");
+            float nowFlatAlbedo = Shader.GetGlobalFloat("_WmvFlatAlbedo");
+            // Compared by REFERENCE, not by name: "the same render target object", not "a
+            // render target that happens to be called the same thing".
+            bool restored = nowRig == prevRig && nowFlatAlbedo == prevFlatAlbedo
+                            && ReferenceEquals(RenderTexture.active, prevActive);
+            Debug.Log(string.Format(
+                "WMV: queueproof: global state -- on entry _WmvRig {0} _WmvFlatAlbedo {1} "
+                + "RenderTexture.active {2}; on exit _WmvRig {3} _WmvFlatAlbedo {4} "
+                + "RenderTexture.active {5} -- {6}",
+                prevRig, prevFlatAlbedo, prevActive == null ? "none" : prevActive.name,
+                nowRig, nowFlatAlbedo,
+                RenderTexture.active == null ? "none" : RenderTexture.active.name,
+                restored ? "every borrowed global restored to the value it was found at"
+                         : "NOT RESTORED -- the diagnostic changed global state it did not put back"));
+        }
+    }
+
+    /// <summary>
+    /// A flat, self-lit, fully opaque-in-alpha blended material: the light rig, the texture, the
+    /// combiner and the alpha channel are all taken out of the reading, so the only thing the
+    /// frame can report is which material drew last.
+    /// </summary>
+    static Material QueueProofMaterial(Shader sh, Color c, string name)
+    {
+        var m = new Material(sh);
+        m.name = name;
+        m.SetColor("_Color", c);
+        m.SetFloat("_CombinerMode", 0f);      // single texture; _MainTex defaults to white
+        m.SetFloat("_Unit0UV", 0f);
+        m.SetFloat("_Unit1UV", 2f);
+        m.SetFloat("_AlphaMode", 0f);         // alpha 1 out of the combiner
+        m.SetFloat("_AlphaScale", 1f);
+        m.SetFloat("_OpaqueAlpha", 1f);       // ...and 1 out of the shader: the later draw wins
+        m.SetFloat("_Emissive", 1f);          // no light rig in the colour
+        m.SetFloat("_Cull", 0f);              // Off: winding cannot decide the outcome either
+        m.SetFloat("_ZWrite", 0f);            // as a transparent batch: depth cannot decide it
+        m.SetFloat("_SrcBlend", (float)UnityEngine.Rendering.BlendMode.SrcAlpha);
+        m.SetFloat("_DstBlend", (float)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+        return m;
+    }
+
+    /// <summary>
+    /// One renderer, one mesh, two submeshes that occupy exactly the same pixels -- built the two
+    /// ways WmvModelBuilder builds a model, so the answer covers both.
+    /// </summary>
+    static GameObject BuildQueueProofCase(Shader sh, Vector3 origin, bool skinned,
+                                          Material[] mats, out Mesh mesh)
+    {
+        Vector3[] corner = { new Vector3(-1f, -1f, 0f), new Vector3(-1f, 1f, 0f),
+                             new Vector3( 1f,  1f, 0f), new Vector3( 1f, -1f, 0f) };
+        var verts = new Vector3[8];
+        var norms = new Vector3[8];
+        for (int q = 0; q < 2; q++)
+            for (int c = 0; c < 4; c++)
+            {
+                verts[q * 4 + c] = corner[c];
+                norms[q * 4 + c] = new Vector3(0f, 0f, -1f);
+            }
+        mesh = new Mesh();
+        mesh.vertices = verts;
+        mesh.normals = norms;
+        mesh.subMeshCount = 2;
+        mesh.SetTriangles(new[] { 0, 1, 2, 0, 2, 3 }, 0, false);
+        mesh.SetTriangles(new[] { 4, 5, 6, 4, 6, 7 }, 1, false);
+        mesh.bounds = new Bounds(Vector3.zero, new Vector3(2f, 2f, 0.1f));
+
+        var go = new GameObject(skinned ? "WmvQueueProofSkinned" : "WmvQueueProofStatic");
+        go.transform.position = origin;
+        if (skinned)
+        {
+            var bone = new GameObject("WmvQueueProofBone");
+            bone.transform.SetParent(go.transform, false);
+            var bw = new BoneWeight[8];
+            for (int i = 0; i < bw.Length; i++) { bw[i].boneIndex0 = 0; bw[i].weight0 = 1f; }
+            mesh.boneWeights = bw;
+            mesh.bindposes = new[] { Matrix4x4.identity };
+            var smr = go.AddComponent<SkinnedMeshRenderer>();
+            smr.sharedMesh = mesh;
+            smr.bones = new[] { bone.transform };
+            smr.rootBone = bone.transform;
+            smr.sharedMaterials = mats;
+            smr.localBounds = mesh.bounds;
+            smr.updateWhenOffscreen = false;
+        }
+        else
+        {
+            go.AddComponent<MeshFilter>().sharedMesh = mesh;
+            go.AddComponent<MeshRenderer>().sharedMaterials = mats;
+        }
+        return go;
+    }
+
+    /// <summary>
+    /// Which material owns the frame: 'A' red, 'B' blue, '?' neither. Counted over every pixel
+    /// rather than sampled at the centre, so a partial draw cannot be read as a whole one.
+    /// </summary>
+    static string QueueProofRead(Color32[] px, out char winner)
+    {
+        int red = 0, blue = 0, neither = 0;
+        for (int i = 0; i < px.Length; i++)
+        {
+            Color32 q = px[i];
+            if (q.r > q.b + 40 && q.r > q.g + 40) red++;
+            else if (q.b > q.r + 40 && q.b > q.g + 40) blue++;
+            else neither++;
+        }
+        winner = red > blue && red > neither ? 'A'
+               : blue > red && blue > neither ? 'B' : '?';
+        return string.Format("{0} ({1} red px, {2} blue px, {3} neither, of {4})",
+                             winner == 'A' ? "A/red" : winner == 'B' ? "B/blue" : "INDETERMINATE",
+                             red, blue, neither, px.Length);
     }
 
     /// <summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -23,7 +23,31 @@ public struct WmvMaterialBinding
     public int EnvSlot;          // M2 texture slot bound as the combiner's second unit, -1 unused
     public bool DropAlpha;       // was the base texture's alpha discarded on upload?
     public bool Unit1DropAlpha;  // ... and the second unit's
-    public bool Unit1Clamp;      // the second unit is sphere-mapped, so it must not wrap
+
+    /// <summary>
+    /// How each unit's texture addresses outside 0..1, per axis: true repeats, false clamps.
+    ///
+    /// It has to live here, not just at build time, because a skin change re-uploads the images
+    /// through RebindTextures and would otherwise hand every texture the default. That is exactly
+    /// how a wrap fix looks intermittent: right on load, wrong the moment the user picks a skin.
+    /// </summary>
+    public bool BaseWrapX, BaseWrapY;
+    public bool Unit1WrapX, Unit1WrapY;
+}
+
+/// <summary>
+/// One drawn batch's place in the transparent draw order. The legacy viewport sorts its passes
+/// before drawing -- blend mode first, then geoset index, then the texture's "special" type
+/// (Source/games/wow/WoWModel.cpp:2011-2018) -- and this renderer drew them in skin order, which
+/// is a different order whenever a model mixes blend modes across submeshes.
+/// </summary>
+struct WmvDrawOrderKey
+{
+    public int Material;     // index into the materials list
+    public int Blend;        // M2 blend mode, the legacy's primary key
+    public int Submesh;      // the legacy's secondary key
+    public int SpecialTex;   // the legacy's tertiary key: texture type, -1 for a plain file
+    public int Built;        // the order this batch was built in: the final tiebreaker
 }
 
 public class WmvRuntimeModel
@@ -131,6 +155,12 @@ public static class WmvModelBuilder
     ///                    size. Zero everywhere means nothing is animating; a number far larger
     ///                    than the model means the rig is being applied wrongly. Both are
     ///                    invisible in a still frame and obvious in this line.
+    ///   -wmvQueueProof   render a controlled two-submesh case offscreen and report which of the
+    ///                    two materials reached the frame buffer last. The transparent draw order
+    ///                    rests on one engine behaviour -- that a per-material render queue orders
+    ///                    the submeshes of a SINGLE renderer -- and reading the render loop's
+    ///                    sorting rules is not the same as measuring it. See
+    ///                    WmvMain.ReportQueueOrder.
     /// </summary>
     public static class Debug_
     {
@@ -138,6 +168,7 @@ public static class WmvModelBuilder
         static bool flipV, forceOpaque, forceSolid, matColors, showHidden, ownShader;
         static bool noSkin, skinCheck, noAnim, animCheck, placeholder, overlay, litShader;
         static bool lightCheck;
+        static bool queueProof;
         static int rig;
         static bool lightDump;
         static float lightYaw = 30f;
@@ -163,6 +194,7 @@ public static class WmvModelBuilder
                 else if (a == "-wmvLitShader") litShader = true;
                 else if (a == "-wmvLightCheck") lightCheck = true;
                 else if (a == "-wmvLightDump") lightDump = true;
+                else if (a == "-wmvQueueProof") queueProof = true;
                 else if (a.StartsWith("-wmvLightYaw="))
                 {
                     float y;
@@ -221,6 +253,18 @@ public static class WmvModelBuilder
         /// parts are. "Looks right" is not checkable from a log; those numbers are.
         /// </summary>
         public static bool LightCheck { get { Parse(); return lightCheck; } }
+
+        /// <summary>
+        /// Measure whether a per-material render queue orders the submeshes of one renderer
+        /// (-wmvQueueProof).
+        ///
+        /// The transparent draw order this builder applies is a claim about the engine, not about
+        /// WoW: the model is ONE renderer, so ranking its blended batches means giving each
+        /// batch's material its own queue value and trusting Unity to draw them in that sequence
+        /// rather than in submesh order. That trust is checkable, and a claim that can be measured
+        /// should not be inferred. The check itself lives in WmvMain.ReportQueueOrder.
+        /// </summary>
+        public static bool QueueProof { get { Parse(); return queueProof; } }
 
         /// <summary>
         /// Which preview light rig the viewport draws with (-wmvRig=N), for a visual A/B:
@@ -562,6 +606,7 @@ public static class WmvModelBuilder
         // Keyed by slot AND by whether the alpha channel was discarded, because the same slot
         // can feed an opaque batch (alpha thrown away) and a blended one (alpha kept).
         var textureCache = new Dictionary<int, Texture2D>();
+        var drawOrder = new List<WmvDrawOrderKey>();
         var triangleSets = new List<int[]>();
         var submeshGeosets = new List<int>();
         int totalTriangles = 0, hiddenByGeoset = 0;
@@ -641,16 +686,24 @@ public static class WmvModelBuilder
                                mode != M2BlendMode.Opaque;
             bool dropAlpha = Debug_.ForceSolid || !alphaIsRead;
 
+            // Unit 0's coordinate source. Read from the same resolved vertex-shader name unit 1
+            // uses; before this it was resolved and thrown away, and unit 0 always took mesh UVs.
+            M2UvSource unit0Uv = shader.UvSource.Length > 0 ? shader.UvSource[0] : M2UvSource.TexCoord0;
+            bool unit0Env = unit0Uv == M2UvSource.Environment;
+            bool baseWrapX, baseWrapY;
+            TextureWrap(model, textureSlot, unit0Env, out baseWrapX, out baseWrapY);
             Texture2D tex = GetTexture(decodedTextures, textureCache, textures, textureSlot,
-                                       dropAlpha, false, objectName);
+                                       dropAlpha, baseWrapX, baseWrapY, objectName);
             // An environment unit is sampled by generated sphere-map coordinates, which must not
             // wrap; a unit fed by a stored UV set is a normal repeating texture. Its own alpha is
             // kept whenever the combiner reads it.
             bool unit1Env = unit1Uv == M2UvSource.Environment;
             bool unit1DropAlpha = !(plan.AlphaMode == 2 || plan.AlphaMode == 3 || plan.AlphaMode == 4 ||
                                     plan.Mode == 4);
+            bool unit1WrapX, unit1WrapY;
+            TextureWrap(model, unit1Slot, unit1Env, out unit1WrapX, out unit1WrapY);
             Texture2D unit1Tex = GetTexture(decodedTextures, textureCache, textures, unit1Slot,
-                                            unit1DropAlpha, unit1Env, objectName);
+                                            unit1DropAlpha, unit1WrapX, unit1WrapY, objectName);
 
             if (log != null)
             {
@@ -680,15 +733,80 @@ public static class WmvModelBuilder
             bindings.Add(new WmvMaterialBinding
             {
                 BaseSlot = textureSlot, EnvSlot = unit1Slot, DropAlpha = dropAlpha,
-                Unit1DropAlpha = unit1DropAlpha, Unit1Clamp = unit1Env,
+                Unit1DropAlpha = unit1DropAlpha,
+                BaseWrapX = baseWrapX, BaseWrapY = baseWrapY,
+                Unit1WrapX = unit1WrapX, Unit1WrapY = unit1WrapY,
             });
-            materials.Add(CreateMaterial(mat, mode, plan, unit1Uv, tex, unit1Tex,
+            if (log != null && (unit0Env || baseWrapX || baseWrapY || unit1WrapX || unit1WrapY))
+                log(string.Format("batch: submesh {0} texture addressing -- unit 0 {1} ({2}), " +
+                                  "unit 1 {3}", batch.SubmeshIndex,
+                                  unit0Env ? "sphere map, clamped" : (baseWrapX ? "repeat X" : "clamp X") + "/" + (baseWrapY ? "repeat Y" : "clamp Y"),
+                                  unit0Uv, unit1Slot < 0 ? "-" : (unit1Env ? "sphere map, clamped"
+                                      : (unit1WrapX ? "repeat X" : "clamp X") + "/" + (unit1WrapY ? "repeat Y" : "clamp Y"))));
+            // The keys the legacy sorts its passes on, kept so the same order can be reproduced
+            // after the loop. specialTex mirrors the legacy's own mapping: a plain file texture is
+            // -1, anything database-resolved keeps its type number.
+            int specialTex = (textureSlot >= 0 && textureSlot < model.Textures.Length &&
+                              model.Textures[textureSlot].Type != 0)
+                             ? (int)model.Textures[textureSlot].Type : -1;
+            drawOrder.Add(new WmvDrawOrderKey
+            {
+                Material = materials.Count, Blend = (int)mode,
+                Submesh = batch.SubmeshIndex, SpecialTex = specialTex, Built = drawOrder.Count,
+            });
+            materials.Add(CreateMaterial(mat, mode, plan, unit0Uv, unit1Uv, tex, unit1Tex,
                                          objectName + "_mat" + materials.Count, log));
         }
 
         if (hiddenCount > 0 && !drawHidden && log != null)
             log(string.Format("{0} of {1} batch(es) hidden at rest -- pass -wmvShowHidden to draw them",
                               hiddenCount, skin.Batches.Length));
+
+        // ---- transparent draw order ---------------------------------------------------------
+        // The whole model is ONE renderer with one submesh per batch, so nothing about the mesh
+        // decides the order the blended ones reach the frame buffer: within a render queue they
+        // are drawn in submesh order, which is the order the skin happens to list them. The legacy
+        // viewport instead sorts every pass by blend mode, then geoset, then texture type. Giving
+        // each transparent material its own queue value in that order reproduces the legacy's
+        // sequence without touching the mesh, the materials' blend state, or the architecture.
+        //
+        // Only modes 2..7 are ranked: opaque and alpha-key already sit in earlier queues and must
+        // stay there. The rank is bounded so it can never reach the next queue band.
+        if (materials.Count > 0)
+        {
+            var ranked = new List<WmvDrawOrderKey>();
+            for (int i = 0; i < drawOrder.Count; i++)
+                if (drawOrder[i].Blend >= 2)
+                    ranked.Add(drawOrder[i]);
+            // A total order: every key compared, and the build position last, so the result is the
+            // same on every run and on every machine.
+            ranked.Sort(delegate(WmvDrawOrderKey a, WmvDrawOrderKey b)
+            {
+                if (a.Blend != b.Blend) return a.Blend.CompareTo(b.Blend);
+                if (a.Submesh != b.Submesh) return a.Submesh.CompareTo(b.Submesh);
+                if (a.SpecialTex != b.SpecialTex) return a.SpecialTex.CompareTo(b.SpecialTex);
+                return a.Built.CompareTo(b.Built);
+            });
+            int transparentQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+            for (int r = 0; r < ranked.Count; r++)
+            {
+                Material m = materials[ranked[r].Material];
+                if (m != null)
+                    m.renderQueue = transparentQueue + Mathf.Min(r, 899);
+            }
+            if (log != null && ranked.Count > 1)
+            {
+                string order = "";
+                for (int r = 0; r < ranked.Count && r < 12; r++)
+                    order += (r > 0 ? " " : "") + "submesh" + ranked[r].Submesh +
+                             "/blend" + ranked[r].Blend;
+                log(string.Format("draw order: {0} transparent batch(es) ranked by blend mode then " +
+                                  "submesh then texture type, queues {1}..{2} -- {3}{4}",
+                                  ranked.Count, transparentQueue,
+                                  transparentQueue + Mathf.Min(ranked.Count - 1, 899), order,
+                                  ranked.Count > 12 ? " ..." : ""));
+            }
+        }
 
         mesh.subMeshCount = triangleSets.Count;
         for (int i = 0; i < triangleSets.Count; i++)
@@ -1136,7 +1254,8 @@ public static class WmvModelBuilder
                 continue;
             WmvMaterialBinding b = runtime.Bindings[i];
 
-            Texture2D tex = GetTexture(decodedTextures, cache, fresh, b.BaseSlot, b.DropAlpha, false, objectName);
+            Texture2D tex = GetTexture(decodedTextures, cache, fresh, b.BaseSlot, b.DropAlpha,
+                                       b.BaseWrapX, b.BaseWrapY, objectName);
             if (tex != null && !Debug_.MatColors)
                 m.mainTexture = tex;
 
@@ -1145,7 +1264,7 @@ public static class WmvModelBuilder
             if (b.EnvSlot >= 0 && m.HasProperty(CombinerModeProperty))
             {
                 Texture2D unit1 = GetTexture(decodedTextures, cache, fresh, b.EnvSlot,
-                                             b.Unit1DropAlpha, b.Unit1Clamp, objectName);
+                                             b.Unit1DropAlpha, b.Unit1WrapX, b.Unit1WrapY, objectName);
                 if (unit1 != null && !Debug_.MatColors)
                     m.SetTexture(SecondTexProperty, unit1);
             }
@@ -1468,7 +1587,7 @@ public static class WmvModelBuilder
     /// </summary>
     static Texture2D GetTexture(Dictionary<int, BlpImage> decodedTextures,
                                 Dictionary<int, Texture2D> cache, List<Texture2D> owned,
-                                int slot, bool dropAlpha, bool clamp, string objectName)
+                                int slot, bool dropAlpha, bool wrapX, bool wrapY, string objectName)
     {
         if (slot < 0 || decodedTextures == null)
             return null;
@@ -1476,18 +1595,41 @@ public static class WmvModelBuilder
         if (!decodedTextures.TryGetValue(slot, out decoded) || decoded == null)
             return null;
 
-        int key = slot * 4 + (dropAlpha ? 2 : 0) + (clamp ? 1 : 0);
+        // The cache key carries the address mode as well, because the same M2 slot can feed one
+        // batch that repeats it and another that clamps it. Keyed on the alpha treatment alone,
+        // whichever batch was built first would silently decide the wrap for both.
+        int key = slot * 8 + (dropAlpha ? 4 : 0) + (wrapX ? 2 : 0) + (wrapY ? 1 : 0);
         Texture2D tex;
         if (cache.TryGetValue(key, out tex))
             return tex;
 
         tex = CreateTexture(decoded, objectName + "_tex" + slot + (dropAlpha ? "_opaque" : ""),
                             dropAlpha);
-        if (clamp)
-            tex.wrapMode = TextureWrapMode.Clamp;
+        // Per axis, from the texture's own flags: the legacy viewport sets GL_REPEAT on the axis
+        // whose bit is set and restores GL_CLAMP_TO_EDGE otherwise
+        // (Source/games/wow/ModelRenderPass.cpp:537-540 and :324-328), reading the same two bits
+        // (Source/games/wow/WoWModel.cpp:1836-1837, TEXTURE_WRAPX = 1, TEXTURE_WRAPY = 2).
+        tex.wrapModeU = wrapX ? TextureWrapMode.Repeat : TextureWrapMode.Clamp;
+        tex.wrapModeV = wrapY ? TextureWrapMode.Repeat : TextureWrapMode.Clamp;
         cache[key] = tex;
         owned.Add(tex);
         return tex;
+    }
+
+    /// <summary>
+    /// How one texture unit should address outside 0..1.
+    ///
+    /// From the texture's own two flag bits, except for a unit fed by the generated sphere map:
+    /// that coordinate is not a stored UV set and must never wrap, whatever the texture says,
+    /// or the reflection tiles at the silhouette.
+    /// </summary>
+    static void TextureWrap(M2ParsedModel model, int slot, bool env, out bool wrapX, out bool wrapY)
+    {
+        wrapX = wrapY = false;
+        if (env || slot < 0 || model == null || slot >= model.Textures.Length)
+            return;
+        wrapX = model.Textures[slot].WrapX;
+        wrapY = model.Textures[slot].WrapY;
     }
 
     /// <summary>
@@ -1560,7 +1702,8 @@ public static class WmvModelBuilder
     /// for exactly how much of one it is.
     /// </summary>
     static Material CreateMaterial(M2MaterialDef def, M2BlendMode mode, CombinerPlan plan,
-                                   M2UvSource unit1Uv, Texture2D tex, Texture2D unit1Tex,
+                                   M2UvSource unit0Uv, M2UvSource unit1Uv,
+                                   Texture2D tex, Texture2D unit1Tex,
                                    string name, Action<string> log)
     {
         var shader = FindRenderShader(log);
@@ -1583,14 +1726,48 @@ public static class WmvModelBuilder
         {
             if (combining) m.SetTexture(SecondTexProperty, unit1Tex);
             m.SetFloat(CombinerModeProperty, combining ? plan.Mode : 0);
-            m.SetFloat("_AlphaMode", combining ? plan.AlphaMode : (plan.AlphaMode == 1 ? 1 : 0));
+            // ALPHA-KEY KEYS ON ITS OWN TEXTURE, whatever combiner it resolved to.
+            //
+            // Without the second clause an alpha-keyed batch whose combiner yields alpha mode 0 --
+            // Combiners_Opaque, which is exactly what a cutout batch normally carries, since the
+            // key comes from the blend mode and not from the combiner -- writes _AlphaMode 0. The
+            // shader's alpha then keeps its 1.0 default and the clip can never fire, so hair
+            // cards, fur flaps and foliage draw as opaque rectangles and cast matching shadows.
+            // The texture's alpha was there all along: alphaIsRead keeps it for every non-opaque
+            // blend mode.
+            //
+            // Confined to the !combining arm ON PURPOSE. That arm is the set of batches the
+            // legacy viewport sends to its fixed-function path, where it keys unconditionally on
+            // the base texture's alpha. The combining arm keeps the plan's own value, because
+            // several two-unit combiners deliberately do not discard, and on those the base
+            // texture's alpha is a reflection mask rather than transparency -- forcing a key
+            // there would punch holes in creature skins.
+            m.SetFloat("_AlphaMode", combining
+                ? plan.AlphaMode
+                : ((plan.AlphaMode == 1 || mode == M2BlendMode.AlphaKey) ? 1 : 0));
             m.SetFloat("_AlphaScale", combining ? plan.AlphaScale : 1f);
             m.SetFloat("_Unit1UV", (float)(int)unit1Uv);
+            m.SetFloat("_Unit0UV", (float)(int)unit0Uv);
         }
 
         string treatedAs;
         // The legacy combiner keys at 128/255, not at a rounded half.
         ApplyBlendMode(m, mode, def.DepthWriteDisabled, 128f / 255f, out treatedAs);
+
+        // THE UNLIT RENDER FLAG, honoured at last.
+        //
+        // An unlit material is light the surface EMITS, not light it receives: an eye, a rune, a
+        // lantern flame, a spirit's body. The flag has been parsed since the parser was written
+        // and read by nothing, so such a batch went through the preview rig and shaded down to
+        // its ambient floor -- a self-lit thing rendered as a dark painted patch. Additive
+        // batches already took the emissive path; this adds the other half of the legacy's own
+        // definition, which disables lighting for exactly these passes.
+        //
+        // It must come AFTER ApplyBlendMode, which writes _Emissive unconditionally and would
+        // otherwise overwrite this with 0. It changes no rig constant: _Emissive is the existing
+        // bypass, and it is already gated so the legacy A/B rig is untouched.
+        if (def.Unlit && m.HasProperty("_Emissive"))
+            m.SetFloat("_Emissive", 1f);
 
         // Only the model's own flag may disable culling; nothing here turns it off globally.
         if (m.HasProperty("_Cull"))
@@ -1623,12 +1800,19 @@ public static class WmvModelBuilder
             "material '{0}': shader '{1}' (shader default queue {2}) -> treated as {3}; " +
             "renderQueue {4} RenderType '{5}' _Mode {6} _Surface {7} _AlphaClip {8} _SrcBlend {9} " +
             "_DstBlend {10} _ZWrite {11} _Cull {12} _CombinerMode {13} keywords [{14}]; " +
-            "WoW blend {15} depthWriteOff {16} twoSided {17}",
+            // The three surface-state values this stage decides. Without them in the log a run
+            // cannot say whether an alpha-key batch can actually clip, whether an unlit batch
+            // took the emissive path, or which coordinate unit 0 sampled -- and "the numbers did
+            // not move" is then indistinguishable from "the fix never reached the material".
+            "_AlphaMode {18} _Emissive {19} _Unit0UV {20} _Unit1UV {21}; " +
+            "WoW blend {15} depthWriteOff {16} twoSided {17} unlit {22}",
             m.name, s != null ? s.name : "<none>", s != null ? s.renderQueue : -1, treatedAs,
             m.renderQueue, m.GetTag("RenderType", false, "<unset>"),
             Prop(m, "_Mode"), Prop(m, "_Surface"), Prop(m, "_AlphaClip"), Prop(m, "_SrcBlend"),
             Prop(m, "_DstBlend"), Prop(m, "_ZWrite"), Prop(m, "_Cull"), Prop(m, CombinerModeProperty),
-            string.Join(",", m.shaderKeywords), mode, def.DepthWriteDisabled, def.TwoSided));
+            string.Join(",", m.shaderKeywords), mode, def.DepthWriteDisabled, def.TwoSided,
+            Prop(m, "_AlphaMode"), Prop(m, "_Emissive"), Prop(m, "_Unit0UV"), Prop(m, "_Unit1UV"),
+            def.Unlit));
 
         if (!shaderCanRenderOpaque)
             log("material '" + m.name + "': the resolved shader bakes blending, depth and culling " +


### PR DESCRIPTION
Five base-surface divergences, fixed before any animated-material or effects work, because each of them would otherwise be debugged twice: once as itself and once as a glow, a particle or a UV scroll that looked wrong for reasons that had nothing to do with animation.

Alpha-key cutout could not discard on the commonest cutout batch. A single-texture material whose combiner resolves to alpha mode 0 -- Combiners_Opaque, which is exactly what a cutout batch carries, since the key comes from the blend mode and not the combiner -- was written _AlphaMode 0, so the shader's alpha kept its 1.0 default and the clip could never fire. The texture's alpha was present the whole time. The fix is confined to the non-combining arm, which is the set the legacy viewport routes to its fixed-function path where it keys unconditionally on the base texture's alpha; the combining arm is untouched, because several two-unit combiners deliberately do not discard and there the base alpha is a reflection mask, not transparency.

The UNLIT render flag is honoured. It has been parsed since the parser was written and read by nothing, so a self-lit surface went through the preview rig. It now takes the existing _Emissive path that additive batches already take. No rig constant is touched and the legacy A/B path is untouched.

Texture wrap comes from the texture's own flags instead of a hardcoded default, per axis, matching the legacy exactly: repeat on the axis whose bit is set, clamp otherwise (ModelRenderPass.cpp:537-540 and :324-328, reading TEXTURE_WRAPX = 1 and TEXTURE_WRAPY = 2 at WoWModel.cpp:1836-1837). No mirror mode is invented; neither tree has one.

Texture unit 0 can reach the sphere map. Four vertex programs put the environment on unit 0, and unit 0 always sampled mesh UVs, so a reflection was pinned to the surface. This is the one change that required the shader: unit 0's coordinate source had to become selectable. It defaults to today's behaviour, so anything that does not set it is unaffected.

Transparent batches draw in a deterministic order. The model is one renderer whose submeshes share a queue, so order was skin order; the legacy sorts every pass by blend mode, then geoset, then texture type (WoWModel.cpp:2011-2018). Transparent materials are now ranked on those same keys with the build position as a final tiebreaker. No priorityPlane, no architecture change.

Validation models were found by loading 47 candidates and reading what the renderer reported, not chosen by name. Each fix is proven to reach the material it targets: ethereal2_m 10 of 10 alpha-key materials can now clip and 52 of 52 unlit ones took the emissive path; deathwingdungeon 3 of 3 and 1 of 1; progenitorbotgiant 5 of 5 and 9 of 9; voidcreeper 2 materials route unit 0 to the sphere map; voidwraithsoldier 41 of 41 unlit.

How much the frame moves depends on how much of the DRAWN surface those materials cover: voidwraithsoldier moves from 0.1908 to 0.1516 mean, and its percentiles show the signature of the rig being removed rather than a brightness change -- p05 rises 0.0155 to 0.0266 while p95 falls 0.8784 to 0.8745, darks lifted and brights reduced. ethereal2_m and progenitorbotgiant are unchanged because they draw 21 of 91 and 15 of 24 submeshes and their affected materials are among the hidden ones. chicken2, horse3, agronn and drustvarbeastman are byte-identical.

Parser suite 152 passing, type-check clean across four input configurations, headless regression 14 of 14 before and after. The per-material log now reports _AlphaMode, _Emissive, _Unit0UV and the unlit flag, because "the numbers did not move" is otherwise indistinguishable from "the fix never reached the material".