### PR TITLE
Preserve M2 HDR effect output in Unity renderer

### DIFF
--- a/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
@@ -574,15 +574,42 @@ Shader "WMV/Opaque Textured"
                 // bypass leaking into the legacy path was measurable -- a model with glow
                 // batches moved by +0.002 mean under -wmvRig=1 -- and it was also the proof
                 // that the property finally reached the material.)
+                bool rigApplied = true;
                 if (_Emissive > 0.5h && _WmvRig < 0.5)
                 {
                     lum  = 1.0h;
                     spec = 0.0h;
+                    rigApplied = false;   // no preview light in this pass -- see the roll-off below
                 }
 
                 c.rgb = c.rgb * lum + spec;
 
-                if (_WmvRig < 0.5)
+                // THE ROLL-OFF SHAPES THE PREVIEW LIGHT, SO IT RUNS WHERE THE PREVIEW LIGHT DID.
+                //
+                // It was written (125f3781, "Improve Unity M2 preview lighting") for one reason,
+                // in its own words: the rig's terms deliberately sum past 1.0 -- "the light now
+                // sums to 1.24 at full incidence and the top end is rolled off instead" -- and
+                // capping the light instead would make a white texture read grey. That is a
+                // statement about LIGHT. The emissive bypass did not exist yet; _Emissive entered
+                // the shader eleven days later (0880a08d), and until then every fragment,
+                // additive ones included, carried preview light for the curve to shape.
+                //
+                // On the emissive path there is no longer any light to shape. The bypass above
+                // assigns lum = 1 and spec = 0, so c.rgb at this point is exactly the combiner
+                // times _Color: model-authored, every rig term discarded. Running a preview-light
+                // curve over it only darkens what the model asked for -- an authored white leaves
+                // at 0.742 -- and the legacy renderer, whose material semantics these passes come
+                // from, applies no clamp or curve of its own (the OpenGL viewport saturates at the
+                // framebuffer, which is a destination artefact, and the repository's own export
+                // target exists precisely so "values above 1.0 (emissive/additive passes)
+                // survive", RenderTexture.cpp).
+                //
+                // The one argument recorded for keeping it here -- that "a stacked glow cannot run
+                // away past white" -- is about ACCUMULATION, and a per-fragment curve cannot
+                // deliver it: this shader runs before blending and cannot see what it is adding
+                // to. Stacking is bounded by the destination, as it is in the legacy viewport and
+                // in the pipeline's own tone map.
+                if (_WmvRig < 0.5 && rigApplied)
                 {
                     // SHOULDER, not a ceiling.
                     //

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
@@ -177,6 +177,73 @@ public static class WmvLifecycleSelfTest
         raw.Dispose(); item.Dispose(); alt.Dispose();
     }
 
+    /// <summary>
+    /// THE OUTPUT GATE, tested against real materials rather than against a copy of the arithmetic.
+    ///
+    /// WmvOpaque.shader skips the preview-light roll-off exactly where the preview light did not
+    /// apply, and the thing that decides that is _Emissive: the shader's bypass reads it, and the
+    /// builder writes it from the M2 blend mode (additive) or the material's own 0x01 UNLIT flag.
+    /// A fragment program cannot be run from either harness, so the curve itself is pinned as
+    /// arithmetic in the parser suite and said there to be a mirror. What CAN be tested here, in
+    /// the player, on materials the real builder produced, is the gate's INPUT -- which is the part
+    /// this branch actually changed. If _Emissive ever stopped tracking blend mode and the unlit
+    /// flag, the exemption would silently apply to the wrong passes and nothing else would notice.
+    /// </summary>
+    static void OutputGateTests(Action<string> log)
+    {
+        // EVERY M2 blend mode, so the boundary is pinned from both sides rather than sampled,
+        // plus the two cases where the material's own 0x01 UNLIT flag is what decides.
+        int[] flags  = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01 };
+        int[] blends = {    0,    1,    2,    3,    4,    5,    6,    7,    0,    4 };
+        bool[] wantEmissive =
+        {
+            false, false, false, true, true, false, false, false, true, true
+        };
+        string[] what =
+        {
+            "blend 0 opaque, not unlit -> lit, the curve applies",
+            "blend 1 alpha key -> a cut-out surface is still lit",
+            "blend 2 alpha blend -> a lit surface seen through transparency",
+            "blend 3 NoAlphaAdd (One/One) -> emissive, the curve is skipped",
+            "blend 4 Add (SrcAlpha/One) -> emissive, the curve is skipped",
+            "blend 5 modulate -> multiplies the destination, still lit",
+            "blend 6 modulate 2x -> still lit",
+            "blend 7 BlendAdd (One/OneMinusSrcAlpha) -> premultiplied, NOT in the exempt set",
+            "the 0x01 UNLIT flag makes an OPAQUE pass emissive on its own",
+            "additive AND unlit -> emissive, the two sources agree rather than fight",
+        };
+
+        byte[] m2 = M2Synthetic.MaterialModeModel(flags, blends);
+        byte[] sk = M2Synthetic.MaterialModeSkin(flags.Length);
+        M2ParsedModel model = M2Parser.Parse(m2, 0);
+        M2ParsedSkin skin = M2SkinParser.Parse(sk);
+        WmvRuntimeModel rt = WmvModelBuilder.Build(model, skin, new Dictionary<int, BlpImage>(),
+                                                   "OutputGateTest", log, null);
+        Check(rt != null, "output gate: the material-mode model built", log);
+        if (rt == null) return;
+        Check(rt.Materials != null && rt.Materials.Length == flags.Length,
+              "output gate: one material per case reached the runtime", log);
+        if (rt.Materials == null || rt.Materials.Length != flags.Length) { rt.Dispose(); return; }
+
+        for (int i = 0; i < flags.Length; i++)
+        {
+            Material m = rt.Materials[i];
+            bool has = m != null && m.HasProperty("_Emissive");
+            Check(has, "output gate: material " + i + " carries _Emissive at all", log);
+            if (!has) continue;
+            bool got = m.GetFloat("_Emissive") > 0.5f;
+            Check(got == wantEmissive[i], "output gate: " + what[i], log);
+        }
+
+        // The exemption is gated on the SHIPPED rig as well; if the legacy rig were live the
+        // curve would be skipped on the A/B baseline too and that baseline would stop meaning
+        // anything. -wmvRig defaults to 0.
+        Check(WmvModelBuilder.Debug_.Rig < 0.5f,
+              "output gate: the shipped rig is the default, so the exemption is the live path", log);
+
+        rt.Dispose();
+    }
+
     public static void RunAll(Action<string> log)
     {
         passed = failed = 0;
@@ -184,6 +251,7 @@ public static class WmvLifecycleSelfTest
             foreach (int keyed in new[] { 1, 0 })
                 Run(skinned, keyed, log);
         GeosetTests(log);
+        OutputGateTests(log);
         log(string.Format("lifecycle-test: {0} passed, {1} failed", passed, failed));
     }
 }

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Synthetic.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Synthetic.cs
@@ -212,6 +212,98 @@ namespace Wmv.Wow
         }
 
         /// <summary>
+        /// A model whose materials cover a chosen set of (render flags, blend mode) pairs, one
+        /// submesh and one batch each. It exists so the OUTPUT GATE can be tested against real
+        /// materials built by the real builder: _Emissive is what decides whether the preview-light
+        /// roll-off runs, and it is set from the blend mode (additive) or the material's 0x01 UNLIT
+        /// flag. Each pair is (flags[i], blends[i]); batch i draws submesh i against material i.
+        /// </summary>
+        public static byte[] MaterialModeModel(int[] flags, int[] blends)
+        {
+            int n = flags.Length;
+            int verts = n * 3;
+            int oVerts = HeaderSize;
+            int oTex = oVerts + verts * 48;
+            int oMat = oTex + 16;
+            int oTexLookup = oMat + n * 4;
+            int oSeqs = oTexLookup + 2;
+            int fixedEnd = oSeqs + 64;
+
+            var f = new Image(fixedEnd);
+            byte[] b = f.B;
+            PutMagic(b, 0, "MD20");
+            PutU32(b, 0x04, 272);
+            PutU32(b, 0x1C, 1); PutU32(b, 0x20, (uint)oSeqs);
+            PutU16(b, oSeqs, 0);
+            PutU32(b, oSeqs + 4, 1000);
+            PutU32(b, oSeqs + 12, 0x20);
+            PutU32(b, 0x3C, (uint)verts); PutU32(b, 0x40, (uint)oVerts);
+            for (int i = 0; i < verts; i++)
+            {
+                int o = oVerts + i * 48;
+                PutF32(b, o + 0, (i % 3) == 1 ? 1f : 0f);
+                PutF32(b, o + 4, (i % 3) == 2 ? 1f : 0f);
+                PutF32(b, o + 8, i / 3);
+                PutF32(b, o + 20, 0f); PutF32(b, o + 24, 0f); PutF32(b, o + 28, 1f);
+                PutF32(b, o + 32, (i % 3) == 1 ? 1f : 0f);
+                PutF32(b, o + 36, (i % 3) == 2 ? 1f : 0f);
+            }
+            PutU32(b, 0x44, 1);
+            PutU32(b, 0x50, 1); PutU32(b, 0x54, (uint)oTex);
+            PutU32(b, oTex, 0); PutU32(b, oTex + 4, 3);
+            PutU32(b, 0x70, (uint)n); PutU32(b, 0x74, (uint)oMat);
+            for (int i = 0; i < n; i++)
+            {
+                PutU16(b, oMat + i * 4, (ushort)flags[i]);
+                PutU16(b, oMat + i * 4 + 2, (ushort)blends[i]);
+            }
+            PutU32(b, 0x80, 1); PutU32(b, 0x84, (uint)oTexLookup);
+            PutU16(b, oTexLookup, 0);
+            return f.Done();
+        }
+
+        /// <summary>The matching skin: submesh i drawn by batch i against material i.</summary>
+        public static byte[] MaterialModeSkin(int n)
+        {
+            const int headerSize = 0x30;
+            int vertOffset = headerSize;
+            int triOffset = vertOffset + n * 3 * 2;
+            int subOffset = triOffset + n * 3 * 2;
+            int batchOffset = subOffset + n * 48;
+            var b = new byte[batchOffset + n * 24];
+            PutMagic(b, 0, "SKIN");
+            PutU32(b, 0x04, (uint)(n * 3)); PutU32(b, 0x08, (uint)vertOffset);
+            PutU32(b, 0x0C, (uint)(n * 3)); PutU32(b, 0x10, (uint)triOffset);
+            PutU32(b, 0x14, 0); PutU32(b, 0x18, 0);
+            PutU32(b, 0x1C, (uint)n); PutU32(b, 0x20, (uint)subOffset);
+            PutU32(b, 0x24, (uint)n); PutU32(b, 0x28, (uint)batchOffset);
+            for (int i = 0; i < n * 3; i++)
+            {
+                PutU16(b, vertOffset + i * 2, (ushort)i);
+                PutU16(b, triOffset + i * 2, (ushort)i);
+            }
+            for (int s = 0; s < n; s++)
+            {
+                int o = subOffset + s * 48;
+                PutU16(b, o + 0, 0);                         // every submesh at geoset id 0
+                PutU16(b, o + 4, (ushort)(s * 3));
+                PutU16(b, o + 6, 3);
+                PutU16(b, o + 8, (ushort)(s * 3));
+                PutU16(b, o + 10, 3);
+                int bo = batchOffset + s * 24;
+                PutU16(b, bo + 4, (ushort)s);                // submesh
+                PutU16(b, bo + 8, 0xFFFF);                   // no colour entry
+                PutU16(b, bo + 10, (ushort)s);               // material s
+                PutU16(b, bo + 14, 1);                       // one texture unit
+                PutU16(b, bo + 16, 0);
+                PutU16(b, bo + 18, 0xFFFF);
+                PutU16(b, bo + 20, 0xFFFF);
+                PutU16(b, bo + 22, 0xFFFF);
+            }
+            return b;
+        }
+
+        /// <summary>
         /// The matching skin: one submesh per entry of geosetIds, each one triangle, each with its
         /// own batch. This is how a component model that carries alternatives is shaped.
         /// </summary>

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -351,6 +351,8 @@ namespace Wmv.Wow.Tests
             CrossSequenceGateTests();
             WeightLookupTests();
             MaterialLifecycleTests();
+            log.Add("Effect output curve");
+            OutputCurveTests();
             log.Add("Bones");
             BoneTests();
             log.Add("Animation");
@@ -1682,5 +1684,69 @@ namespace Wmv.Wow.Tests
             Check(tri[0] == 0 && tri[1] == 2 && tri[2] == 1, "coords: winding flipped (triangle 1)");
             Check(tri[3] == 3 && tri[4] == 5 && tri[5] == 4, "coords: winding flipped (triangle 2)");
         }
+
+        /// <summary>
+        /// THE PREVIEW-LIGHT ROLL-OFF, PINNED.
+        ///
+        /// WmvOpaque.shader shapes the top end of the preview rig's output with
+        ///
+        ///     ov     = max(mx - KNEE, 0)
+        ///     rolled = min(mx, KNEE) + (CEIL - KNEE) * (1 - exp(-ov / (CEIL - KNEE)))
+        ///     rgb   *= rolled / mx
+        ///
+        /// with KNEE 0.298 and CEIL 1.0, and it runs ONLY where the preview light contributed --
+        /// not on the emissive path, where the bypass has already set lum = 1 and spec = 0 and the
+        /// colour is entirely the model's own.
+        ///
+        /// WHAT THIS TEST IS AND IS NOT. It is a mirror of that arithmetic, not a test of the
+        /// compiled shader: neither harness can run a fragment program, the parser suite does not
+        /// even link against Unity. It exists so that changing the curve or its constants shows up
+        /// as a failing number here and has to be done on purpose. If the shader and this mirror
+        /// ever disagree, the shader is the truth and this test is the thing that is wrong.
+        /// </summary>
+        static void OutputCurveTests()
+        {
+            const double KNEE = 0.298, CEIL = 1.0;
+            Func<double, double> roll = mx =>
+            {
+                double ov = Math.Max(mx - KNEE, 0.0);
+                return Math.Min(mx, KNEE) + (CEIL - KNEE) * (1.0 - Math.Exp(-ov / (CEIL - KNEE)));
+            };
+
+            // Below the knee the painted colour is untouched -- that is the whole point of a knee.
+            Near((float)roll(0.0), 0f, "output curve: 0 stays 0");
+            Near((float)roll(0.1), 0.1f, "output curve: 0.1 is below the knee and unchanged");
+            Near((float)roll(0.298), 0.298f, "output curve: the knee itself is unchanged");
+
+            // Above it the curve bends over. These are the values the branch was measured against.
+            Near((float)roll(0.5), 0.4735f, "output curve: 0.5 -> 0.4735");
+            Near((float)roll(1.0), 0.7417f, "output curve: an authored white 1.0 -> 0.7417");
+            Near((float)roll(1.25), 0.8191f, "output curve: 1.25 -> 0.8191");
+            Near((float)roll(1.5), 0.8733f, "output curve: 1.5 -> 0.8733");
+            Near((float)roll(2.0), 0.9379f, "output curve: 2.0 -> 0.9379");
+            Near((float)roll(4.0), 0.9964f, "output curve: 4.0 -> 0.9964");
+
+            // The two figures the shoulder audit measured, reproduced exactly.
+            Near((float)roll(1.331), 0.8388f, "output curve: the audit's cracks, 1.331 -> 0.839");
+            Near((float)roll(1.150), 0.7914f, "output curve: the audit's trail, 1.150 -> 0.791");
+
+            // CEIL is an asymptote: the curve approaches it and never reaches it, for any finite
+            // input. That is why the value matters and why it is not a clamp.
+            // CEIL is a mathematical asymptote, but only a mathematical one: past roughly 10 the
+            // exponential underflows and the result saturates to CEIL exactly in floating point.
+            // Both halves are worth pinning, because "never reaches white" is true of the curve
+            // and false of the arithmetic that evaluates it.
+            Check(roll(4.0) < CEIL, "output curve: below CEIL where it matters (4.0)");
+            Check(roll(1e6) <= CEIL, "output curve: never above CEIL, however large the input");
+            Check(roll(8.0) > roll(4.0), "output curve: still monotonic far above the knee");
+
+            // What the emissive exemption is worth, as a number rather than an impression: an
+            // authored value keeps all of itself instead of the fraction the curve would leave.
+            Check(Math.Abs(1.0 - roll(1.0)) > 0.25,
+                  "output curve: the curve costs an authored white more than a quarter of itself");
+            Check(Math.Abs(0.5 - roll(0.5)) > 0.02,
+                  "output curve: it costs a mid-bright authored value something too");
+        }
+
     }
 }


### PR DESCRIPTION
The preview-light roll-off was running on passes that carry no preview light, compressing the model's own authored output. It now runs where the preview light did.

Three lines of shader change: the emissive bypass records that it fired, and the roll-off's gate reads that flag.

WHY. The roll-off was introduced by 125f3781 ("Improve Unity M2 preview lighting") for one stated reason -- the rig's terms deliberately sum past 1.0, "the light now sums to 1.24 at full incidence and the top end is rolled off instead" -- and capping the light instead would make a white texture read grey. That is a statement about light. It ran unconditionally then, because every fragment carried preview light: _Emissive entered the shader eleven days later, in 0880a08d, which added the bypass and gated the curve to the shipped rig.

On the emissive path the bypass assigns lum = 1 and spec = 0, so the colour reaching the curve is exactly the combiner times _Color, with every rig term discarded. Running a preview-light curve over it only darkens what the model asked for: the curve starts at KNEE 0.298, so an authored white leaves at 0.742. The legacy renderer, whose material semantics these passes come from, applies no clamp or curve of its own; its viewport saturates at the framebuffer, which is a destination artefact, and the repository's own export target exists precisely so "values above 1.0 (emissive/additive passes) survive".

This overturns a recorded decision rather than correcting an oversight. 0880a08d kept the curve on emissive passes so that "a stacked glow cannot run away past white". That is an argument about accumulation, and a per-fragment curve cannot deliver it: the shader runs before blending and cannot see what it is adding to. Stacking is bounded by the destination, as it is in the legacy viewport and in the pipeline's own tone map.

WHICH PASSES THIS IS, stated exactly, because it is broader than "the effects". The affected set is every pass with _Emissive = 1: blend mode 3 (One/One) and blend mode 4 (SrcAlpha/One), plus ANY blend mode when the M2 material carries the 0x01 UNLIT flag. So it includes unlit-flagged passes that are opaque, alpha-key, alpha-blended, modulate and modulate-2x. An unlit-flagged opaque pass neither blends nor accumulates, so the argument above does not describe it; what the change does there is simply preserve the authored colour. Mode 7 (BlendAdd) is not in the set.

MEASURED IN THE EMBEDDED VIEWPORT. Every figure here is the frame the viewport presented -- Camera.main, HDR and post-processing on -- captured at end of frame, so it has been through the HDR colour buffer, bloom, the Neutral tonemap and the vignette. On Drakestalker's Trophy Pauldrons the effects gain a little (eye mean 0.4747 to 0.4969, upper-wisp max 0.5850 to 0.6351) and every lit control lands on exactly the number it had before, to four decimals: armour 0.3250, armour lower 0.2951, scales 0.5239. Removing the curve outright instead moves all three (0.3370, 0.2965, 0.5437), which is why it was not simply deleted.

A FIGURE FROM AN EARLIER DRAFT OF THIS MESSAGE IS WITHDRAWN. It said removing the curve entirely "lifted ordinary armour from 215 to 238 sRGB". That came from the offscreen diagnostic camera, which has no HDR buffer and no tone map, and it overstated the effect; the viewport figures above replace it. The conclusion is unchanged.

THE LIT CASE, ASKED AND ANSWERED WITHOUT A RULE. Whether authored output above 1.0 inside a LIT pass should also be exempt was left open. It is now measured rather than assumed. Drakestalker itself does not have the problem: its lit batch authors 0.624 to 0.985 before any lighting, so the heat that prompted the question -- 1.256 red, 1.311 purple before the curve -- is the preview rig's own gain, lum reaching 1.505 there. Across every creature model in the client census carrying a lit combiner-2 or combiner-12 batch (84 models, the whole population), 10 of the 79 usable ones do author above 1.0 on a lit pass, peaking at 1.274 on tens of pixels each, always on small detail. So it is real, and small.

No rule is shipped for it. A gate on the authored value is implementable -- the shader holds that value at the multiply -- but it is discontinuous: two texels at authored 0.99 and 1.01 under the same light would land at 0.87 and 1.52, a 73 per cent jump for a one per cent change in the texture, in the middle of a painted gradient. Softening it means inventing a blend width, nothing in the repository establishes what the game does here, and the rule would have to be safe across 46.87 per cent of all lit batches in 3887 of 4501 models. Recorded as unresolved, with the reason, rather than approximated.

KEY_FLOOR, KEY_GAIN, KNEE and CEIL are unchanged, the rig, shadows and contact shadows are untouched, and the legacy _WmvRig path is unaffected because its gate still excludes it.

TESTS. 16 checks pin the curve and its constants; they mirror the arithmetic rather than run the shader, which neither harness can do, and say so. This is joined by a runtime test of the thing the change actually turns on -- the gate's input. OutputGateTests builds real materials through the real builder inside the player and asserts _Emissive across all eight M2 blend modes and both UNLIT-flag cases, so the exempt set is pinned from both sides, and asserts that the shipped rig is the default so the exemption is the live path. Runtime suite 97 to 120 checks passing.