### PR TITLE
Fix item component geoset state in Unity renderer

### DIFF
--- a/Source/games/wow/WoWModel.h
+++ b/Source/games/wow/WoWModel.h
@@ -295,6 +295,12 @@ public:
   // @TODO use geoset id instead of geoset index in vector
   void showGeoset(uint geosetindex, bool value);  
   void hideAllGeosets();
+  // How many of geosets[] this model OWNS. refreshMerging rebuilds geosets[] from rawGeosets and
+  // then appends a COPY of every merged model's geosets after them, so entries at or past this
+  // index describe geometry belonging to another model. The same count is already the stop
+  // criterion in setGeosetGroupDisplay, setCreatureGeosetData and refreshSkinnedModels; this
+  // exposes it so code outside the class can respect the same boundary.
+  size_t ownGeosetCount() const { return rawGeosets.size(); }
   bool isGeosetDisplayed(uint geosetindex);
   void setGeosetGroupDisplay(CharGeosets group, int val);
   void setGeosetDisplayById(int geosetId, bool display); // toggle the exact geoset id(s); never id 0

--- a/Source/wowmodelviewer/UnityAssetAccess.cpp
+++ b/Source/wowmodelviewer/UnityAssetAccess.cpp
@@ -223,12 +223,42 @@ bool UnityAssetAccess::selectedModelGeosets(int m2FileDataID, std::vector<int> &
   out.clear();
   if (m2FileDataID <= 0 || !hasActiveClient())
     return false;
-  if (!g_modelViewer || !g_modelViewer->animControl || !g_selModel || !g_selModel->gamefile)
+  if (!g_selModel || !g_selModel->gamefile)
     return false;
   if ((int)g_selModel->gamefile->fileDataId() != m2FileDataID)
     return false;   // a question about some other model; we only know about the displayed one
 
-  return g_modelViewer->animControl->selectedSkinGeosets(out);
+  // THE MODEL'S OWN STATE, not one of the inputs to it.
+  //
+  // This used to report the selected skin group's creatureGeosetData, which is the input the
+  // CREATURE path happens to use. Every path -- creature, item, plain default -- lands in the same
+  // place: each ModelGeosetHD's display flag, set by WoWModel::setCreatureGeosetData for a
+  // creature, by WoWItem/ModelViewer for an item component, and by the parse-time default
+  // otherwise. Reading the flags reports what the application actually decided instead of one of
+  // the reasons it decided it, so an item component's geosets survive to the renderer while the
+  // creature answer is unchanged (setCreatureGeosetData writes exactly the named set into these
+  // flags: "showGeoset(i, cgd.count(id) > 0)").
+  //
+  // ONLY THE GEOSETS THIS MODEL OWNS.
+  //
+  // A character has other models merged into it, and refreshMerging appends a copy of each merged
+  // model's geosets to geosets[] after the root's own. Reporting those would be wrong twice over:
+  // they describe geometry the renderer is not drawing, and an appended id can be the SAME NUMBER
+  // as one of the root's -- geoset numbering is per model, not global -- so a merged copy that is
+  // visible could switch on a root submesh the character has deliberately hidden. Stopping at
+  // ownGeosetCount() is the boundary the model class already uses everywhere else for this exact
+  // reason.
+  const size_t owned = g_selModel->ownGeosetCount();
+  for (size_t i = 0; i < owned && i < g_selModel->geosets.size(); i++)
+  {
+    const int id = g_selModel->geosets[i]->id;
+    // Submesh id 0 is drawn by every rule on both sides; listing it would say nothing.
+    if (id != 0 && g_selModel->geosets[i]->display)
+      out.push_back(id);
+  }
+  std::sort(out.begin(), out.end());
+  out.erase(std::unique(out.begin(), out.end()), out.end());
+  return true;   // the displayed model always has an answer, even when it is "none"
 }
 
 bool UnityAssetAccess::resolveModelTextures(int m2FileDataID, std::vector<ModelTexture> & out, QString & error)

--- a/Source/wowmodelviewer/UnityAssetAccess.h
+++ b/Source/wowmodelviewer/UnityAssetAccess.h
@@ -71,12 +71,13 @@ public:
   // "database" / "selection" / "convention" -- the wire spelling of ModelTexture::Source.
   static const char * sourceName(ModelTexture::Source source);
 
-  // The geosets the displayed skin switches on, as the numbers the model's own submeshes are
-  // identified by. A creature display can differ from another by GEOMETRY rather than texture,
-  // and the renderer cannot work that out for itself: only the app knows which display is
-  // selected. An empty list with a true return means "this display switches none on", which is
-  // not the same as not knowing -- see WoWModel::setCreatureGeosetData, where a submesh is drawn
-  // when its id is 0 or appears in this set. False when there is no selection to report.
+  // The non-zero geosets the displayed model is currently showing, as the numbers its own
+  // submeshes are identified by. Read from the model's own per-geoset display flags, which is
+  // where every rule lands: a creature display that differs by GEOMETRY rather than texture
+  // (WoWModel::setCreatureGeosetData), an item component's state, or the parse-time default of
+  // "submesh id 0 only". The renderer cannot work any of that out for itself. An empty list with
+  // a true return means "the model is showing none of them", which is not the same as not
+  // knowing; false means there is no displayed model to ask about.
   static bool selectedModelGeosets(int m2FileDataID, std::vector<int> & out);
 
   // Resolve the texture(s) of a model that the M2 itself does not name.

--- a/Source/wowmodelviewer/app.cpp
+++ b/Source/wowmodelviewer/app.cpp
@@ -871,7 +871,7 @@ bool WowModelViewApp::OnInit()
     QString a = QString::fromWCharArray(argv[ai]);
     if (a == "-m" || a == "-mo" || a == "-armory" || a == "-npc" || a == "-fbxexport" ||
         a == "-animdump" || a == "-fbxinspect" || a == "-dbfromfile" || a == "-dumptex" ||
-        a == "-m2inspect" || a == "-mpq" || a.endsWith(".chr"))
+        a == "-m2inspect" || a == "-mpq" || a == "-item" || a.endsWith(".chr"))
     {
       earlyHeadless = true;
       break;
@@ -1021,6 +1021,7 @@ bool WowModelViewApp::OnInit()
   // Command arguments
   QString cmd;
   QString snapModelPath; // -mo: defer load+screenshot until after LoadWoW
+  int snapItemId = 0;    // -item: defer an item/display-context load until after LoadWoW
   QString snapArmoryUrl; // -armory <url>: headless import + screenshot (test harness)
   QString snapNpcArg;    // -npc <id|id:displayId>: headless NPC load + screenshot (test harness)
   QString fbxExportPath; // -fbxexport <out.fbx>: headless FBX export of the -mo model (test harness)
@@ -1068,6 +1069,13 @@ bool WowModelViewApp::OnInit()
         // must be loaded before a model can be resolved/composed.
         snapModelPath = fn;
       }
+    }
+    else if (cmd == "-item") {
+      // Headless item load: "-item <itemID>" shows the item through the same ModelViewer::LoadItem
+      // the item-selection dialog calls, so the item/display-context path -- which resolves the
+      // item's display, its component model and its component geoset state -- can be captured and
+      // regressed. Composes with -unityipctest exactly as -mo does.
+      if (i + 1 < argc) { i++; snapItemId = QString::fromWCharArray(argv[i]).toInt(); }
     }
     else if (cmd == "-mpq") {
       // Headless legacy-MPQ load: "-mpq <DataFolder> [locale] -mo <path\model.m2>" opens a
@@ -1222,7 +1230,7 @@ bool WowModelViewApp::OnInit()
   for (int i = 1; i < argc; i++)
   {
     QString a = QString::fromWCharArray(argv[i]);
-    if (a == "-m" || a == "-mo" || a == "-armory" || a == "-npc" || a == "-fbxexport" || a == "-animdump" || a == "-fbxinspect" || a == "-dbfromfile" || a == "-dumptex" || a == "-m2inspect" || a == "-mpq" || a.endsWith(".chr"))
+    if (a == "-m" || a == "-mo" || a == "-armory" || a == "-npc" || a == "-fbxexport" || a == "-animdump" || a == "-fbxinspect" || a == "-dbfromfile" || a == "-dumptex" || a == "-m2inspect" || a == "-mpq" || a == "-item" || a.endsWith(".chr"))
     {
       headlessLoad = true;
       break;
@@ -1268,6 +1276,18 @@ bool WowModelViewApp::OnInit()
     {
       doHeadlessDumpTexture(dumpTexFileDataId, dumpTexOutPath);
       return false; // forensic dump done -> exit
+    }
+
+    if (snapItemId > 0)
+    {
+      // The item path decides the display, the component model, its skin and its component
+      // geoset state. Everything after this is the same tail -mo uses.
+      frame->LoadItem((unsigned int)snapItemId);
+      if (unityIpcTest)
+        doHeadlessUnityIpcTest(frame);
+      QString out = QString("ss_item_%1.png").arg(snapItemId);
+      frame->canvas->Screenshot(out.toStdWString());
+      return false; // headless capture done -> exit
     }
 
     if (!snapModelPath.isEmpty())

--- a/Source/wowmodelviewer/modelviewer.cpp
+++ b/Source/wowmodelviewer/modelviewer.cpp
@@ -1295,6 +1295,60 @@ void ModelViewer::LoadNPCByDisplay(int npcId, int displayId, int type, const QSt
     m_exportNpcDisplayId = displayId;
 }
 
+// The component-geoset state an item's own model should be shown with.
+//
+// Opening an item here loads its component M2 as a plain model, and a plain model comes up in the
+// parse-time default: submesh id 0 only (WoWModel's "hdgeo->display = (hdgeo->id == 0)"). That
+// default is right for a raw M2 opened on its own. It is NOT what the item looks like, and the
+// application already knows better -- WoWItem decides a component's geosets when the item is
+// equipped, and for the slots below it decides "all of them" (WoWItem::updateItemModel, "for (uint
+// i = 0; i < m->geosets.size(); i++) m->showGeoset(i, true);"). Drakestalker's Trophy Pauldrons are
+// the worked example: their upper flame plumes are submesh 2, geoset 2602, and the default hides
+// them here while the equipped item shows them.
+//
+// WHICH SLOTS. ModelResourcesID1 -- the model this function loads -- is the ATTACHED component for
+// head, shoulder, belt (the buckle) and both hands; those take WoWItem's attachment path and its
+// all-on rule, and that is what is reproduced. For boots, trousers, shirt, chest, gloves and cape
+// ModelResourcesID1 is instead the MERGED component: WoWItem hides everything and re-opens one
+// variant per geoset group from ItemDisplayInfo.AttachmentGeosetGroup, against a model merged into
+// the character. That selection has no meaning for a component shown on its own out of that
+// context, so those slots are deliberately left at the default rather than guessed at.
+void ModelViewer::applyItemComponentGeosets(unsigned int itemId)
+{
+  WoWModel * m = const_cast<WoWModel *>(canvas ? canvas->model() : 0);
+  if (!m)
+    return;
+
+  sqlResult r = GAMEDATABASE.sqlQuery(
+      QString("SELECT InventoryType FROM Item WHERE ID = %1").arg(itemId));
+  if (!r.valid || r.empty())
+    return;
+  const int invType = r.values[0][0].toInt();
+
+  // The slot this inventory type belongs to, through the application's own mapping rather than a
+  // second table of numbers kept in step by hand.
+  int slot = -1;
+  for (int s = 0; s < NUM_CHAR_SLOTS; s++)
+  {
+    if (correctType(invType, s)) { slot = s; break; }
+  }
+
+  const bool attachedComponent = (slot == CS_HEAD || slot == CS_SHOULDER || slot == CS_BELT ||
+                                  slot == CS_HAND_LEFT || slot == CS_HAND_RIGHT);
+  if (!attachedComponent)
+  {
+    LOG_INFO << "[itemgeoset] item" << itemId << "inventory type" << invType
+             << "-- its first component is merged into the character, not attached; left at the"
+             << "default geoset state";
+    return;
+  }
+
+  for (uint i = 0; i < m->geosets.size(); i++)
+    m->showGeoset(i, true);
+  LOG_INFO << "[itemgeoset] item" << itemId << "slot" << slot << ": showed all"
+           << (int)m->geosets.size() << "component geoset(s), as the equipped attachment path does";
+}
+
 void ModelViewer::LoadItem(unsigned int id)
 {
   canvas->clearAttachments();
@@ -1320,6 +1374,7 @@ void ModelViewer::LoadItem(unsigned int id)
       if (itemInfos.values[0][0] != "" && itemInfos.values[0][1] != "")
       {
         LoadModel(GAMEDIRECTORY.getFile(itemInfos.values[0][0].toInt()));
+        applyItemComponentGeosets(id);
         TextureGroup grp;
         grp.base = TEXTURE_OBJECT_SKIN;
         grp.count = 1;

--- a/Source/wowmodelviewer/modelviewer.h
+++ b/Source/wowmodelviewer/modelviewer.h
@@ -135,6 +135,8 @@ public:
 
   void LoadModel(GameFile * f);
   void LoadItem(unsigned int displayID);
+  // The component-geoset state an item's own model should be shown with. See the definition.
+  void applyItemComponentGeosets(unsigned int itemId);
   void LoadNPC(unsigned int modelid);
   // Register an NPC in the in-memory DB (if not already present) and load it. Shared by the
   // "Import NPC from URL" dialog flow and the -npc headless test harness.

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
@@ -94,12 +94,96 @@ public static class WmvLifecycleSelfTest
         rt.Dispose();
     }
 
+    static int DrawnCount(WmvRuntimeModel rt)
+    {
+        int n = 0;
+        for (int i = 0; i < rt.SubmeshIndices.Length; i++)
+            if (WmvModelBuilder.GeosetVisibleFor(rt, i)) n++;
+        return n;
+    }
+
+    /// <summary>
+    /// WHICH SUBMESHES A GEOSET SELECTION DRAWS, and what changing it costs.
+    ///
+    /// Two things are checked that nothing checked before. First the rule itself: submesh id 0 is
+    /// always drawn, any other id only when the reported selection names it, and no selection at
+    /// all means id 0 alone -- which is why a component opened as a raw model shows less than the
+    /// same component shown as an item. Second, and the reason this lives in the runtime suite
+    /// rather than the parser one: changing the selection must not rebuild anything. A geoset
+    /// change is an index-buffer switch; if it started recreating the mesh, materials or textures
+    /// the model would flicker and every per-model diagnostic would reset.
+    /// </summary>
+    static void GeosetTests(Action<string> log)
+    {
+        // A Drakestalker-shaped component: two submeshes at id 0 and one alternative at 2602.
+        byte[] m2 = M2Synthetic.GeosetModel(3);
+        byte[] sk = M2Synthetic.GeosetSkin(new[] { 0, 0, 2602 });
+        M2ParsedModel model = M2Parser.Parse(m2, 0);
+        M2ParsedSkin skin = M2SkinParser.Parse(sk);
+
+        WmvRuntimeModel raw = WmvModelBuilder.Build(model, skin, new Dictionary<int, BlpImage>(),
+                                                    "GeosetTestRaw", log, null);
+        Check(raw != null, "geoset: component built with no selection reported", log);
+        if (raw == null) return;
+        Check(DrawnCount(raw) == 2, "geoset: raw component draws the two id-0 submeshes only", log);
+        Check(!WmvModelBuilder.GeosetVisibleFor(raw, 2), "geoset: raw component withholds 2602", log);
+
+        // The same component with the state an item would report for it.
+        var itemSet = new HashSet<int>(new[] { 2602 });
+        WmvRuntimeModel item = WmvModelBuilder.Build(model, skin, new Dictionary<int, BlpImage>(),
+                                                     "GeosetTestItem", log, itemSet);
+        Check(item != null, "geoset: component built with the item's selection", log);
+        if (item == null) { raw.Dispose(); return; }
+        Check(DrawnCount(item) == 3, "geoset: the item's selection draws all three submeshes", log);
+        Check(WmvModelBuilder.GeosetVisibleFor(item, 2), "geoset: 2602 drawn when the item names it", log);
+
+        // Alternatives in one group: exactly one of them draws, and changing which does not rebuild.
+        byte[] am2 = M2Synthetic.GeosetModel(5);
+        byte[] askin = M2Synthetic.GeosetSkin(new[] { 0, 2701, 2702, 2703, 2704 });
+        M2ParsedModel amodel = M2Parser.Parse(am2, 0);
+        M2ParsedSkin askn = M2SkinParser.Parse(askin);
+        WmvRuntimeModel alt = WmvModelBuilder.Build(amodel, askn, new Dictionary<int, BlpImage>(),
+                                                    "GeosetTestAlt", log, new HashSet<int>(new[] { 2702 }));
+        Check(alt != null, "geoset: alternatives model built", log);
+        if (alt == null) { raw.Dispose(); item.Dispose(); return; }
+        Check(DrawnCount(alt) == 2, "geoset: id 0 plus exactly one alternative draw", log);
+        Check(WmvModelBuilder.GeosetVisibleFor(alt, 2), "geoset: the selected alternative 2702 draws", log);
+        Check(!WmvModelBuilder.GeosetVisibleFor(alt, 1) && !WmvModelBuilder.GeosetVisibleFor(alt, 3) &&
+              !WmvModelBuilder.GeosetVisibleFor(alt, 4), "geoset: its three siblings do not draw", log);
+
+        // Change the selection. Nothing may be recreated.
+        var meshBefore = alt.Mesh;
+        var matsBefore = alt.Materials;
+        var mat0Before = (alt.Materials != null && alt.Materials.Length > 0) ? alt.Materials[0] : null;
+        WmvModelBuilder.ApplyGeosets(alt, new HashSet<int>(new[] { 2704 }), log);
+        Check(!WmvModelBuilder.GeosetVisibleFor(alt, 2), "geoset: 2702 withheld after the change", log);
+        Check(WmvModelBuilder.GeosetVisibleFor(alt, 4), "geoset: 2704 restored after the change", log);
+        Check(DrawnCount(alt) == 2, "geoset: still exactly one alternative after the change", log);
+        Check(ReferenceEquals(alt.Mesh, meshBefore), "geoset: the mesh was NOT recreated", log);
+        Check(ReferenceEquals(alt.Materials, matsBefore), "geoset: the material array was NOT recreated", log);
+        Check(alt.Materials != null && alt.Materials.Length > 0 &&
+              ReferenceEquals(alt.Materials[0], mat0Before), "geoset: material 0 was NOT recreated", log);
+
+        // An explicitly empty selection means id 0 alone, and agrees with no selection at all.
+        WmvModelBuilder.ApplyGeosets(alt, new HashSet<int>(), log);
+        Check(DrawnCount(alt) == 1, "geoset: an empty selection draws id 0 alone", log);
+        WmvModelBuilder.ApplyGeosets(alt, null, log);
+        Check(DrawnCount(alt) == 1, "geoset: no selection draws id 0 alone, as an empty one does", log);
+
+        // The diagnostic override must be inert unless it was passed.
+        Check(WmvModelBuilder.Debug_.OnlySubmeshes == null,
+              "geoset: -wmvOnlySubmesh is unset, so the geoset rule alone decides", log);
+
+        raw.Dispose(); item.Dispose(); alt.Dispose();
+    }
+
     public static void RunAll(Action<string> log)
     {
         passed = failed = 0;
         foreach (bool skinned in new[] { false, true })
             foreach (int keyed in new[] { 1, 0 })
                 Run(skinned, keyed, log);
+        GeosetTests(log);
         log(string.Format("lifecycle-test: {0} passed, {1} failed", passed, failed));
     }
 }

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Synthetic.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Synthetic.cs
@@ -166,6 +166,96 @@ namespace Wmv.Wow
         }
 
         /// <summary>
+        /// A model with one triangle per submesh and nothing animated: the shape the geoset tests
+        /// need, where each submesh can carry its own geoset id. Same single unlit opaque material
+        /// and single texture as the transform model, so nothing but the geosets varies.
+        /// </summary>
+        public static byte[] GeosetModel(int submeshCount)
+        {
+            const int nSeq = 1;
+            int verts = submeshCount * 3;
+            int oVerts = HeaderSize;
+            int oTex = oVerts + verts * 48;
+            int oMat = oTex + 16;
+            int oTexLookup = oMat + 4;
+            int oSeqs = oTexLookup + 2;
+            int fixedEnd = oSeqs + nSeq * 64;
+
+            var f = new Image(fixedEnd);
+            byte[] b = f.B;
+            PutMagic(b, 0, "MD20");
+            PutU32(b, 0x04, 272);
+            PutU32(b, 0x1C, nSeq); PutU32(b, 0x20, (uint)oSeqs);
+            PutU16(b, oSeqs, 0);
+            PutU32(b, oSeqs + 4, 1000);
+            PutU32(b, oSeqs + 12, 0x20);
+            PutU32(b, 0x3C, (uint)verts); PutU32(b, 0x40, (uint)oVerts);
+            for (int i = 0; i < verts; i++)
+            {
+                int o = oVerts + i * 48;
+                PutF32(b, o + 0, (i % 3) == 1 ? 1f : 0f);
+                PutF32(b, o + 4, (i % 3) == 2 ? 1f : 0f);
+                PutF32(b, o + 8, i / 3);
+                PutF32(b, o + 20, 0f); PutF32(b, o + 24, 0f); PutF32(b, o + 28, 1f);
+                PutF32(b, o + 32, (i % 3) == 1 ? 1f : 0f);
+                PutF32(b, o + 36, (i % 3) == 2 ? 1f : 0f);
+            }
+            PutU32(b, 0x44, 1);
+            PutU32(b, 0x50, 1); PutU32(b, 0x54, (uint)oTex);
+            PutU32(b, oTex, 0); PutU32(b, oTex + 4, 3);
+            PutU32(b, 0x70, 1); PutU32(b, 0x74, (uint)oMat);
+            PutU16(b, oMat, 0x01);
+            PutU16(b, oMat + 2, 0);
+            PutU32(b, 0x80, 1); PutU32(b, 0x84, (uint)oTexLookup);
+            PutU16(b, oTexLookup, 0);
+            return f.Done();
+        }
+
+        /// <summary>
+        /// The matching skin: one submesh per entry of geosetIds, each one triangle, each with its
+        /// own batch. This is how a component model that carries alternatives is shaped.
+        /// </summary>
+        public static byte[] GeosetSkin(int[] geosetIds)
+        {
+            int n = geosetIds.Length;
+            const int headerSize = 0x30;
+            int vertOffset = headerSize;
+            int triOffset = vertOffset + n * 3 * 2;
+            int subOffset = triOffset + n * 3 * 2;
+            int batchOffset = subOffset + n * 48;
+            var b = new byte[batchOffset + n * 24];
+            PutMagic(b, 0, "SKIN");
+            PutU32(b, 0x04, (uint)(n * 3)); PutU32(b, 0x08, (uint)vertOffset);
+            PutU32(b, 0x0C, (uint)(n * 3)); PutU32(b, 0x10, (uint)triOffset);
+            PutU32(b, 0x14, 0); PutU32(b, 0x18, 0);
+            PutU32(b, 0x1C, (uint)n); PutU32(b, 0x20, (uint)subOffset);
+            PutU32(b, 0x24, (uint)n); PutU32(b, 0x28, (uint)batchOffset);
+            for (int i = 0; i < n * 3; i++)
+            {
+                PutU16(b, vertOffset + i * 2, (ushort)i);
+                PutU16(b, triOffset + i * 2, (ushort)i);
+            }
+            for (int s = 0; s < n; s++)
+            {
+                int o = subOffset + s * 48;
+                PutU16(b, o + 0, (ushort)geosetIds[s]);      // the geoset id
+                PutU16(b, o + 4, (ushort)(s * 3));           // vertexStart
+                PutU16(b, o + 6, 3);                         // vertexCount
+                PutU16(b, o + 8, (ushort)(s * 3));           // indexStart
+                PutU16(b, o + 10, 3);                        // indexCount
+                int bo = batchOffset + s * 24;
+                PutU16(b, bo + 4, (ushort)s);                // submesh
+                PutU16(b, bo + 8, 0xFFFF);                   // no colour entry
+                PutU16(b, bo + 14, 1);                       // one texture unit
+                PutU16(b, bo + 16, 0);
+                PutU16(b, bo + 18, 0xFFFF);
+                PutU16(b, bo + 20, 0xFFFF);
+                PutU16(b, bo + 22, 0xFFFF);
+            }
+            return b;
+        }
+
+        /// <summary>
         /// The skin for TransformSwitchModel: three vertices, one triangle, one submesh, one batch
         /// with one texture unit, no colour entry, no weight entry, transform combo 0.
         /// </summary>


### PR DESCRIPTION
Opening an item showed its component model with the geoset state of a raw file rather than the state the item has. Drakestalker's Trophy Pauldrons are the worked example: their upper flame plumes are submesh 2, geoset 2602, and the item view withheld them.

Host side only; no Unity renderer change and no protocol change.

ModelViewer::LoadItem loaded the component and applied only its texture, so the model kept WoWModel's parse-time default of "submesh id 0 only". It now also applies the component-geoset rule the equipped item applies. For the slots whose ModelResourcesID1 is an ATTACHED component -- head, shoulder, belt, both hands -- that rule is WoWItem::updateItemModel's: show every component geoset. Merged slots return early and log why; their one-variant-per-group selection is made against a model merged into a character and has no meaning for a component shown on its own, so it is not guessed at here. The slot comes from the application's own correctType() mapping, not a second table of numbers.

UnityAssetAccess::selectedModelGeosets reported the selected skin group's creatureGeosetData -- one INPUT to the decision, and the one an item never fills. It now reports the displayed model's own per-geoset display flags, which is where every rule already lands, and it reports ONLY the geosets that model owns. refreshMerging appends copies of every merged model's geosets to geosets[], and geoset numbering is per model: measured across 144 character bodies and 4287 item components, 70 ids occur in both populations and 1620 components carry at least one, so an appended visible copy could otherwise switch on a root submesh the character has hidden. WoWModel gains ownGeosetCount(), naming the boundary setGeosetGroupDisplay, setCreatureGeosetData and refreshSkinnedModels already stop at.

Creature payloads are unchanged: on chicken2, horse3, voidwraithboss, drustvarbeastman and dragonelementium the old and new accessors produce the exact same sorted non-zero id set, across empty, single, multiple and changing selections. One wire value does change and is not silently equivalent -- hasGeosets is now true for a model with no skin selector, where it used to be false. The only receiver that distinguishes them treats false as "keep what is on screen", so an explicit empty set now correctly clears a previous model's selection instead of leaving it applied.

Also adds -item <itemID>, which opens an item through the same LoadItem the item dialog calls, so this path can be captured and regressed headlessly.

Drakestalker in item context goes from 2 of 3 submeshes drawn to 3 of 3, with every changed pixel inside the region submesh 2 draws. A raw standalone load is byte-identical, and so is a merged-slot item. 19 new runtime checks cover the rule, the mutual-exclusion case and the fact that changing a selection recreates no mesh, material or texture (self-test 78 -> 97, 0 failing).