### PR TITLE
Implement M2 particles and ribbons in Unity

### DIFF
--- a/Source/wowmodelviewer/UnityAssetAccess.cpp
+++ b/Source/wowmodelviewer/UnityAssetAccess.cpp
@@ -371,6 +371,76 @@ bool UnityAssetAccess::resolveModelTextures(int m2FileDataID, std::vector<ModelT
   return false;
 }
 
+bool UnityAssetAccess::resolveParticleColor(int m2FileDataID, ParticleColorSet & out, QString & error)
+{
+  out = ParticleColorSet();
+  if (m2FileDataID <= 0)
+  {
+    error = "invalid model fileDataID";
+    return false;
+  }
+  if (!hasActiveClient())
+  {
+    error = g_clientLoadDepth > 0 ? "game client is still loading" : "no game client loaded";
+    return false;
+  }
+
+  // WHICH DISPLAY. An item component model is reached from its display through
+  // ItemDisplayInfo.ModelResourcesID{1,2} -> ModelFileData.ModelResourcesID, so the join runs
+  // backwards from the file the renderer actually loaded. Both model slots are tried because a
+  // two-handed or paired item puts its second component in slot 2.
+  //
+  // Only rows with a non-zero ParticleColorID are considered: an item whose display sets none
+  // must fall through to what the emitters authored rather than to row 0.
+  int colorId = 0;
+  // NOT named "slots": Qt defines that as an empty macro for moc, so a local of that name is a
+  // syntax error the moment this file sees a Qt header.
+  const char * modelSlots[] = { "ModelResourcesID1", "ModelResourcesID2" };
+  for (const char * slot : modelSlots)
+  {
+    const sqlResult r = GAMEDATABASE.sqlQuery(
+      QString("SELECT ItemDisplayInfo.ParticleColorID FROM ItemDisplayInfo "
+              "LEFT JOIN ModelFileData ON ItemDisplayInfo.%1 = ModelFileData.ModelResourcesID "
+              "WHERE ModelFileData.FileDataID = %2 AND ItemDisplayInfo.ParticleColorID > 0")
+        .arg(slot).arg(m2FileDataID));
+    if (r.valid && !r.values.empty() && !r.values[0].empty())
+    {
+      colorId = r.values[0][0].toInt();
+      if (colorId > 0)
+        break;
+    }
+  }
+  if (colorId <= 0)
+  {
+    error = "no item display references this model with a particle colour";
+    return false;
+  }
+
+  const sqlResult pc = GAMEDATABASE.sqlQuery(
+    QString("SELECT Start1, Start2, Start3, Mid1, Mid2, Mid3, End1, End2, End3 "
+            "FROM ParticleColor WHERE ID = %1").arg(colorId));
+  if (!pc.valid || pc.values.empty() || pc.values[0].size() < 9)
+  {
+    error = QString("ParticleColor row %1 could not be read").arg(colorId);
+    return false;
+  }
+
+  const std::vector<QString> & row = pc.values[0];
+  for (int stop = 0; stop < 3; stop++)
+    for (int ch = 0; ch < 3; ch++)
+    {
+      int v = row[stop * 3 + ch].toInt();
+      out.rgb[stop][ch] = v < 0 ? 0 : (v > 255 ? 255 : v);
+    }
+  out.id = colorId;
+  out.ok = true;
+  LOG_INFO << "[unityipc] model" << m2FileDataID << "-> ParticleColor" << colorId
+           << "start(" << out.rgb[0][0] << out.rgb[0][1] << out.rgb[0][2] << ")"
+           << "mid(" << out.rgb[1][0] << out.rgb[1][1] << out.rgb[1][2] << ")"
+           << "end(" << out.rgb[2][0] << out.rgb[2][1] << out.rgb[2][2] << ")";
+  return true;
+}
+
 UnityAssetAccess::Result UnityAssetAccess::readByFileDataID(int fileDataID)
 {
   Result r;

--- a/Source/wowmodelviewer/UnityAssetAccess.h
+++ b/Source/wowmodelviewer/UnityAssetAccess.h
@@ -93,6 +93,31 @@ public:
   // False with a reason when none of them can answer.
   static bool resolveModelTextures(int m2FileDataID, std::vector<ModelTexture> & out, QString & error);
 
+  // The three colour stops of one ParticleColor row: start, middle and end, each an RGB
+  // triple of 0..255. An M2 particle emitter opts into an override with ParticleColorIndex
+  // 11, 12 or 13, which select stop set 0, 1 and 2 -- so a resolved row supplies all three
+  // sets at once and each emitter takes the one its index names.
+  struct ParticleColorSet
+  {
+    bool ok = false;
+    int id = 0;               // the ParticleColor row, for the log
+    int rgb[3][3] = {};       // [stop][channel], 0..255
+  };
+
+  // Resolve the ParticleColor override for a model, in ITEM context.
+  //
+  // Retail assigns an item display a ParticleColorID and recolours the emitters its models
+  // declare with it: ItemDisplayInfo.ParticleColorID -> ParticleColor. WMV has always parsed
+  // the emitter's ParticleColorIndex (WoWModel.cpp:1242-1245 collects them) but never resolved
+  // a colour to put there -- WoWModel::replaceParticleColors is initialised false and nothing
+  // assigns it, so the override path has been dead.
+  //
+  // The displayed item is preferred when it is the model being asked about, because several
+  // displays can share one model with different particle colours; otherwise the display is
+  // found from the model file itself through ModelFileData.
+  // False with a reason when the model has no override, which is the common case.
+  static bool resolveParticleColor(int m2FileDataID, ParticleColorSet & out, QString & error);
+
   // Name of the active client's storage backend ("CASC"/"MPQ"/"Unknown") -- for logging.
   static QString activeProviderName();
 

--- a/Source/wowmodelviewer/UnityIpcServer.cpp
+++ b/Source/wowmodelviewer/UnityIpcServer.cpp
@@ -308,6 +308,23 @@ void UnityIpcServer::addGeosets(QJsonObject & msg, int m2FileDataID)
   msg["geosets"] = arr;
 }
 
+void UnityIpcServer::addParticleColor(QJsonObject & msg, int m2FileDataID)
+{
+  UnityAssetAccess::ParticleColorSet set;
+  QString error;
+  if (!UnityAssetAccess::resolveParticleColor(m2FileDataID, set, error))
+    return;   // no override is the common case, and is not an error worth a field
+
+  // [start.r,start.g,start.b, mid.r,..., end.r,...] as 0..255, the order the DBC stores them and
+  // the order an emitter's ParticleColorIndex of 11 / 12 / 13 selects from.
+  QJsonArray arr;
+  for (int stop = 0; stop < 3; stop++)
+    for (int ch = 0; ch < 3; ch++)
+      arr.append(set.rgb[stop][ch]);
+  msg["particleColor"] = arr;
+  msg["particleColorId"] = set.id;
+}
+
 void UnityIpcServer::sendModelSkin(int m2FileDataID)
 {
   if (!m_client || !m_unityReady || m2FileDataID <= 0)
@@ -329,6 +346,7 @@ void UnityIpcServer::sendModelSkin(int m2FileDataID)
   msg["fileDataID"] = m2FileDataID;
   msg["textures"] = textureArray(textures);
   addGeosets(msg, m2FileDataID);
+  addParticleColor(msg, m2FileDataID);
   m_stats.skinPushes++;
   m_stats.lastSkin = QString("%1 (%2)").arg(textures[0].fileDataID)
                                        .arg(UnityAssetAccess::sourceName(textures[0].source));
@@ -461,6 +479,7 @@ void UnityIpcServer::handleGetModelTextures(const QJsonObject & msg)
   {
     resp["textures"] = textureArray(textures);
     addGeosets(resp, fdid);
+    addParticleColor(resp, fdid);
     m_stats.responsesOk++;
     LOG_INFO << "[unityipc] -> modelTextures" << requestId << "resolved" << (int)textures.size()
              << "texture(s) from" << UnityAssetAccess::sourceName(textures.empty()

--- a/Source/wowmodelviewer/UnityIpcServer.h
+++ b/Source/wowmodelviewer/UnityIpcServer.h
@@ -166,6 +166,11 @@ private:
   static QJsonArray textureArray(const std::vector<UnityAssetAccess::ModelTexture> & textures);
   // Adds "geosets"/"hasGeosets" to a message about one model, when a selection is known.
   static void addGeosets(QJsonObject & msg, int m2FileDataID);
+
+  // The item ParticleColor override, when the displayed model has one. Attached to the same two
+  // messages as the geosets, so a renderer that has the textures always has the colours that go
+  // with them and the two can never describe different states.
+  static void addParticleColor(QJsonObject & msg, int m2FileDataID);
   void queueJson(const QJsonObject & obj);
   void dropClient(const char * why);
 

--- a/Tools/UnityRendererProject/Assets/Resources/WmvParticle.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvParticle.shader
@@ -1,0 +1,133 @@
+// WmvParticle.shader
+//
+// The pass every M2 particle and ribbon is drawn with. One shader, one material per emitter,
+// everything that differs between emitters carried as a uniform -- the same discipline
+// WmvOpaque.shader follows, and for the same reason: variants are what a player build strips.
+//
+// WHAT IT COMPUTES
+//   texture * vertex colour, and nothing else. The legacy viewport binds a particle's texture
+//   with GL_MODULATE and supplies the life-ramped colour through glColor4fv
+//   (Source/games/wow/particle.cpp:360, :427), so the fragment is exactly that product. There is
+//   no lighting: a particle is emissive art, and the legacy has GL_LIGHTING off for the ribbons
+//   (:843) and never enables a light for the particle quads either.
+//
+// COLOUR SPACE -- the same rule as WmvOpaque, and it is not bookkeeping
+//   The project renders in LINEAR space, so the framebuffer holds linear light and the swapchain
+//   applies the sRGB curve on write. Model textures are uploaded UNDECODED (WmvModelBuilder.
+//   CreateTexture passes linear:true, which in Unity's vocabulary means "hand the shader the
+//   stored value"), so the whole shader runs in the AUTHORED domain and converts once, at the
+//   end, with the exact sRGB EOTF. Doing the multiply in the authored domain matters here more
+//   than anywhere: 56 % of the client's particle emitters are additive, and an additive term is
+//   not scale-invariant between the two domains -- the same authored value lands at a different
+//   framebuffer level depending on which space the sum is taken in.
+//
+//   Values above 1 are left unclamped so an additive stack can still blow out and still feed
+//   bloom, which is what makes a dense emitter read as bright rather than as flat white.
+//
+// BLEND MODES
+//   _SrcBlend / _DstBlend are set per emitter from the M2 blend field, with the factors the
+//   legacy's ParticleSystem::draw uses for each mode (particle.cpp:306-353). _AlphaTest covers
+//   mode 1, the only one that discards.
+//
+// DEPTH
+//   ZWrite is off and the queue is Transparent: a particle must not occlude the model or another
+//   particle. The legacy is the same -- glDepthMask(GL_FALSE) for ribbons (:846), and the
+//   particle pass runs after the model with blending on.
+
+Shader "Wmv/Particle"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend ("Src blend", Float) = 5   // SrcAlpha
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend ("Dst blend", Float) = 1   // One
+        [Toggle] _AlphaTest ("Alpha test", Float) = 0
+        _Cutoff ("Alpha cutoff", Range(0,1)) = 0.5
+
+        /// Matches WmvOpaque's switch of the same name, so both passes can be put back into the
+        /// linear-composited behaviour together if the project's colour space ever changes.
+        [Toggle] _WmvAuthoredDomain ("Composite in the authored domain", Float) = 1
+    }
+
+    SubShader
+    {
+        // No LightMode tag, for the same reason WmvOpaque has none: the built-in pipeline draws
+        // this as an ordinary transparent pass and URP draws it through SRPDefaultUnlit, so one
+        // SubShader covers both.
+        Tags { "RenderType" = "Transparent" "Queue" = "Transparent" "IgnoreProjector" = "True" }
+
+        Cull Off
+        Blend [_SrcBlend] [_DstBlend]
+        ZWrite Off
+        ZTest LEqual
+        Lighting Off
+        Fog { Mode Off }
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv     : TEXCOORD0;
+                fixed4 color  : COLOR;
+            };
+
+            struct v2f
+            {
+                float4 pos   : SV_POSITION;
+                float2 uv    : TEXCOORD0;
+                fixed4 color : COLOR;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            half _AlphaTest;
+            half _Cutoff;
+            half _WmvAuthoredDomain;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                // Straight through. There is no COLOR0 doubling convention here: that belongs to
+                // the M2 *model* vertex shaders, whose 0.5 at the vertex and 2 at the pixel
+                // cancel. This colour is the life ramp, written by the renderer, meant as it is.
+                o.color = v.color;
+                return o;
+            }
+
+            // The exact sRGB EOTF, not the pow(2.2) approximation: it has to invert the
+            // swapchain's encode exactly or every mid-tone shifts. Unclamped above 1 on purpose.
+            half3 WmvAuthoredToLinear(half3 c)
+            {
+                half3 lo = c * (1.0h / 12.92h);
+                half3 hi = pow(max((c + 0.055h) * (1.0h / 1.055h), 0.0h), 2.4h);
+                return lerp(lo, hi, step(0.04045h, c));
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                fixed4 tex = tex2D(_MainTex, i.uv);
+                fixed4 c = tex * i.color;
+
+                // Blend mode 1 is the only M2 particle mode that discards; the legacy turns the
+                // alpha test on for it and leaves the blend at ONE/ZERO (particle.cpp:313-317).
+                if (_AlphaTest > 0.5 && c.a < _Cutoff)
+                    discard;
+
+                if (_WmvAuthoredDomain > 0.5)
+                    c.rgb = WmvAuthoredToLinear(c.rgb);
+                return c;
+            }
+            ENDCG
+        }
+    }
+
+    Fallback Off
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
@@ -1,0 +1,1469 @@
+// WmvEmitterRuntime.cs
+//
+// Draws an M2's particle and ribbon emitters. Until this file existed the Unity renderer parsed
+// neither and drew neither: a search of the builder for "particle" or "ribbon" returned one hit,
+// and it was a comment about shader names. The Lich King's four emitters, the phoenix's
+// thirty-four, and the glow motes on every one of the validation weapons were simply absent.
+//
+// ============================================================================================
+// WHAT DRIVES IT: THE MODEL'S OWN CLOCK, NEVER Time.time
+// ============================================================================================
+// Every quantity here advances on the animation clock WmvM2Animator already owns. Tick() is
+// called from that animator's LateUpdate, after the bones are posed, with the animation's own
+// advance for this frame -- dt * speed while playing, and exactly ZERO while paused. That is
+// what the legacy viewport does: ModelCanvas::tick sets ddt = 0 when the animation is paused and
+// passes the same ddt to both the bone tick and updateEmitters (modelcanvas.cpp:1515-1522,
+// WoWModel.cpp:2647-2649). A paused model's particles hang in the air; they do not keep raining.
+//
+// Track values are sampled at the animator's sequence time, and tracks bound to a global
+// sequence at the global clock, through the same evaluator the bones use. Nothing in this file
+// reads Time.time, and the only Time.deltaTime is the one the animator already turned into an
+// animation advance before calling in.
+//
+// ============================================================================================
+// WHY THERE IS NO ParticleSystem AND NO GameObject PER PARTICLE
+// ============================================================================================
+// One GameObject, one Material and one Mesh PER EMITTER -- not per particle. A particle is
+// sixteen floats in a flat array; a frame writes four vertices for each live one into arrays
+// that were allocated when the model loaded and are never reallocated. So a 21-emitter staff is
+// 21 draw calls whatever the particle count, and the steady state allocates nothing.
+//
+// Unity's own ParticleSystem was not used. It cannot express what these emitters do -- the
+// three-stop life ramp, the M2 blend modes, tile flipbooks driven by a model clock that pauses,
+// bone-local versus model-space integration chosen per emitter by a flag -- and configuring one
+// per emitter at runtime would be more machinery than the 200 lines that do it directly.
+//
+// ============================================================================================
+// WHERE THIS DIVERGES FROM Source/games/wow/particle.cpp, AND WHY
+// ============================================================================================
+// The legacy runtime is the reference, and it is followed except where measurement against real
+// client files shows it is wrong. Every divergence is listed here so none of them is a silent
+// preference:
+//
+//  1. GRAVITY. 82.9 % of the client's emitters set flag 0x800000, which changes how a gravity
+//     KEY is encoded. particle.cpp:38 reads every gravity track as float32 regardless; on those
+//     emitters that decodes to NaN or infinity 47 % of the time. See M2Parser.ReadCompressedGravity.
+//  2. PARTICLE SIZE. particle.cpp:55 multiplies ramp stop i by ModelParticleParams.scales[i].
+//     scales is a per-AXIS scale, not a per-stop one -- see M2ParticleEmitterDef.ParticleScale.
+//     Under the legacy reading Val'anyr's 0.0556 particles come out 28.85 units across.
+//  3. RAMP LENGTH. particle.cpp:48 memcpys three stops whatever the count says. Emitters that
+//     author two are common, so the third stop is unauthored bytes. The count is honoured here.
+//  4. HORIZONTAL SPREAD. particle.cpp:563 passes the VERTICAL range as both angles for a plane
+//     emitter, leaving HorizontalRange -- a field whose own comment reads "They can do it
+//     horizontally too! (range: 0 to 2*pi)" -- unread. Val'anyr's motes author pi/2 vertical and
+//     2*pi horizontal, i.e. a full skirt, and get a quarter of it.
+//  5. SPHERE DIRECTION. particle.cpp:711 tests flag 0x100, which is nameless and set on 7.5 % of
+//     emitters, to choose between emitting radially and emitting along the bone. The format has
+//     MODELPARTICLE_FLAGS_OUTWARD (0x20000) for exactly that, set on 93.3 %. The documented bit
+//     is used. The two populations very nearly coincide, so this changes little and says why.
+//  6. SPHERE AXIS SWAP. particle.cpp:697-699 swaps a spawn direction's y and z with no comment,
+//     in a function whose neighbours are labelled "TODO: fix sphere emitters to work properly".
+//     Dropped; the cone points along the bone's own axis like the plane emitter's does.
+//  7. GRAVITY DIRECTION. particle.cpp:602 sets down = -Z for a plane emitter and :721 sets
+//     down = +Z for a sphere, so the same authored gravity would pull one down and push the
+//     other up. -Z (Unity -Y) for both.
+//  8. THE FLAG SPECIAL CASES at particle.cpp:566-594 compare the WHOLE flags word against 1041,
+//     25 and 17. No current-client emitter can match: Val'anyr's are 0x24021, 0x30031 and
+//     0x20221. They are dead code on this data and are not reproduced.
+//  9. THE TILE FLIPBOOK. particle.cpp:626 always picks a random tile. The format has
+//     RANDOMTEXTURE (0x10000, 33.9 %) for that, and RANDOMSTART (0x200000, 10.1 %) -- a flag
+//     that only means anything if there is a progression to start partway through. So a tile
+//     advances over the particle's life unless RANDOMTEXTURE fixes it at a random one. For the
+//     59.8 % of emitters that are 1x1 the two are identical.
+// 10. RIBBON GEOMETRY -- see RibbonState, where the legacy's own TODO and two glm mistakes are
+//     set out in full.
+//
+// zSource is not implemented, exactly as the legacy does not implement it. It measures as 255.0
+// on the emitters that set it, and one line of header comment is not enough to build motion from.
+// Spline emitters (0.8 % of the client) are not drawn, and the legacy builds no emitter for them
+// either (particle.cpp:117-120).
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Wmv.Wow;
+
+/// <summary>
+/// Every particle and ribbon emitter of one model. Added by WmvModelBuilder to the model root, so
+/// it dies with the model and a switch cannot leave the previous model's effects on screen.
+/// </summary>
+public class WmvEmitterRuntime : MonoBehaviour
+{
+    // ---- tuning, all with a reason ----------------------------------------------------------
+
+    /// <summary>
+    /// Ceiling on the live particles ONE emitter may hold. The legacy's equivalent is 10,000 per
+    /// system (particle.cpp:13); that is a per-system number and this renderer sizes per emitter
+    /// from the emitter's own authored rate and lifespan, so the ceiling only has to stop a
+    /// pathological track from eating memory. The 99th-percentile model has 12 emitters.
+    /// </summary>
+    const int MaxParticlesPerEmitter = 4096;
+
+    /// <summary>Floor on that capacity, so a rate track that is zero in this sequence but not in
+    /// the next does not have to reallocate when the sequence changes.</summary>
+    const int MinParticlesPerEmitter = 32;
+
+    /// <summary>Ceiling on a ribbon's stored edges. res * lifetime measures 5..200 across the
+    /// client; 512 leaves headroom without letting a bad track run away.</summary>
+    const int MaxRibbonEdges = 512;
+
+    /// <summary>
+    /// The fixed step SimulateTo uses to reach a pinned instant. 60 Hz because that is the rate
+    /// a capture is taken at; the point is that a given timestamp always produces the SAME frame,
+    /// so a BEFORE and an AFTER can be compared pixel for pixel.
+    /// </summary>
+    const float PinnedStepSeconds = 1f / 60f;
+
+    /// <summary>How far a pinned simulation will run. Two seconds of particles at 60 Hz is 120
+    /// steps; the guard is against a pin far in the future turning into a stall.</summary>
+    const float PinnedMaxSeconds = 30f;
+
+    // ---- state ------------------------------------------------------------------------------
+
+    class ParticleState
+    {
+        public M2ParticleEmitterDef Def;
+        public Transform Bone;
+        public Matrix4x4 BindPose;          // see BindPoseFor
+        public Vector3 Origin;              // Def.Position, in Unity space
+        public GameObject Go;
+        public Mesh Mesh;
+        public Material Material;
+        public MeshRenderer Renderer;
+
+        /// <summary>
+        /// Does a particle live in the bone's space or in the model's?
+        ///
+        /// DONOTTRAIL (0x10, 44.6 % of the client) says the particle is carried by the emitter
+        /// rather than left behind in the world, and that is the whole difference: a trailing
+        /// particle has the bone matrix baked into its position once, at spawn, and then moves on
+        /// its own; a pinned one keeps a bone-local position and is transformed by the bone every
+        /// frame. The legacy holds exactly these two cases (particle.cpp:429-432, :623-624) but
+        /// hides the second behind a static switch nothing turns on, so it has always drawn the
+        /// first for every emitter.
+        /// </summary>
+        public bool BoneLocal;
+
+        public int Count;
+        public int Capacity;
+        public Vector3[] Pos;               // in BoneLocal ? bone space : model space
+        public Vector3[] Vel;
+        public float[] Life;
+        public float[] MaxLife;
+        public int[] TileSeed;              // the flipbook offset chosen at spawn
+        public Vector3[] QuadRight;         // only allocated when the emitter does not billboard
+        public Vector3[] QuadUp;
+
+        public float SpawnRemainder;
+        public uint Rng;
+
+        public Vector3[] Verts;
+        public Vector2[] Uvs;
+        public Color32[] Colors;
+        public int[] Indices;
+        public int TileCount;
+
+        /// <summary>
+        /// The RGB ramp actually drawn with: the emitter's authored colour stops, or the same
+        /// stops recoloured by a ParticleColor override. RampTimes is parallel to it.
+        ///
+        /// RGB ONLY. The alpha ramp is a SEPARATE track with its own stop count and its own
+        /// times, and it is sampled separately at draw time -- see BuildParticleMesh. Folding it
+        /// onto these stops loses whatever it does between them, and that is not a corner case:
+        /// Val'anyr's motes author two colour stops, at 0.0 and 1.0, and an alpha ramp that is
+        /// zero at both ends and 1.0 at 0.2. Resampled onto the colour's stops the whole ramp
+        /// reads zero and the particles are invisible -- which is exactly what they were.
+        /// </summary>
+        public Color[] RampColor = new Color[0];
+        public float[] RampTimes = new float[0];
+    }
+
+    class RibbonState
+    {
+        public M2RibbonEmitterDef Def;
+        public Transform Bone;
+        public Matrix4x4 BindPose;
+        public Vector3 Origin;
+        public GameObject Go;
+        public Mesh Mesh;
+        public Material Material;
+        public MeshRenderer Renderer;
+
+        // A ring of edges, oldest at Head. Each edge is a point on the ribbon's spine plus the
+        // "up" it was emitted with, both in MODEL space, and the animation time it was laid down.
+        public Vector3[] EdgePos;
+        public Vector3[] EdgeUp;
+        public float[] EdgeAge;             // seconds since the edge was laid down
+        public int Head, Count, Capacity;
+
+        public float SinceLastEdge;
+        public float EdgeInterval;          // 1 / EdgesPerSecond
+        public float Lifetime;              // EdgeLifetimeSeconds
+        public bool HasPrevious;
+
+        public Vector3[] Verts;
+        public Vector2[] Uvs;
+        public Color32[] Colors;
+        public int[] Indices;
+    }
+
+    readonly List<ParticleState> particles = new List<ParticleState>();
+    readonly List<RibbonState> ribbons = new List<RibbonState>();
+    readonly List<Material> ownedMaterials = new List<Material>();
+    readonly List<Mesh> ownedMeshes = new List<Mesh>();
+
+    Transform modelRoot;
+    Camera billboardCamera;
+
+    /// <summary>Start/mid/end RGB per ParticleColor slot (index 0 for emitters whose
+    /// ParticleColorIndex is 11, 1 for 12, 2 for 13), or null when the app supplied none.</summary>
+    Color[][] particleColorOverride;
+
+    // ---- reported numbers -------------------------------------------------------------------
+
+    public int ParticleEmitterCount { get { return particles.Count; } }
+    public int RibbonEmitterCount { get { return ribbons.Count; } }
+    public int SkippedEmitterCount { get; private set; }
+    public int DrawCallCount { get { return particles.Count + ribbons.Count; } }
+
+    public int LiveParticleCount
+    {
+        get
+        {
+            int n = 0;
+            for (int i = 0; i < particles.Count; i++) n += particles[i].Count;
+            return n;
+        }
+    }
+
+    public int RibbonSegmentCount
+    {
+        get
+        {
+            int n = 0;
+            for (int i = 0; i < ribbons.Count; i++) n += ribbons[i].Count;
+            return n;
+        }
+    }
+
+    public int ParticleCapacity
+    {
+        get
+        {
+            int n = 0;
+            for (int i = 0; i < particles.Count; i++) n += particles[i].Capacity;
+            return n;
+        }
+    }
+
+    public bool HasAnything { get { return particles.Count > 0 || ribbons.Count > 0; } }
+
+    // =========================================================================================
+    // Build
+    // =========================================================================================
+
+    /// <summary>
+    /// Create the renderers for one model's emitters.
+    ///
+    /// textureFor maps an M2 texture SLOT to an uploaded Texture2D. A particle's texture field is
+    /// a DIRECT index into the model's texture array, not a route through TextureLookup -- the
+    /// legacy resolves it with getGLTexture(mta.texture), which indexes textures[] (WoWModel.cpp:
+    /// 3596-3610). Every slot the M2 names is fetched whether a batch uses it or not
+    /// (WmvMain.RequestTextures), so a particle's texture is already in hand by the time the
+    /// builder gets here.
+    /// </summary>
+    public void Setup(M2ParsedModel model, Transform root, Transform[] boneTransforms,
+                      Func<int, Texture2D> textureFor, Shader shader, string objectName,
+                      Action<string> log)
+    {
+        Clear();
+        modelRoot = root != null ? root : transform;
+        SkippedEmitterCount = 0;
+        if (model == null || shader == null)
+            return;
+
+        int skippedSpline = 0, skippedNoTexture = 0, skippedNoBone = 0;
+
+        for (int i = 0; i < model.ParticleEmitters.Length; i++)
+        {
+            M2ParticleEmitterDef def = model.ParticleEmitters[i];
+            if (!def.Supported) { skippedSpline++; continue; }
+
+            Transform bone = BoneOrNull(boneTransforms, def.Bone);
+            if (bone == null && boneTransforms.Length > 0) { skippedNoBone++; continue; }
+
+            // MULTITEXTURE packs three 5-bit slot indices into the texture field
+            // (particle.cpp:91-98). This renderer draws the first of them, which is the one the
+            // legacy binds to unit 0 and modulates the others onto; the extra units are a
+            // brightness detail, not the difference between drawing and not drawing.
+            int slot = def.MultiTexture ? (def.TextureId & 0x1f) : def.TextureId;
+            Texture2D tex = textureFor != null ? textureFor(slot) : null;
+            if (tex == null) { skippedNoTexture++; continue; }
+
+            particles.Add(BuildParticle(def, bone, tex, shader, objectName, i));
+        }
+
+        for (int i = 0; i < model.RibbonEmitters.Length; i++)
+        {
+            M2RibbonEmitterDef def = model.RibbonEmitters[i];
+            Transform bone = BoneOrNull(boneTransforms, def.Bone);
+            if (bone == null && boneTransforms.Length > 0) { skippedNoBone++; continue; }
+
+            // "just use the first texture for now; most models I've checked only had one"
+            // (particle.cpp:754). Still true of this client: no ribbon in the validation set
+            // declares more than one.
+            int slot = def.TextureIds.Length > 0 ? def.TextureIds[0] : -1;
+            Texture2D tex = slot >= 0 && textureFor != null ? textureFor(slot) : null;
+            if (tex == null) { skippedNoTexture++; continue; }
+
+            // A ribbon's blend mode comes from the model's MATERIALS array, through the
+            // second index array in the emitter (see M2RibbonEmitterDef.MaterialIndex). The
+            // legacy never reads it and hardcodes SRC_ALPHA/ONE (particle.cpp:847); that is
+            // right for the additive majority and wrong for the rest.
+            int blend = 4;
+            if (def.MaterialIndex >= 0 && def.MaterialIndex < model.Materials.Length)
+                blend = model.Materials[def.MaterialIndex].BlendMode;
+            ribbons.Add(BuildRibbon(def, bone, tex, shader, objectName, i, blend));
+        }
+
+        SkippedEmitterCount = skippedSpline + skippedNoTexture + skippedNoBone;
+
+        if (log != null && (HasAnything || SkippedEmitterCount > 0))
+        {
+            log(string.Format("emitters: {0} particle + {1} ribbon drawn of {2} + {3} declared; "
+                              + "capacity {4} particle(s)", particles.Count, ribbons.Count,
+                              model.ParticleEmitterCount, model.RibbonEmitterCount, ParticleCapacity));
+            if (skippedSpline > 0)
+                log(string.Format("emitters: {0} spline emitter(s) skipped -- neither renderer "
+                                  + "has ever drawn one (0.8 % of the client)", skippedSpline));
+            if (skippedNoTexture > 0)
+                log(string.Format("emitters: {0} skipped for a texture slot that did not resolve",
+                                  skippedNoTexture));
+            if (skippedNoBone > 0)
+                log(string.Format("emitters: {0} skipped for a bone index outside the skeleton",
+                                  skippedNoBone));
+        }
+    }
+
+    static Transform BoneOrNull(Transform[] bones, int index)
+    {
+        if (bones == null || index < 0 || index >= bones.Length)
+            return null;
+        return bones[index];
+    }
+
+    /// <summary>
+    /// The matrix that takes a point from the model's own space into a bone's local frame, as the
+    /// bone sits AT REST.
+    ///
+    /// THIS IS THE PIECE THAT MAKES AN EMITTER SIT ON ITS BONE. An emitter's position is in MODEL
+    /// space; the legacy transforms it by Bone::mat, which is a model-space-to-model-space matrix
+    /// -- built as T(pivot) * T(trans) * R(rot) * S(scale) * T(-pivot) and composed through the
+    /// parents, so it is the IDENTITY at rest and describes only how far the bone has MOVED.
+    /// Unity's bone.localToWorldMatrix is a different animal: it maps the bone's own local frame
+    /// to the world, and applying it to a model-space point displaces that point by the bone's
+    /// pivot. Composing it with this rest inverse gives back exactly the legacy's quantity:
+    ///
+    ///     rootInverse * bone.localToWorld * bindPose  ==  identity at rest
+    ///
+    /// which is the same construction the SkinnedMeshRenderer's own bind poses use
+    /// (WmvModelBuilder: bindPoses[i] = bones[i].worldToLocalMatrix * root.localToWorldMatrix).
+    /// It is captured HERE because Setup runs while the model is still in its rest pose, before
+    /// the animator exists -- reading it later would bake in whatever frame was showing.
+    /// </summary>
+    Matrix4x4 BindPoseFor(Transform bone)
+    {
+        if (bone == null || modelRoot == null)
+            return Matrix4x4.identity;
+        return bone.worldToLocalMatrix * modelRoot.localToWorldMatrix;
+    }
+
+    ParticleState BuildParticle(M2ParticleEmitterDef def, Transform bone, Texture2D tex,
+                                Shader shader, string objectName, int index)
+    {
+        var s = new ParticleState();
+        s.Def = def;
+        s.Bone = bone;
+        s.BindPose = BindPoseFor(bone);
+        s.Origin = ToUnity(def.Position);
+        s.BoneLocal = def.DoNotTrail || def.Pinned;
+        s.TileCount = Mathf.Max(1, def.Rows * def.Cols);
+        s.Capacity = CapacityFor(def);
+        s.Rng = (uint)(0x9E3779B9u * (uint)(index + 1) + 0x85EBCA6Bu);
+
+        s.Pos = new Vector3[s.Capacity];
+        s.Vel = new Vector3[s.Capacity];
+        s.Life = new float[s.Capacity];
+        s.MaxLife = new float[s.Capacity];
+        s.TileSeed = new int[s.Capacity];
+        if (def.DoNotBillboard)
+        {
+            s.QuadRight = new Vector3[s.Capacity];
+            s.QuadUp = new Vector3[s.Capacity];
+        }
+
+        s.Verts = new Vector3[s.Capacity * 4];
+        s.Uvs = new Vector2[s.Capacity * 4];
+        s.Colors = new Color32[s.Capacity * 4];
+        s.Indices = BuildQuadIndices(s.Capacity);
+
+        s.Go = NewChild(objectName + "_particles" + index);
+        s.Mesh = NewMesh(objectName + "_particleMesh" + index, s.Capacity * 4);
+        s.Material = NewMaterial(shader, tex, def.BlendMode, objectName + "_particleMat" + index);
+        s.Renderer = Attach(s.Go, s.Mesh, s.Material);
+        ResolveRamp(s);
+        return s;
+    }
+
+    RibbonState BuildRibbon(M2RibbonEmitterDef def, Transform bone, Texture2D tex,
+                            Shader shader, string objectName, int index, int blend)
+    {
+        var s = new RibbonState();
+        s.Def = def;
+        s.Bone = bone;
+        s.BindPose = BindPoseFor(bone);
+        s.Origin = ToUnity(def.Position);
+        s.Lifetime = def.EdgeLifetimeSeconds > 0f ? def.EdgeLifetimeSeconds : 0.5f;
+        float rate = def.EdgesPerSecond > 0f ? def.EdgesPerSecond : 30f;
+        s.EdgeInterval = 1f / rate;
+        // +2: one edge for the head that is still being extended and one so the ring never has
+        // to drop an edge that is still inside its lifetime.
+        s.Capacity = Mathf.Clamp(Mathf.CeilToInt(rate * s.Lifetime) + 2, 4, MaxRibbonEdges);
+
+        s.EdgePos = new Vector3[s.Capacity];
+        s.EdgeUp = new Vector3[s.Capacity];
+        s.EdgeAge = new float[s.Capacity];
+
+        s.Verts = new Vector3[s.Capacity * 2];
+        s.Uvs = new Vector2[s.Capacity * 2];
+        s.Colors = new Color32[s.Capacity * 2];
+        s.Indices = BuildStripIndices(s.Capacity);
+
+        s.Go = NewChild(objectName + "_ribbon" + index);
+        s.Mesh = NewMesh(objectName + "_ribbonMesh" + index, s.Capacity * 2);
+        s.Material = NewMaterial(shader, tex, blend, objectName + "_ribbonMat" + index);
+        s.Renderer = Attach(s.Go, s.Mesh, s.Material);
+        return s;
+    }
+
+    /// <summary>
+    /// How many particles this emitter can have alive at once, from its own authored numbers:
+    /// the largest rate it reaches times the longest lifespan it reaches, which is the steady
+    /// state by definition. Sized from the data rather than from a fixed 10,000 so that a model
+    /// with 231 emitters is not 231 x 10,000 slots of memory.
+    /// </summary>
+    static int CapacityFor(M2ParticleEmitterDef def)
+    {
+        float rate = TrackMax(def.EmissionRate, 0f);
+        float life = TrackMax(def.Lifespan, 0f);
+        int need = Mathf.CeilToInt(rate * life * 1.25f) + 4;
+        return Mathf.Clamp(need, MinParticlesPerEmitter, MaxParticlesPerEmitter);
+    }
+
+    static float TrackMax(M2Track<float> t, float fallback)
+    {
+        if (!t.HasData)
+            return fallback;
+        float m = float.NegativeInfinity;
+        for (int i = 0; i < t.Values.Length; i++)
+            if (t.Values[i] > m) m = t.Values[i];
+        return m > 0f ? m : 0f;
+    }
+
+    GameObject NewChild(string name)
+    {
+        var go = new GameObject(name);
+        go.transform.SetParent(modelRoot, false);
+        go.transform.localPosition = Vector3.zero;
+        go.transform.localRotation = Quaternion.identity;
+        go.transform.localScale = Vector3.one;
+        return go;
+    }
+
+    Mesh NewMesh(string name, int vertexCount)
+    {
+        var m = new Mesh();
+        m.name = name;
+        m.MarkDynamic();
+        // 16-bit indices top out at 65,535 vertices; the caps above stay far below that, but a
+        // mesh that silently truncated would be very hard to see.
+        if (vertexCount > 65000)
+            m.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+        ownedMeshes.Add(m);
+        return m;
+    }
+
+    MeshRenderer Attach(GameObject go, Mesh mesh, Material mat)
+    {
+        var mf = go.AddComponent<MeshFilter>();
+        mf.sharedMesh = mesh;
+        var mr = go.AddComponent<MeshRenderer>();
+        mr.sharedMaterial = mat;
+        mr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        mr.receiveShadows = false;
+        mr.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
+        mr.reflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Off;
+        return mr;
+    }
+
+    // =========================================================================================
+    // Materials: the M2 blend modes, as the legacy sets them
+    // =========================================================================================
+
+    /// <summary>
+    /// One material per emitter, from the same shader the meshes use, with the blend factors the
+    /// legacy's ParticleSystem::draw sets for each mode (particle.cpp:306-353).
+    ///
+    /// Only four of the eight ever appear on a particle in this client: 4 (additive on alpha)
+    /// 56.3 %, 2 (alpha blend) 24.9 %, 7 18.6 % and 1 (alpha test) 0.2 %. The rest are wired
+    /// anyway, because they cost a switch case and a mode nobody has seen is exactly the one that
+    /// would otherwise draw as garbage.
+    /// </summary>
+    Material NewMaterial(Shader shader, Texture2D tex, int blend, string name)
+    {
+        var m = new Material(shader);
+        m.name = name;
+        m.mainTexture = tex;
+
+        UnityEngine.Rendering.BlendMode src, dst;
+        bool alphaTest = false;
+        switch (blend)
+        {
+            case 0:  // BM_OPAQUE
+                src = UnityEngine.Rendering.BlendMode.One;
+                dst = UnityEngine.Rendering.BlendMode.Zero;
+                break;
+            case 1:  // BM_TRANSPARENT -- ONE/ZERO with the alpha test on
+                src = UnityEngine.Rendering.BlendMode.One;
+                dst = UnityEngine.Rendering.BlendMode.Zero;
+                alphaTest = true;
+                break;
+            case 3:  // BM_ADDITIVE
+                src = UnityEngine.Rendering.BlendMode.SrcColor;
+                dst = UnityEngine.Rendering.BlendMode.One;
+                break;
+            case 4:  // BM_ADDITIVE_ALPHA
+                src = UnityEngine.Rendering.BlendMode.SrcAlpha;
+                dst = UnityEngine.Rendering.BlendMode.One;
+                break;
+            case 5:  // BM_MODULATE
+                src = UnityEngine.Rendering.BlendMode.DstColor;
+                dst = UnityEngine.Rendering.BlendMode.Zero;
+                break;
+            case 6:  // BM_MODULATEX2
+                src = UnityEngine.Rendering.BlendMode.DstColor;
+                dst = UnityEngine.Rendering.BlendMode.SrcColor;
+                break;
+            case 7:  // BM_7, new in WoD
+                src = UnityEngine.Rendering.BlendMode.One;
+                dst = UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha;
+                break;
+            default: // 2, BM_ALPHA_BLEND -- and anything unknown, which the legacy also maps here
+                src = UnityEngine.Rendering.BlendMode.SrcAlpha;
+                dst = UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha;
+                break;
+        }
+        m.SetFloat("_SrcBlend", (float)src);
+        m.SetFloat("_DstBlend", (float)dst);
+        m.SetFloat("_AlphaTest", alphaTest ? 1f : 0f);
+        ownedMaterials.Add(m);
+        return m;
+    }
+
+    // =========================================================================================
+    // The ParticleColor override
+    // =========================================================================================
+
+    /// <summary>
+    /// Supply the three ParticleColor stop sets the app resolved for this model, or null to drop
+    /// back to what the emitters authored.
+    ///
+    /// An emitter opts in with ParticleColorIndex 11, 12 or 13, which select set 0, 1 and 2. The
+    /// override replaces the RGB of all three ramp stops and LEAVES THE AUTHORED ALPHA ALONE,
+    /// which is what the legacy does (particle.cpp:162-172) and is what makes it usable: the
+    /// alpha ramp is what fades a particle in and out over its life, and a colour table has no
+    /// opinion about that.
+    /// </summary>
+    public void SetParticleColorOverride(Color[][] sets)
+    {
+        particleColorOverride = sets;
+        for (int i = 0; i < particles.Count; i++)
+            ResolveRamp(particles[i]);
+    }
+
+    /// <summary>
+    /// Build the RGB ramp this emitter draws with.
+    ///
+    /// Where a ParticleColor override applies it replaces the RGB and NOTHING ELSE -- the
+    /// authored alpha ramp is untouched, which is what the legacy does (particle.cpp:162-172,
+    /// which copies the replacement colours and then puts the authored alphas back) and what
+    /// makes an override usable at all: the alpha ramp is what fades a particle in and out over
+    /// its life, and a colour table has no opinion about that.
+    /// </summary>
+    void ResolveRamp(ParticleState s)
+    {
+        WowVec3[] keys = s.Def.ColorKeys;
+        int idx = s.Def.ParticleColorIndex - 11;
+        Color[] over = null;
+        if (particleColorOverride != null && idx >= 0 && idx < particleColorOverride.Length &&
+            particleColorOverride[idx] != null && particleColorOverride[idx].Length >= 3)
+            over = particleColorOverride[idx];
+
+        if (keys == null || keys.Length == 0)
+        {
+            // No colour ramp: white for its whole life, or the override's own ramp if there is
+            // one. The alpha still reaches the particle -- it is a different track.
+            s.RampTimes = new float[] { 0f, 0.5f, 1f };
+            s.RampColor = over != null
+                ? new[] { over[0], over[1], over[2] }
+                : new[] { Color.white, Color.white, Color.white };
+            return;
+        }
+
+        int n = keys.Length;
+        float[] times = s.Def.ColorTimes;
+        s.RampTimes = times;
+        s.RampColor = new Color[n];
+        for (int i = 0; i < n; i++)
+        {
+            float at = (times != null && i < times.Length) ? times[i] : 0f;
+            s.RampColor[i] = over != null ? OverrideAt(over, at)
+                                          : new Color(keys[i].X, keys[i].Y, keys[i].Z, 1f);
+        }
+    }
+
+    /// <summary>A ParticleColor row is itself a start/middle/end ramp; sample it at a stop's
+    /// time so an override lands on the same curve the emitter authored.</summary>
+    static Color OverrideAt(Color[] set, float t)
+    {
+        return t <= 0.5f ? Color.Lerp(set[0], set[1], t * 2f)
+                         : Color.Lerp(set[1], set[2], (t - 0.5f) * 2f);
+    }
+
+    static float SampleAlphaRamp(M2ParticleEmitterDef def, float t)
+    {
+        if (def.AlphaKeys == null || def.AlphaKeys.Length == 0)
+            return 1f;
+        int a, b;
+        float r = RampSpan(def.AlphaTimes, t, out a, out b);
+        if (a >= def.AlphaKeys.Length) a = def.AlphaKeys.Length - 1;
+        if (b >= def.AlphaKeys.Length) b = def.AlphaKeys.Length - 1;
+        return a == b ? def.AlphaKeys[a] : Mathf.Lerp(def.AlphaKeys[a], def.AlphaKeys[b], r);
+    }
+
+    // =========================================================================================
+    // Per-frame
+    // =========================================================================================
+
+    /// <summary>
+    /// Advance every emitter by one animation frame and rebuild its mesh.
+    ///
+    /// dtSeconds is the ANIMATION's advance, not the frame's: zero while paused, scaled by the
+    /// playback speed otherwise. sequenceTimeMs and globalTimeMs are the two clocks the tracks
+    /// are sampled on, exactly as the bones and materials sample them.
+    /// </summary>
+    public void Tick(float dtSeconds, float sequenceTimeMs, float globalTimeMs)
+    {
+        Advance(dtSeconds, sequenceTimeMs, globalTimeMs);
+        Build(sequenceTimeMs, globalTimeMs);
+    }
+
+    /// <summary>
+    /// Move the simulation on by one animation step, WITHOUT touching a mesh.
+    ///
+    /// Split from the geometry so a pinned capture can run a hundred and twenty steps to reach
+    /// its instant and upload once, instead of uploading a frame nobody will ever see per step.
+    /// </summary>
+    public void Advance(float dtSeconds, float sequenceTimeMs, float globalTimeMs)
+    {
+        if (!HasAnything)
+            return;
+        if (dtSeconds < 0f)
+            dtSeconds = -dtSeconds;      // a scrub backwards must not run the simulation backwards
+
+        Matrix4x4 rootInverse = modelRoot.worldToLocalMatrix;
+
+        for (int i = 0; i < particles.Count; i++)
+        {
+            ParticleState s = particles[i];
+            AdvanceParticles(s, BoneMatrix(rootInverse, s.Bone, s.BindPose),
+                             dtSeconds, sequenceTimeMs, globalTimeMs);
+        }
+        for (int i = 0; i < ribbons.Count; i++)
+        {
+            RibbonState s = ribbons[i];
+            AdvanceRibbon(s, BoneMatrix(rootInverse, s.Bone, s.BindPose), dtSeconds);
+        }
+    }
+
+    /// <summary>
+    /// Write the current state into the meshes. Also the whole of a frame in which nothing
+    /// advanced -- a paused model still has to face a camera the user is moving.
+    /// </summary>
+    public void Build(float sequenceTimeMs, float globalTimeMs)
+    {
+        if (!HasAnything)
+            return;
+        Matrix4x4 rootInverse = modelRoot.worldToLocalMatrix;
+        Vector3 camRight, camUp;
+        BillboardBasis(rootInverse, out camRight, out camUp);
+
+        for (int i = 0; i < particles.Count; i++)
+        {
+            ParticleState s = particles[i];
+            BuildParticleMesh(s, BoneMatrix(rootInverse, s.Bone, s.BindPose), camRight, camUp);
+        }
+        for (int i = 0; i < ribbons.Count; i++)
+            BuildRibbonMesh(ribbons[i], sequenceTimeMs, globalTimeMs);
+    }
+
+    /// <summary>The legacy's Bone::mat, in this renderer's terms. See BindPoseFor.</summary>
+    static Matrix4x4 BoneMatrix(Matrix4x4 rootInverse, Transform bone, Matrix4x4 bindPose)
+    {
+        if (bone == null)
+            return Matrix4x4.identity;
+        return rootInverse * bone.localToWorldMatrix * bindPose;
+    }
+
+    /// <summary>
+    /// The billboard axes, in the model root's space.
+    ///
+    /// The legacy takes them from the first two rows of the GL modelview matrix
+    /// (particle.cpp:406-407), which is the camera's right and up expressed in the space the
+    /// particles are in. Same thing, said in Unity's vocabulary.
+    /// </summary>
+    void BillboardBasis(Matrix4x4 rootInverse, out Vector3 right, out Vector3 up)
+    {
+        if (billboardCamera == null)
+            billboardCamera = Camera.main;
+        if (billboardCamera == null)
+        {
+            right = Vector3.right;
+            up = Vector3.up;
+            return;
+        }
+        Transform t = billboardCamera.transform;
+        right = rootInverse.MultiplyVector(t.right).normalized;
+        up = rootInverse.MultiplyVector(t.up).normalized;
+        if (right.sqrMagnitude < 1e-8f) right = Vector3.right;
+        if (up.sqrMagnitude < 1e-8f) up = Vector3.up;
+    }
+
+    void AdvanceParticles(ParticleState s, Matrix4x4 boneMatrix, float dt,
+                          float seqMs, float globalMs)
+    {
+        // ---- emission -----------------------------------------------------------------------
+        // (dt * rate / lifespan) + carry, from particle.cpp:203-224. Dividing by the lifespan is
+        // what makes "rate" the number ALIVE at once rather than the number spawned per second:
+        // at equilibrium, rate/lifespan spawns per second times lifespan seconds of life is rate
+        // particles standing.
+        if (dt > 0f)
+        {
+            float rate = Sample(s.Def.EmissionRate, seqMs, globalMs, 0f);
+            float lifespan = Sample(s.Def.Lifespan, seqMs, globalMs, 0f);
+            bool enabled = !s.Def.EnabledIn.HasData
+                           || Sample(s.Def.EnabledIn, seqMs, globalMs, 1f) != 0f;
+
+            float toSpawn = lifespan > 0f ? (dt * rate / lifespan) + s.SpawnRemainder
+                                          : s.SpawnRemainder;
+            if (toSpawn < 1f)
+            {
+                s.SpawnRemainder = toSpawn > 0f ? toSpawn : 0f;
+            }
+            else
+            {
+                int n = (int)toSpawn;
+                s.SpawnRemainder = toSpawn - n;
+                if (enabled)
+                {
+                    float speed = Sample(s.Def.EmissionSpeed, seqMs, globalMs, 0f);
+                    float variation = Sample(s.Def.SpeedVariation, seqMs, globalMs, 0f);
+                    float vertical = Sample(s.Def.VerticalRange, seqMs, globalMs, 0f);
+                    float horizontal = Sample(s.Def.HorizontalRange, seqMs, globalMs, 0f);
+                    // areal/areaw are halved before use, so the jitter is +/- half the area and
+                    // the emitter spans the authored width (particle.cpp:226-227).
+                    float halfLength = Sample(s.Def.EmissionAreaLength, seqMs, globalMs, 0f) * 0.5f;
+                    float halfWidth = Sample(s.Def.EmissionAreaWidth, seqMs, globalMs, 0f) * 0.5f;
+                    for (int i = 0; i < n && s.Count < s.Capacity; i++)
+                        Spawn(s, boneMatrix, lifespan, speed, variation, vertical, horizontal,
+                              halfLength, halfWidth);
+                }
+            }
+        }
+
+        // ---- integrate ----------------------------------------------------------------------
+        float gravity = Sample(s.Def.Gravity, seqMs, globalMs, 0f);
+        Vector3 down = new Vector3(0f, -1f, 0f);      // WoW -Z is Unity -Y
+        float slowdown = s.Def.Slowdown;
+
+        for (int i = 0; i < s.Count; )
+        {
+            s.Vel[i] += down * (gravity * dt);
+            float damping = slowdown > 0f ? Mathf.Exp(-slowdown * s.Life[i]) : 1f;
+            s.Pos[i] += s.Vel[i] * (damping * dt);
+            s.Life[i] += dt;
+
+            if (s.MaxLife[i] <= 0f || s.Life[i] >= s.MaxLife[i])
+            {
+                // Swap-with-last removal: O(1), no shuffling, no allocation. Order within an
+                // emitter is not meaningful -- the legacy draws its list in whatever order the
+                // std::list happens to hold, and every blend mode here is order-independent
+                // except alpha blend, whose particles are the same texture and colour anyway.
+                int last = s.Count - 1;
+                s.Pos[i] = s.Pos[last];
+                s.Vel[i] = s.Vel[last];
+                s.Life[i] = s.Life[last];
+                s.MaxLife[i] = s.MaxLife[last];
+                s.TileSeed[i] = s.TileSeed[last];
+                if (s.QuadRight != null)
+                {
+                    s.QuadRight[i] = s.QuadRight[last];
+                    s.QuadUp[i] = s.QuadUp[last];
+                }
+                s.Count--;
+                continue;
+            }
+            i++;
+        }
+    }
+
+    void Spawn(ParticleState s, Matrix4x4 boneMatrix, float lifespan, float speed,
+               float variation, float vertical, float horizontal, float halfLength, float halfWidth)
+    {
+        int i = s.Count++;
+
+        // The spread cone: tilt local +Z by a random angle within the VERTICAL range, then swing
+        // it by a random angle within the HORIZONTAL range. Both ranges are full cone angles, so
+        // the random half-angle is +/- range/2 -- particle.cpp:521-522.
+        float tilt = RandRange(s, -vertical, vertical) * 0.5f;
+        float swing = RandRange(s, -horizontal, horizontal) * 0.5f;
+        float ct = Mathf.Cos(tilt), st = Mathf.Sin(tilt);
+        float cs = Mathf.Cos(swing), ss = Mathf.Sin(swing);
+
+        // Local axes in WoW terms (emit along +Z), written straight in Unity's: WoW +Z is Unity
+        // +Y, WoW +X is Unity +Z, WoW +Y is Unity -X.
+        Vector3 dirLocal = new Vector3(-st * ss, ct, st * cs);
+        Vector3 rightLocal = new Vector3(-cs, 0f, ss);
+
+        Vector3 posLocal;
+        if (s.Def.EmitterType == (byte)M2EmitterType.Sphere)
+        {
+            // A sphere emitter puts the particle ON the shell it just picked a direction on, at a
+            // random radius, and (when OUTWARD) sends it along that same radius.
+            float radius = RandUnit(s);
+            Vector3 shell = new Vector3(dirLocal.x * halfWidth, dirLocal.y * halfLength,
+                                        dirLocal.z * halfWidth) * radius;
+            posLocal = s.Origin + shell;
+            if (!s.Def.Outward && shell.sqrMagnitude > 1e-12f)
+                dirLocal = new Vector3(0f, 1f, 0f);
+            else if (shell.sqrMagnitude > 1e-12f)
+                dirLocal = shell.normalized;
+        }
+        else
+        {
+            // A plane emitter scatters over its rectangle. areal runs along the model's forward
+            // axis and areaw across it (particle.cpp:596).
+            posLocal = s.Origin + new Vector3(-RandRange(s, -halfWidth, halfWidth), 0f,
+                                              RandRange(s, -halfLength, halfLength));
+        }
+
+        float scale = speed * (1f + RandRange(s, -variation, variation));
+
+        if (s.BoneLocal)
+        {
+            s.Pos[i] = posLocal;
+            s.Vel[i] = dirLocal * scale;
+            if (s.QuadRight != null)
+            {
+                s.QuadRight[i] = rightLocal;
+                s.QuadUp[i] = dirLocal;
+            }
+        }
+        else
+        {
+            s.Pos[i] = boneMatrix.MultiplyPoint3x4(posLocal);
+            s.Vel[i] = boneMatrix.MultiplyVector(dirLocal) * scale;
+            if (s.QuadRight != null)
+            {
+                s.QuadRight[i] = boneMatrix.MultiplyVector(rightLocal);
+                s.QuadUp[i] = boneMatrix.MultiplyVector(dirLocal);
+            }
+        }
+
+        s.Life[i] = 0f;
+        // A lifespan of zero would divide by zero in the life ramp; the legacy substitutes one
+        // second (particle.cpp:619-620).
+        s.MaxLife[i] = lifespan > 0f ? lifespan : 1f;
+        s.TileSeed[i] = (s.Def.RandomTexture || s.Def.RandomStart)
+                        ? (int)(RandUnit(s) * s.TileCount) % s.TileCount : 0;
+    }
+
+    // =========================================================================================
+    // The life ramps
+    // =========================================================================================
+    //
+    // A ramp is a list of (normalised time, value) stops evaluated piecewise-linearly against a
+    // particle's own age -- NOT the legacy's three fixed stops at 0 / 0.5 / 1 (lifeRamp,
+    // particle.cpp:17-24, with mid pinned at :57). 42 % of the client's ramps do not have three
+    // stops, and of those that do, the middle one sits at 0.5 only 55 % of the time. See
+    // M2ParticleEmitterDef.ColorTimes.
+
+    /// <summary>Locate a normalised age among a ramp's times. Before the first stop and after the
+    /// last, the ramp holds -- which is what an authored ramp bounded by 0 and 1 means.</summary>
+    static float RampSpan(float[] times, float t, out int i0, out int i1)
+    {
+        int n = times != null ? times.Length : 0;
+        if (n <= 1) { i0 = i1 = 0; return 0f; }
+        if (t <= times[0]) { i0 = i1 = 0; return 0f; }
+        if (t >= times[n - 1]) { i0 = i1 = n - 1; return 0f; }
+        int lo = 0, hi = n - 1;
+        while (hi - lo > 1)
+        {
+            int mid = (lo + hi) >> 1;
+            if (times[mid] <= t) lo = mid; else hi = mid;
+        }
+        i0 = lo; i1 = hi;
+        float span = times[hi] - times[lo];
+        return span > 0f ? (t - times[lo]) / span : 0f;
+    }
+
+    static Color RampColorAt(float[] times, Color[] keys, float t, Color fallback)
+    {
+        if (keys == null || keys.Length == 0) return fallback;
+        int a, b;
+        float r = RampSpan(times, t, out a, out b);
+        if (a >= keys.Length) a = keys.Length - 1;
+        if (b >= keys.Length) b = keys.Length - 1;
+        return a == b ? keys[a] : Color.Lerp(keys[a], keys[b], r);
+    }
+
+    static WowVec2 RampSizeAt(float[] times, WowVec2[] keys, float t)
+    {
+        if (keys == null || keys.Length == 0) return new WowVec2(1f, 1f);
+        int a, b;
+        float r = RampSpan(times, t, out a, out b);
+        if (a >= keys.Length) a = keys.Length - 1;
+        if (b >= keys.Length) b = keys.Length - 1;
+        if (a == b) return keys[a];
+        return new WowVec2(Mathf.Lerp(keys[a].X, keys[b].X, r), Mathf.Lerp(keys[a].Y, keys[b].Y, r));
+    }
+
+    void BuildParticleMesh(ParticleState s, Matrix4x4 boneMatrix, Vector3 camRight, Vector3 camUp)
+    {
+        int v = 0;
+        Vector3 min = Vector3.positiveInfinity, max = Vector3.negativeInfinity;
+        bool billboard = !s.Def.DoNotBillboard;
+        float spin = s.Def.SpriteRotation;
+        float spinCos = 1f, spinSin = 0f;
+        if (billboard && spin != 0f)
+        {
+            spinCos = Mathf.Cos(spin);
+            spinSin = Mathf.Sin(spin);
+        }
+
+        for (int i = 0; i < s.Count; i++)
+        {
+            float t = Mathf.Clamp01(s.Life[i] / s.MaxLife[i]);
+
+            Vector3 centre = s.BoneLocal ? boneMatrix.MultiplyPoint3x4(s.Pos[i]) : s.Pos[i];
+            // The x stop scales the quad's right axis and the y stop its up axis. The legacy uses
+            // the x for both (particle.cpp:55); real emitters author non-square sizes -- Battle
+            // Magister's Orbs runs (0.173,0.138) -> (0.315,0.252) -> (0.069,0.055).
+            WowVec2 size = RampSizeAt(s.Def.SizeTimes, s.Def.SizeKeys, t);
+            float halfX = size.X;
+            float halfY = size.Y;
+
+            Vector3 right, up;
+            if (billboard)
+            {
+                // The sprite rotation turns the quad in the plane facing the camera.
+                right = (camRight * spinCos + camUp * spinSin) * halfX;
+                up = (camUp * spinCos - camRight * spinSin) * halfY;
+            }
+            else
+            {
+                Vector3 r = s.QuadRight[i];
+                Vector3 u = s.QuadUp[i];
+                if (s.BoneLocal)
+                {
+                    r = boneMatrix.MultiplyVector(r);
+                    u = boneMatrix.MultiplyVector(u);
+                }
+                right = r * halfX;
+                up = u * halfY;
+            }
+
+            // Colour and alpha are sampled INDEPENDENTLY, each on its own track's times. See
+            // ParticleState.RampColor for what folding them together costs.
+            Color rgb = RampColorAt(s.RampTimes, s.RampColor, t, Color.white);
+            Color32 c32 = new Color(rgb.r, rgb.g, rgb.b, SampleAlphaRamp(s.Def, t));
+
+            // The flipbook. RANDOMTEXTURE holds the tile the particle was born with; otherwise
+            // the tile advances across rows*cols over the particle's life, starting at the tile
+            // RANDOMSTART picked. See divergence 9 in the file header.
+            int tile;
+            if (s.Def.RandomTexture)
+                tile = s.TileSeed[i];
+            else if (s.TileCount > 1)
+                tile = (s.TileSeed[i] + (int)(t * s.TileCount)) % s.TileCount;
+            else
+                tile = 0;
+            int col = tile % s.Def.Cols;
+            int row = tile / s.Def.Cols;
+            float u0 = col / (float)s.Def.Cols, u1 = (col + 1) / (float)s.Def.Cols;
+            // WoW's V runs down from the top and Unity's up from the bottom, the same flip the
+            // mesh UVs take (WowCoordinateConverter.ConvertTexCoord).
+            float v1 = 1f - row / (float)s.Def.Rows, v0 = 1f - (row + 1) / (float)s.Def.Rows;
+
+            Vector3 p0 = centre - right - up;
+            Vector3 p1 = centre + right - up;
+            Vector3 p2 = centre + right + up;
+            Vector3 p3 = centre - right + up;
+
+            s.Verts[v] = p0; s.Uvs[v] = new Vector2(u0, v0); s.Colors[v++] = c32;
+            s.Verts[v] = p1; s.Uvs[v] = new Vector2(u1, v0); s.Colors[v++] = c32;
+            s.Verts[v] = p2; s.Uvs[v] = new Vector2(u1, v1); s.Colors[v++] = c32;
+            s.Verts[v] = p3; s.Uvs[v] = new Vector2(u0, v1); s.Colors[v++] = c32;
+
+            Grow(ref min, ref max, p0);
+            Grow(ref min, ref max, p2);
+        }
+
+        Upload(s.Mesh, s.Verts, s.Uvs, s.Colors, s.Indices, v, s.Count * 6, min, max);
+    }
+
+    // =========================================================================================
+    // Ribbons
+    // =========================================================================================
+    //
+    // A ribbon is a trail of EDGES left behind by a point on a bone. Each edge remembers where
+    // that point was and which way was "up" for it; the strip between consecutive edges is the
+    // ribbon. An edge is laid down every 1/res seconds and retired once it is `length` seconds
+    // old, so a res of 50 and a length of 0.2 -- the Thunderblade's numbers -- is a ten-edge
+    // ribbon covering the last fifth of a second of the sword's motion.
+    //
+    // WHY NOT THE LEGACY'S GEOMETRY. RibbonEmitter::setup (particle.cpp:773-822) reads `res` as a
+    // segment COUNT and `length` as a spatial segment LENGTH, multiplies them into a total
+    // spatial length, and advances the head by
+    //
+    //     float dlen = (ntpos-tpos).length();
+    //
+    // glm::vec3::length() returns the number of COMPONENTS -- 3 -- not the magnitude. So dlen is
+    // the constant 3 on every frame of every ribbon ever drawn, the head advances by 3 whatever
+    // the bone did, and the ribbon's extent has nothing to do with how far anything moved. The
+    // "up" vector two lines above has the same class of mistake twice over: it is built as
+    //
+    //     ntup = parent->mat * (vec4(pos,1) + vec4(0,0,1,1));   // w becomes 2: the translation
+    //     ntup -= ntpos;                                        // is added a second time
+    //     glm::normalize(ntup);                                 // result discarded
+    //
+    // so it is neither a direction nor normalised. Above and below it, the file's own comment
+    // reads "TODO: figure out actual correct way to calculate length" and gives two models it
+    // gets visibly wrong in opposite directions.
+    //
+    // The data settles what the fields mean without having to guess: across this client `res` is
+    // 30..100 and `length` is 0.1..2.0. Read as a count and a distance those are 30..100 segments
+    // spanning 3..200 model units -- a ribbon longer than most models are tall. Read as edges per
+    // second and a lifetime in seconds they are 5..200 edges covering a tenth of a second to two
+    // seconds of motion, which is what a weapon trail is.
+
+    void AdvanceRibbon(RibbonState s, Matrix4x4 boneMatrix, float dt)
+    {
+        Vector3 pos = boneMatrix.MultiplyPoint3x4(s.Origin);
+        // "Up" is the emitter's own +Z carried by the bone: the ribbon is a flat band standing
+        // on the spine, and this is which way it stands. WoW +Z is Unity +Y.
+        Vector3 up = boneMatrix.MultiplyVector(Vector3.up);
+        if (up.sqrMagnitude < 1e-12f)
+            up = Vector3.up;
+        else
+            up = up.normalized;
+
+        if (!s.HasPrevious)
+        {
+            s.Head = 0;
+            s.Count = 0;
+            s.SinceLastEdge = 0f;
+            s.HasPrevious = true;
+            PushEdge(s, pos, up);
+            return;
+        }
+
+        for (int i = 0; i < s.Count; i++)
+            s.EdgeAge[(s.Head + i) % s.Capacity] += dt;
+
+        // Retire from the tail anything older than the edge lifetime. The newest edge is never
+        // retired, so a ribbon on a paused model keeps the shape it had.
+        while (s.Count > 1 && s.EdgeAge[s.Head] > s.Lifetime)
+        {
+            s.Head = (s.Head + 1) % s.Capacity;
+            s.Count--;
+        }
+
+        // The head edge tracks the bone continuously; a new one is laid down once the interval
+        // has passed. Without the first part a slow ribbon would visibly lag its own emitter.
+        int head = (s.Head + s.Count - 1) % s.Capacity;
+        s.EdgePos[head] = pos;
+        s.EdgeUp[head] = up;
+
+        s.SinceLastEdge += dt;
+        while (s.SinceLastEdge >= s.EdgeInterval && s.EdgeInterval > 0f)
+        {
+            s.SinceLastEdge -= s.EdgeInterval;
+            PushEdge(s, pos, up);
+        }
+    }
+
+    static void PushEdge(RibbonState s, Vector3 pos, Vector3 up)
+    {
+        if (s.Count >= s.Capacity)
+        {
+            // Full: drop the oldest. The ring is sized from res * lifetime, so this is the
+            // safety net rather than the normal path.
+            s.Head = (s.Head + 1) % s.Capacity;
+            s.Count--;
+        }
+        int slot = (s.Head + s.Count) % s.Capacity;
+        s.EdgePos[slot] = pos;
+        s.EdgeUp[slot] = up;
+        s.EdgeAge[slot] = 0f;
+        s.Count++;
+    }
+
+    void BuildRibbonMesh(RibbonState s, float seqMs, float globalMs)
+    {
+        Color tint = Color.white;
+        if (s.Def.Color.HasData)
+        {
+            WowVec3 c = SampleVec3(s.Def.Color, seqMs, globalMs);
+            tint = new Color(c.X, c.Y, c.Z, 1f);
+        }
+        tint.a = s.Def.Opacity.HasData ? Sample(s.Def.Opacity, seqMs, globalMs, 1f) : 1f;
+        float above = Sample(s.Def.Above, seqMs, globalMs, 0f);
+        float below = Sample(s.Def.Below, seqMs, globalMs, 0f);
+
+        int v = 0;
+        Vector3 min = Vector3.positiveInfinity, max = Vector3.negativeInfinity;
+        // Walk newest first, so u = 0 is the emitter and u = 1 is the tail. That is the direction
+        // a trail texture is authored in, and it matches the legacy's own walk, which runs from
+        // the head of its list (particle.cpp:851-862).
+        for (int i = 0; i < s.Count; i++)
+        {
+            int slot = (s.Head + s.Count - 1 - i) % s.Capacity;
+            float age = s.Lifetime > 0f ? Mathf.Clamp01(s.EdgeAge[slot] / s.Lifetime) : 0f;
+            Vector3 p = s.EdgePos[slot];
+            Vector3 u = s.EdgeUp[slot];
+
+            Vector3 top = p + u * above;
+            Vector3 bottom = p - u * below;
+
+            // The band fades out along its length rather than ending in a hard edge. The legacy
+            // draws a flat colour and lets the texture do it; a texture that does not, ends
+            // abruptly, and every ribbon in the validation set is a soft streak.
+            Color32 c32 = new Color(tint.r, tint.g, tint.b, tint.a * (1f - age));
+
+            s.Verts[v] = top; s.Uvs[v] = new Vector2(age, 0f); s.Colors[v++] = c32;
+            s.Verts[v] = bottom; s.Uvs[v] = new Vector2(age, 1f); s.Colors[v++] = c32;
+
+            Grow(ref min, ref max, top);
+            Grow(ref min, ref max, bottom);
+        }
+
+        int quads = s.Count > 1 ? s.Count - 1 : 0;
+        Upload(s.Mesh, s.Verts, s.Uvs, s.Colors, s.Indices, v, quads * 6, min, max);
+    }
+
+    // =========================================================================================
+    // Mesh upload
+    // =========================================================================================
+
+    /// <summary>
+    /// Push one emitter's geometry. Every array was allocated at build time and is passed with a
+    /// length, so nothing here allocates: the steady state of a model with particles is zero
+    /// managed allocations per frame.
+    ///
+    /// Clear(false) first because the vertex count shrinks as particles die, and an index buffer
+    /// still describing the larger mesh would be validated against the smaller one.
+    /// </summary>
+    static void Upload(Mesh mesh, Vector3[] verts, Vector2[] uvs, Color32[] colors, int[] indices,
+                       int vertexCount, int indexCount, Vector3 min, Vector3 max)
+    {
+        mesh.Clear(false);
+        if (vertexCount <= 0 || indexCount <= 0)
+            return;
+        mesh.SetVertices(verts, 0, vertexCount);
+        mesh.SetUVs(0, uvs, 0, vertexCount);
+        mesh.SetColors(colors, 0, vertexCount);
+        mesh.SetIndices(indices, 0, indexCount, MeshTopology.Triangles, 0, false);
+        // Bounds are computed from the points that were just written rather than by
+        // RecalculateBounds, which would walk the vertex array a second time.
+        mesh.bounds = new Bounds((min + max) * 0.5f, max - min);
+    }
+
+    static void Grow(ref Vector3 min, ref Vector3 max, Vector3 p)
+    {
+        if (p.x < min.x) min.x = p.x;
+        if (p.y < min.y) min.y = p.y;
+        if (p.z < min.z) min.z = p.z;
+        if (p.x > max.x) max.x = p.x;
+        if (p.y > max.y) max.y = p.y;
+        if (p.z > max.z) max.z = p.z;
+    }
+
+    static int[] BuildQuadIndices(int quads)
+    {
+        var idx = new int[quads * 6];
+        for (int q = 0; q < quads; q++)
+        {
+            int v = q * 4, i = q * 6;
+            idx[i] = v; idx[i + 1] = v + 2; idx[i + 2] = v + 1;
+            idx[i + 3] = v; idx[i + 4] = v + 3; idx[i + 5] = v + 2;
+        }
+        return idx;
+    }
+
+    static int[] BuildStripIndices(int edges)
+    {
+        int quads = edges > 1 ? edges - 1 : 0;
+        var idx = new int[quads * 6];
+        for (int q = 0; q < quads; q++)
+        {
+            int v = q * 2, i = q * 6;
+            idx[i] = v; idx[i + 1] = v + 2; idx[i + 2] = v + 1;
+            idx[i + 3] = v + 1; idx[i + 4] = v + 2; idx[i + 5] = v + 3;
+        }
+        return idx;
+    }
+
+    // =========================================================================================
+    // Track evaluation -- the same rules the bones and materials follow
+    // =========================================================================================
+
+    float Sample(M2Track<float> track, float seqMs, float globalMs, float fallback)
+    {
+        if (!track.HasData)
+            return fallback;
+        float t = TimeFor(track.GlobalSequence, track.IsGlobal, seqMs, globalMs);
+        int i0, i1;
+        float r = Locate(track.Times, t, out i0, out i1);
+        if (track.Interpolation == M2Interpolation.None)
+            return track.Values[i0];
+        return Mathf.Lerp(track.Values[i0], track.Values[i1], r);
+    }
+
+    WowVec3 SampleVec3(M2Track<WowVec3> track, float seqMs, float globalMs)
+    {
+        if (!track.HasData)
+            return new WowVec3(1f, 1f, 1f);
+        float t = TimeFor(track.GlobalSequence, track.IsGlobal, seqMs, globalMs);
+        int i0, i1;
+        float r = Locate(track.Times, t, out i0, out i1);
+        WowVec3 a = track.Values[i0];
+        if (track.Interpolation == M2Interpolation.None || i0 == i1)
+            return a;
+        WowVec3 b = track.Values[i1];
+        return new WowVec3(Mathf.Lerp(a.X, b.X, r), Mathf.Lerp(a.Y, b.Y, r), Mathf.Lerp(a.Z, b.Z, r));
+    }
+
+    /// <summary>
+    /// Which clock a track runs on. A global-sequence track loops over its own duration on the
+    /// shared clock, whatever the animation is doing -- the same rule WmvM2Animator applies, and
+    /// the reason a torch keeps flickering on a paused model.
+    /// </summary>
+    float TimeFor(int globalSequence, bool isGlobal, float seqMs, float globalMs)
+    {
+        if (!isGlobal)
+            return seqMs;
+        uint[] gs = globalSequences;
+        if (gs == null || globalSequence < 0 || globalSequence >= gs.Length || gs[globalSequence] == 0)
+            return 0f;
+        float d = gs[globalSequence];
+        float t = globalMs - Mathf.Floor(globalMs / d) * d;
+        return t;
+    }
+
+    uint[] globalSequences = new uint[0];
+
+    /// <summary>The model's global-sequence durations, needed to evaluate a track bound to one.</summary>
+    public void SetGlobalSequences(uint[] durations)
+    {
+        globalSequences = durations ?? new uint[0];
+    }
+
+    /// <summary>Find the keys either side of t and how far between them it sits. Past the last
+    /// key a track holds its last value, which is what the legacy evaluator does
+    /// (Animated::getValue, animated.h).</summary>
+    static float Locate(uint[] times, float t, out int i0, out int i1)
+    {
+        int n = times.Length;
+        if (n <= 1) { i0 = i1 = 0; return 0f; }
+        if (t <= times[0]) { i0 = i1 = 0; return 0f; }
+        if (t >= times[n - 1]) { i0 = i1 = n - 1; return 0f; }
+        int lo = 0, hi = n - 1;
+        while (hi - lo > 1)
+        {
+            int mid = (lo + hi) >> 1;
+            if (times[mid] <= t) lo = mid; else hi = mid;
+        }
+        i0 = lo; i1 = hi;
+        float span = times[hi] - times[lo];
+        return span > 0f ? (t - times[lo]) / span : 0f;
+    }
+
+    // =========================================================================================
+    // Deterministic randomness
+    // =========================================================================================
+    //
+    // xorshift32 per emitter, seeded from the emitter index. Deterministic on purpose: a pinned
+    // capture at "1.0 s" has to produce the same frame every time or a BEFORE and an AFTER of
+    // the same instant cannot be compared, and UnityEngine.Random would also be sharing state
+    // with whatever else the scene does.
+
+    static uint NextRandom(ParticleState s)
+    {
+        uint x = s.Rng;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        s.Rng = x;
+        return x;
+    }
+
+    static float RandUnit(ParticleState s)
+    {
+        return (NextRandom(s) & 0xFFFFFF) / (float)0x1000000;
+    }
+
+    static float RandRange(ParticleState s, float a, float b)
+    {
+        return a == b ? a : a + (b - a) * RandUnit(s);
+    }
+
+    // =========================================================================================
+    // Lifecycle
+    // =========================================================================================
+
+    /// <summary>
+    /// Throw away every live particle and every ribbon edge, keeping the emitters themselves.
+    ///
+    /// Called when the sequence changes and when a pinned simulation restarts. Without it a
+    /// ribbon would draw a straight line from wherever the bone was in the old animation to
+    /// wherever it is in the new one -- a smear across the model that no bone ever traced.
+    /// </summary>
+    public void ResetState()
+    {
+        for (int i = 0; i < particles.Count; i++)
+        {
+            ParticleState s = particles[i];
+            s.Count = 0;
+            s.SpawnRemainder = 0f;
+            s.Rng = (uint)(0x9E3779B9u * (uint)(i + 1) + 0x85EBCA6Bu);
+            s.Mesh.Clear(false);
+        }
+        for (int i = 0; i < ribbons.Count; i++)
+        {
+            RibbonState s = ribbons[i];
+            s.Head = 0;
+            s.Count = 0;
+            s.SinceLastEdge = 0f;
+            s.HasPrevious = false;
+            s.Mesh.Clear(false);
+        }
+    }
+
+    /// <summary>
+    /// Re-point the emitters at a re-parsed model, for when the app changes the animation.
+    ///
+    /// The DEFINITIONS come back with their tracks narrowed to the new sequence, which is the
+    /// whole reason this exists: an emitter that has no EmissionRate keys in the new sequence has
+    /// to stop, and one that gains them has to start. Emitter identity is by index, and the
+    /// emitter array does not depend on which sequence was parsed, so index i is the same emitter
+    /// it was. Anything else -- a different model, a different count -- rebuilds instead.
+    /// </summary>
+    public bool Rebind(M2ParsedModel model)
+    {
+        if (model == null)
+            return false;
+        if (model.ParticleEmitters.Length != particles.Count ||
+            model.RibbonEmitters.Length != ribbons.Count)
+            return false;
+        for (int i = 0; i < particles.Count; i++)
+        {
+            particles[i].Def = model.ParticleEmitters[i];
+            ResolveRamp(particles[i]);
+        }
+        for (int i = 0; i < ribbons.Count; i++)
+        {
+            RibbonState s = ribbons[i];
+            s.Def = model.RibbonEmitters[i];
+            s.Lifetime = s.Def.EdgeLifetimeSeconds > 0f ? s.Def.EdgeLifetimeSeconds : 0.5f;
+            s.EdgeInterval = 1f / (s.Def.EdgesPerSecond > 0f ? s.Def.EdgesPerSecond : 30f);
+        }
+        SetGlobalSequences(model.GlobalSequences);
+        ResetState();
+        return true;
+    }
+
+    void Clear()
+    {
+        for (int i = 0; i < particles.Count; i++)
+            if (particles[i].Go != null) Destroy(particles[i].Go);
+        for (int i = 0; i < ribbons.Count; i++)
+            if (ribbons[i].Go != null) Destroy(ribbons[i].Go);
+        particles.Clear();
+        ribbons.Clear();
+        for (int i = 0; i < ownedMaterials.Count; i++)
+            if (ownedMaterials[i] != null) Destroy(ownedMaterials[i]);
+        for (int i = 0; i < ownedMeshes.Count; i++)
+            if (ownedMeshes[i] != null) Destroy(ownedMeshes[i]);
+        ownedMaterials.Clear();
+        ownedMeshes.Clear();
+    }
+
+    void OnDestroy()
+    {
+        Clear();
+    }
+
+    static Vector3 ToUnity(WowVec3 v)
+    {
+        float x, y, z;
+        WowCoordinateConverter.ConvertPosition(v, out x, out y, out z);
+        return new Vector3(x, y, z);
+    }
+
+    // =========================================================================================
+    // Pinned capture
+    // =========================================================================================
+
+    /// <summary>
+    /// Run the simulation from a clean state to a given instant, in fixed steps.
+    ///
+    /// A capture taken with -wmvAnimTime holds both clocks still, which is exactly right for
+    /// bones and exactly wrong for emitters: a frozen clock never spawns a particle, so a pinned
+    /// AFTER would be as empty as the BEFORE it is meant to be compared with. This runs the
+    /// emitters forward to the pinned instant instead, deterministically, so "1.0 s" is the same
+    /// frame every time it is captured.
+    ///
+    /// poseAt is called before each step with that step's sequence time, so particles are emitted
+    /// from where the bone actually was rather than from where it ends up.
+    /// </summary>
+    public void SimulateTo(float wallMs, Func<float, float> sequenceTimeAt, Action<float> poseAt)
+    {
+        ResetState();
+        float seconds = Mathf.Clamp(wallMs / 1000f, 0f, PinnedMaxSeconds);
+        int steps = Mathf.CeilToInt(seconds / PinnedStepSeconds);
+        float lastSeq = sequenceTimeAt != null ? sequenceTimeAt(wallMs) : wallMs;
+        for (int i = 1; i <= steps; i++)
+        {
+            float wall = Mathf.Min(i * PinnedStepSeconds * 1000f, wallMs);
+            lastSeq = sequenceTimeAt != null ? sequenceTimeAt(wall) : wall;
+            if (poseAt != null)
+                poseAt(lastSeq);
+            Advance(PinnedStepSeconds, lastSeq, wall);
+        }
+        if (steps == 0 && poseAt != null)
+            poseAt(lastSeq);
+        // One upload, for the instant that was asked for.
+        Build(lastSeq, wallMs);
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvIpcClient.cs
@@ -114,6 +114,19 @@ public class WmvIpcClient : MonoBehaviour
         /// </summary>
         public int[] geosets = new int[0];
         public bool hasGeosets;
+
+        /// <summary>
+        /// The item ParticleColor override for this model, as nine bytes:
+        /// [start.r, start.g, start.b, mid.r, mid.g, mid.b, end.r, end.g, end.b], 0..255. Empty
+        /// when the item display names no particle colour, which is the common case.
+        ///
+        /// An M2 particle emitter opts in with ParticleColorIndex 11, 12 or 13, selecting the
+        /// start, middle or end set. Retail assigns the colour on ItemDisplayInfo and recolours
+        /// the emitters of the models that display references; WMV has always parsed the emitter's
+        /// index but never resolved a colour to put there.
+        /// </summary>
+        public int[] particleColor = new int[0];
+        public int particleColorId;
     }
 
     /// <summary>
@@ -157,6 +170,8 @@ public class WmvIpcClient : MonoBehaviour
         public MsgTexture[] textures;
         public int[] geosets;
         public bool hasGeosets;
+        public int[] particleColor;
+        public int particleColorId;
         public string type;
         public string requestId;
         public string path;
@@ -292,6 +307,8 @@ public class WmvIpcClient : MonoBehaviour
         }
         r.hasGeosets = msg.hasGeosets;
         if (msg.geosets != null) r.geosets = msg.geosets;
+        if (msg.particleColor != null) r.particleColor = msg.particleColor;
+        r.particleColorId = msg.particleColorId;
         return r;
     }
 

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
@@ -113,6 +113,133 @@ public static class WmvLifecycleSelfTest
     /// change is an index-buffer switch; if it started recreating the mesh, materials or textures
     /// the model would flicker and every per-model diagnostic would reset.
     /// </summary>
+
+    // ---------------------------------------------------------------- emitters
+
+    /// <summary>A 2x2 opaque white texture, so an emitter has something to bind. The lifecycle
+    /// test never looks at a pixel; it only needs the slot to resolve.</summary>
+    static BlpImage FlatTexture()
+    {
+        var img = new BlpImage { Width = 2, Height = 2, Rgba = new byte[2 * 2 * 4], Encoding = "test" };
+        for (int i = 0; i < img.Rgba.Length; i++) img.Rgba[i] = 255;
+        return img;
+    }
+
+    static Dictionary<int, BlpImage> EmitterTextures()
+    {
+        return new Dictionary<int, BlpImage> { { 0, FlatTexture() }, { 1, FlatTexture() } };
+    }
+
+    /// <summary>
+    /// The emitter runtime, driven through the real builder the way the host drives it.
+    ///
+    /// What this is actually for: the emitters are the first thing in this renderer whose state
+    /// is a HISTORY rather than a function of the current instant, so the questions worth asking
+    /// are the lifecycle ones -- does a sequence change stop an emitter that should stop, does it
+    /// leave the previous animation's particles behind, does a model without emitters pay for the
+    /// feature at all, and does a rebuild produce two of everything.
+    /// </summary>
+    static void EmitterTests(Action<string> log)
+    {
+        // Rate keys in ANIMATION 0. The emitter float tracks are read there whichever sequence
+        // plays -- WMV's bZeroParticle default, see M2Parser -- so this is the fixture that
+        // emits, and the sequence-change check below is that switching does NOT stop it.
+        byte[] m2 = M2Synthetic.EmitterModel(0);
+        byte[] sk = M2Synthetic.TransformSwitchSkin();
+
+        M2ParsedModel model = M2Parser.Parse(m2, 0);
+        M2ParsedSkin skin = M2SkinParser.Parse(sk);
+        WmvRuntimeModel rt = WmvModelBuilder.Build(model, skin, EmitterTextures(), "EmitterTest",
+                                                   s => log("  " + s));
+        Check(rt != null && rt.Root != null, "emitter: model built", log);
+        Check(rt.Emitters != null, "emitter: runtime component added", log);
+        if (rt.Emitters == null) { rt.Dispose(); return; }
+
+        Check(rt.Emitters.ParticleEmitterCount == 1, "emitter: one particle emitter drawn", log);
+        Check(rt.Emitters.RibbonEmitterCount == 1, "emitter: one ribbon emitter drawn", log);
+        Check(rt.Emitters.DrawCallCount == 2, "emitter: two draw calls, not two per particle", log);
+        Check(rt.Emitters.SkippedEmitterCount == 0, "emitter: nothing skipped", log);
+        Check(rt.Animator != null, "emitter: a clock exists for the emitters to run on", log);
+        Check(rt.Animator.Emitters == rt.Emitters, "emitter: the animator drives THIS runtime", log);
+
+        // The emitter GameObjects must be children of the model root, or a model switch would
+        // leave the previous model's effects hanging in the scene.
+        int children = 0;
+        for (int i = 0; i < rt.Root.transform.childCount; i++)
+            if (rt.Root.transform.GetChild(i).GetComponent<MeshRenderer>() != null)
+                children++;
+        Check(children == 2, "emitter: both renderers are children of the model root", log);
+
+        // Two seconds of animation: the emitter should be running and the ribbon laying edges.
+        rt.Emitters.ResetState();
+        for (int i = 0; i < 120; i++)
+            rt.Emitters.Advance(1f / 60f, i * 16f, i * 16f);
+        int live = rt.Emitters.LiveParticleCount;
+        Check(live > 0, "emitter: the emitter emits (" + live + " live)", log);
+        Check(rt.Emitters.RibbonSegmentCount > 1,
+              "emitter: the ribbon laid down segments (" + rt.Emitters.RibbonSegmentCount + ")", log);
+
+        // A sequence change, through exactly the call the host makes.
+        M2Parser.ReadAnimationInto(m2, 1, model);
+        bool applied = WmvModelBuilder.ApplySequence(rt, model, s => log("  " + s));
+        Check(applied, "emitter: ApplySequence reports something to animate", log);
+        Check(rt.Emitters.ParticleEmitterCount == 1 && rt.Emitters.RibbonEmitterCount == 1,
+              "emitter: the sequence change did NOT duplicate the emitters", log);
+        Check(rt.Emitters.LiveParticleCount == 0 && rt.Emitters.RibbonSegmentCount == 0,
+              "emitter: the sequence change cleared the previous animation's particles and "
+              + "ribbon history (no smear from where the bone used to be)", log);
+
+        for (int i = 0; i < 120; i++)
+            rt.Emitters.Advance(1f / 60f, i * 16f, i * 16f);
+        Check(rt.Emitters.LiveParticleCount > 0,
+              "emitter: still emitting after the sequence change ("
+              + rt.Emitters.LiveParticleCount + " live)", log);
+
+        // A PAUSED model does not emit: dt is the animation's advance, and the animator passes
+        // zero while paused. Running with dt = 0 must change nothing at all.
+        int before = rt.Emitters.LiveParticleCount;
+        int segsBefore = rt.Emitters.RibbonSegmentCount;
+        for (int i = 0; i < 60; i++)
+            rt.Emitters.Advance(0f, 500f, 500f);
+        Check(rt.Emitters.LiveParticleCount == before,
+              "emitter: dt = 0 (paused) spawns nothing and kills nothing", log);
+        Check(rt.Emitters.RibbonSegmentCount == segsBefore,
+              "emitter: dt = 0 (paused) lays down no ribbon segment", log);
+
+        // Deterministic: the same instant, reached the same way, twice.
+        rt.Emitters.SimulateTo(1000f, x => x, null);
+        int a = rt.Emitters.LiveParticleCount;
+        rt.Emitters.SimulateTo(1000f, x => x, null);
+        Check(rt.Emitters.LiveParticleCount == a,
+              "emitter: SimulateTo is deterministic (" + a + " live both times)", log);
+
+        // A ParticleColor override must not change how many particles exist, only their colour.
+        var set = new Color[3];
+        for (int i = 0; i < 3; i++) set[i] = new Color(1f, 0f, 0f, 1f);
+        rt.Emitters.SetParticleColorOverride(new[] { set, set, set });
+        Check(rt.Emitters.LiveParticleCount == a, "emitter: a colour override changes no counts", log);
+        rt.Emitters.SetParticleColorOverride(null);
+
+        // Disposing the model drops the whole record, emitters included: the renderers are
+        // children of Root, so destroying Root destroys them, and the component's own OnDestroy
+        // releases the meshes and materials it made. That is why a model switch cannot leave the
+        // previous model's effects on screen.
+        rt.Dispose();
+        Check(rt.Root == null && rt.Emitters == null,
+              "emitter: disposing the model takes the emitters with it", log);
+
+        // A model with NO emitters gets no component, no GameObject and no per-frame call. That
+        // is the "costs nothing" property, and it is structural rather than a fast path.
+        M2ParsedModel plain = M2Parser.Parse(M2Synthetic.TransformSwitchModel(1, true), 0);
+        WmvRuntimeModel prt = WmvModelBuilder.Build(plain, skin, EmitterTextures(), "NoEmitterTest",
+                                                    s => log("  " + s));
+        Check(prt.Emitters == null,
+              "emitter: a model with no emitters gets no runtime component at all", log);
+        Check(prt.Root.GetComponent<WmvEmitterRuntime>() == null,
+              "emitter: ... and none on its root either", log);
+        prt.Dispose();
+    }
+
     static void GeosetTests(Action<string> log)
     {
         // A Drakestalker-shaped component: two submeshes at id 0 and one alternative at 2602.
@@ -252,6 +379,7 @@ public static class WmvLifecycleSelfTest
                 Run(skinned, keyed, log);
         GeosetTests(log);
         OutputGateTests(log);
+        EmitterTests(log);
         log(string.Format("lifecycle-test: {0} passed, {1} failed", passed, failed));
     }
 }

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
@@ -74,6 +74,20 @@ public class WmvM2Animator : MonoBehaviour
     public WmvMaterialAnimator Materials;
 
     /// <summary>
+    /// The model's particle and ribbon emitters, or null. Driven from here for exactly the same
+    /// reason the materials are: one clock. An emitter that timed itself off Time.time would keep
+    /// raining while the model was paused, run at the wrong rate when the app changed the playback
+    /// speed, and ignore a scrub -- and the legacy viewport is explicit that it must not, passing
+    /// its emitters the SAME per-frame delta it passes the animation and zeroing that delta when
+    /// the animation is paused (modelcanvas.cpp:1515-1522, WoWModel.cpp:2647-2649).
+    /// </summary>
+    public WmvEmitterRuntime Emitters;
+
+    /// <summary>The -wmvAnimTime instant the emitters were last simulated to, or -1. A pinned
+    /// capture runs them forward once and then only refreshes the billboards.</summary>
+    float pinnedEmittersAt = -1f;
+
+    /// <summary>
     /// Converted tracks, keyed by sequence index.
     ///
     /// Setup turns the parsed WoW tracks into the renderer's own space -- every key of every
@@ -287,8 +301,30 @@ public class WmvM2Animator : MonoBehaviour
             GlobalTimeMs = pinned;
             timeMs = SequenceTimeAt(pinned);
             ApplyPose((float)timeMs);
+            if (Emitters != null && Emitters.HasAnything)
+            {
+                // A HELD CLOCK NEVER SPAWNS A PARTICLE. Pinning is right for bones -- one instant,
+                // one pose -- but an emitter's state is the whole history that led to the instant,
+                // so a pinned frame with the emitters merely frozen would be as empty as one with
+                // no emitter code at all, and a BEFORE/AFTER pair at "1.0 s" would show nothing.
+                // Run them forward to the pinned instant instead, in fixed deterministic steps,
+                // posing the bones at each one so particles leave the bone where it actually was.
+                if (pinnedEmittersAt != pinned)
+                {
+                    Emitters.SimulateTo(pinned, SequenceTimeAt, ApplyPose);
+                    pinnedEmittersAt = pinned;
+                    ApplyPose((float)timeMs);      // the simulation left the bones at the last step
+                }
+                else
+                {
+                    // Advance nothing; rebuild the meshes so the billboards still face a camera
+                    // the user is moving around a held frame.
+                    Emitters.Tick(0f, (float)timeMs, pinned);
+                }
+            }
             return;
         }
+        pinnedEmittersAt = -1f;
 
         // GLOBAL SEQUENCES KEEP RUNNING WHILE THE ANIMATION IS PAUSED, and ignore the speed. That
         // is not an oversight copied by accident: the legacy viewport advances its global clock
@@ -308,6 +344,14 @@ public class WmvM2Animator : MonoBehaviour
                 timeMs += Math.Ceiling(-timeMs / lengthMs) * lengthMs;
         }
         ApplyPose((float)timeMs);
+
+        // AFTER the pose, so an emitter reads the bone matrix for THIS frame rather than the
+        // previous one, and with the ANIMATION's advance rather than the frame's: zero while
+        // paused, scaled by the playback speed otherwise.
+        if (Emitters != null && Emitters.HasAnything)
+            Emitters.Tick(playing ? (float)(dt * speed) / 1000f : 0f,
+                          (float)timeMs, (float)GlobalTimeMs);
+
         AdvanceWatchTick(beforeTimeMs, dt);
     }
 

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -111,6 +111,13 @@ public class WmvMain : MonoBehaviour
     /// </summary>
     HashSet<int> currentGeosets;
 
+    /// <summary>
+    /// The item ParticleColor override the host last reported, as three RGB stops, or null when
+    /// the displayed item names none. Kept alongside currentGeosets because it arrives on the
+    /// same two messages and describes the same displayed state.
+    /// </summary>
+    Color[][] currentParticleColor;
+
     /// <summary>Textures still on their way for a skin change. Requests are keyed to the M2
     /// texture slot they will land in.</summary>
     class SkinJob
@@ -358,6 +365,7 @@ public class WmvMain : MonoBehaviour
             return;
         job.PendingTextureList = null;
         AdoptGeosets(r);
+        AdoptParticleColor(r);
 
         if (!r.ok || r.textures.Length == 0)
         {
@@ -439,6 +447,8 @@ public class WmvMain : MonoBehaviour
 
             if (current != null) current.Dispose();      // never leak the previous model
             current = built;
+            // The emitters were created by that build; the override arrived with the textures.
+            ApplyParticleColor();
             if (placeholder != null) placeholder.SetActive(false);
 
             // Keep what a later skin change needs: the parsed model (to map a texture type onto
@@ -1656,6 +1666,8 @@ public class WmvMain : MonoBehaviour
         // Geometry first: a variant can change which submeshes are drawn as well as which texture
         // they wear, and the two are independent -- a variant that only swaps geosets has no
         // texture to fetch and would otherwise be dropped by the no-op check below.
+        if (AdoptParticleColor(r))
+            ApplyParticleColor();
         if (AdoptGeosets(r))
         {
             WmvModelBuilder.ApplyGeosets(current, currentGeosets, s => Debug.Log("WMV: " + s));
@@ -1782,6 +1794,57 @@ public class WmvMain : MonoBehaviour
         return true;
     }
 
+    /// <summary>
+    /// Take the ParticleColor override out of a host message.
+    ///
+    /// The host sends nine bytes -- start, middle and end as RGB 0..255 -- and an emitter's
+    /// ParticleColorIndex of 11, 12 or 13 selects one of the three as ITS ramp. So each of the
+    /// three slots gets the whole three-stop ramp rooted at that stop, which is the shape
+    /// WmvEmitterRuntime.SetParticleColorOverride expects and what the legacy's
+    /// particleColorReplacements holds (particle.h:105, three sets of three).
+    ///
+    /// An absent field means "no override", which is different from black: it must leave the
+    /// emitters on their authored colours rather than tint them to nothing.
+    /// </summary>
+    bool AdoptParticleColor(WmvIpcClient.ModelTexturesResponse r)
+    {
+        Color[][] next = null;
+        if (r.particleColor != null && r.particleColor.Length >= 9)
+        {
+            var stops = new Color[3];
+            for (int i = 0; i < 3; i++)
+                stops[i] = new Color(r.particleColor[i * 3] / 255f,
+                                     r.particleColor[i * 3 + 1] / 255f,
+                                     r.particleColor[i * 3 + 2] / 255f, 1f);
+            // Index 11 -> start, 12 -> middle, 13 -> end. Each is the ramp an emitter with that
+            // index draws, so each is the same three stops rotated to begin at its own.
+            next = new Color[3][];
+            next[0] = new[] { stops[0], stops[1], stops[2] };
+            next[1] = new[] { stops[1], stops[2], stops[0] };
+            next[2] = new[] { stops[2], stops[0], stops[1] };
+        }
+
+        bool changed = (next == null) != (currentParticleColor == null);
+        if (!changed && next != null)
+            for (int i = 0; i < 3 && !changed; i++)
+                for (int j = 0; j < 3 && !changed; j++)
+                    if (next[i][j].r != currentParticleColor[i][j].r ||
+                        next[i][j].g != currentParticleColor[i][j].g ||
+                        next[i][j].b != currentParticleColor[i][j].b)
+                        changed = true;
+        currentParticleColor = next;
+        if (changed && r.particleColorId > 0)
+            Debug.Log("WMV: ParticleColor " + r.particleColorId + " applies to this model's emitters");
+        return changed;
+    }
+
+    /// <summary>Push whatever override is current onto the model on screen.</summary>
+    void ApplyParticleColor()
+    {
+        if (current != null && current.Emitters != null)
+            current.Emitters.SetParticleColorOverride(currentParticleColor);
+    }
+
     void Fail(string reason)
     {
         status.Set("FAILED: " + reason);
@@ -1839,6 +1902,7 @@ public class WmvMain : MonoBehaviour
         long heap = System.GC.GetTotalMemory(false) - allocProbe.HeapAtStart;
         int gen0 = System.GC.CollectionCount(0) - allocProbe.Gen0AtStart;
         WmvMaterialAnimator ma = current.MaterialAnimator;
+        WmvEmitterRuntime em = current.Emitters;
         Debug.Log(string.Format(
             "WMV: alloccheck: {0} frames with {1}; managed heap delta {2} bytes ({3:F1} bytes/frame), "
             + "gen-0 collections {4}; material bindings evaluated per frame {5} ({6} colour, {7} colour-alpha, "
@@ -1851,6 +1915,16 @@ public class WmvMain : MonoBehaviour
             ma != null ? ma.TransformCount : 0,
             ma != null ? ma.GateToggles - allocProbe.TogglesAtStart : 0,
             current.Animator != null ? current.Animator.AnimatedBoneCount : 0));
+
+        // The emitters, in the same window and on the same clock. Reported separately because
+        // "no allocation per frame" is a claim about THEM more than about anything else here:
+        // they are the only per-frame work that grows and shrinks with what is on screen.
+        Debug.Log(em == null
+            ? "WMV: alloccheck: emitters none -- no component, no GameObject, no per-frame call"
+            : string.Format("WMV: alloccheck: emitters {0} particle + {1} ribbon = {2} draw call(s); "
+                            + "{3} live particle(s) of {4} slot(s) reserved; {5} ribbon segment(s)",
+                            em.ParticleEmitterCount, em.RibbonEmitterCount, em.DrawCallCount,
+                            em.LiveParticleCount, em.ParticleCapacity, em.RibbonSegmentCount));
     }
 }
 

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -121,6 +121,13 @@ public class WmvRuntimeModel
     /// <summary>The component evaluating the material tracks, or null when no batch has any.</summary>
     public WmvMaterialAnimator MaterialAnimator;
 
+    /// <summary>
+    /// The model's particle and ribbon emitters, or null when it declares none this renderer can
+    /// draw. Its renderers are children of Root, so Dispose takes them with it, and its own
+    /// OnDestroy releases the meshes and materials it made.
+    /// </summary>
+    public WmvEmitterRuntime Emitters;
+
     /// <summary>One entry per material/submesh: which tracks feed it.</summary>
     public WmvMaterialAnimBinding[] MaterialAnim = new WmvMaterialAnimBinding[0];
 
@@ -148,6 +155,7 @@ public class WmvRuntimeModel
         foreach (var t in Textures) if (t != null) UnityEngine.Object.Destroy(t);
         Root = null;
         Mesh = null;
+        Emitters = null;
         Bones = new Transform[0];
         BoneRestPositions = new Vector3[0];
         Animator = null;
@@ -216,6 +224,8 @@ public static class WmvModelBuilder
     ///                    it. At rest that distance is the whole claim of the skinning milestone,
     ///                    so it is worth being able to measure rather than assert. Only meaningful
     ///                    together with -wmvNoAnim: a moving model is not in its rest pose.
+    ///   -wmvNoEmitters   draw no particles and no ribbons: the control for every emitter
+    ///                    measurement, and the BEFORE of a before/after pair.
     ///   -wmvNoAnim       do not play anything. The model is still skinned, and still sits in the
     ///                    rest pose the bind poses describe, which is what the milestone before
     ///                    this one shipped.
@@ -236,6 +246,7 @@ public static class WmvModelBuilder
         static bool parsed;
         static bool flipV, forceOpaque, forceSolid, matColors, showHidden, ownShader;
         static bool noSkin, skinCheck, noAnim, animCheck, placeholder, overlay, litShader;
+        static bool noEmitters;
         static bool lightCheck;
         static bool queueProof;
         static float animTime = -1f;
@@ -364,12 +375,13 @@ public static class WmvModelBuilder
                 else if (a == "-wmvNoSkin") noSkin = true;
                 else if (a == "-wmvSkinCheck") skinCheck = true;
                 else if (a == "-wmvNoAnim") noAnim = true;
+                else if (a == "-wmvNoEmitters") noEmitters = true;
                 else if (a == "-wmvAnimCheck") animCheck = true;
                 else if (a == "-wmvPlaceholder") placeholder = true;
                 else if (a == "-wmvOverlay") overlay = true;
             }
             if (flipV || forceOpaque || forceSolid || matColors || showHidden || ownShader ||
-                noSkin || skinCheck || noAnim || animCheck)
+                noSkin || skinCheck || noAnim || animCheck || noEmitters)
                 Debug.Log("WMV debug switches: flipV=" + flipV + " forceOpaque=" + forceOpaque +
                           " forceSolid=" + forceSolid + " matColors=" + matColors +
                           " showHidden=" + showHidden + " ownShader=" + ownShader +
@@ -512,6 +524,15 @@ public static class WmvModelBuilder
         public static bool NoSkin { get { Parse(); return noSkin; } }
         public static bool SkinCheck { get { Parse(); return skinCheck; } }
         public static bool NoAnim { get { Parse(); return noAnim; } }
+
+        /// <summary>
+        /// Draw no particles and no ribbons (-wmvNoEmitters).
+        ///
+        /// The control for every emitter measurement: the same model, the same camera, the same
+        /// instant, with the emitters the only difference. It is also the BEFORE of a before/after
+        /// pair without needing to check out the previous commit.
+        /// </summary>
+        public static bool NoEmitters { get { Parse(); return noEmitters; } }
         public static bool AnimCheck { get { Parse(); return animCheck; } }
 
         /// <summary>
@@ -1264,6 +1285,12 @@ public static class WmvModelBuilder
             smr.localBounds = mesh.bounds;
             smr.updateWhenOffscreen = false;
 
+            // Emitters BEFORE the animation block, because whether the model has any is one of
+            // the reasons to keep an animator: the emitters run on its clock, so a model whose
+            // idle moves no bone but which trails fire still needs one.
+            BuildEmitters(result, model, go, boneTransforms, decodedTextures, textureCache,
+                          textures, objectName, log);
+
             if (log != null)
             {
                 log(string.Format("skin: {0} bone(s), {1} root(s), max depth {2}; " +
@@ -1291,7 +1318,8 @@ public static class WmvModelBuilder
                 var animator = go.AddComponent<WmvM2Animator>();
                 animator.Setup(model, boneTransforms, restLocalPositions, log);
                 animator.Materials = result.MaterialAnimator;
-                if (animator.AnimatedBoneCount == 0 && !MaterialsAnimate(result))
+                animator.Emitters = result.Emitters;
+                if (animator.AnimatedBoneCount == 0 && !NeedsClock(result))
                 {
                     // Nothing in the idle actually moves; the component would burn a LateUpdate
                     // per frame to write nothing.
@@ -1333,17 +1361,23 @@ public static class WmvModelBuilder
             renderer.sharedMaterials = materials.ToArray();
             if (log != null)
                 log("skin: drawn as a static mesh -- " + skinPlan.Reason);
+            // No bones: an emitter still draws, at its authored model-space offset, with the
+            // identity where a bone matrix would be.
+            BuildEmitters(result, model, go, boneTransforms, decodedTextures, textureCache,
+                          textures, objectName, log);
             // A static mesh has no bones to drive, but its materials may still move. The same
             // animator supplies the clock, with nothing to pose.
-            if (!Debug_.NoAnim && MaterialsAnimate(result) &&
+            if (!Debug_.NoAnim && NeedsClock(result) &&
                 model.AnimatedSequence >= 0 && model.AnimatedSequence < model.Sequences.Length)
             {
                 var animator = go.AddComponent<WmvM2Animator>();
                 animator.Setup(model, new Transform[0], new Vector3[0], log);
                 animator.Materials = result.MaterialAnimator;
+                animator.Emitters = result.Emitters;
                 result.Animator = animator;
                 if (log != null)
-                    log("anim: static mesh, but materials animate -- an animator supplies the clock");
+                    log("anim: static mesh, but materials or emitters animate -- an animator "
+                        + "supplies the clock");
             }
         }
 
@@ -1501,14 +1535,22 @@ public static class WmvModelBuilder
         // before the bones, so a model whose ONLY animation is material still switches.
         if (runtime.MaterialAnimator != null)
             runtime.MaterialAnimator.Rebind(model, log);
-        if (!runtime.Skinned || runtime.Bones.Length == 0)
+
+        // The emitters' tracks were re-read for the new sequence too, and that is not cosmetic:
+        // an emitter with no EmissionRate keys in the new sequence has to stop and one that gains
+        // them has to start (see M2ParsedModel.ParticleEmitters). Rebind also drops every live
+        // particle and every ribbon edge, so a trail cannot smear from where the bone was in the
+        // old animation to where it is in the new one.
+        if (runtime.Emitters != null && !runtime.Emitters.Rebind(model) && log != null)
+            log("emitters: the re-parsed model has a different emitter count -- the existing "
+                + "emitters were left as they were");
         {
             // (-wmvNoAnim never reaches here -- SwitchToSequence returns first -- but the rule
             // "no clock under -wmvNoAnim" is kept explicit rather than implied.)
-            if (!Debug_.NoAnim && MaterialsAnimate(runtime))
+            if (!Debug_.NoAnim && NeedsClock(runtime))
             {
-                // A static mesh whose materials animate in THIS sequence: the clock must exist and
-                // point at it. It is created here when the build had nothing to drive (the
+                // A static mesh whose materials or emitters animate in THIS sequence: the clock
+                // must exist and point at it. It is created here when the build had nothing to drive (the
                 // materials were dormant then) and merely re-pointed otherwise.
                 if (runtime.Animator == null)
                 {
@@ -1518,6 +1560,7 @@ public static class WmvModelBuilder
                 }
                 runtime.Animator.Setup(model, new Transform[0], new Vector3[0], log);
                 runtime.Animator.Materials = runtime.MaterialAnimator;
+                runtime.Animator.Emitters = runtime.Emitters;
                 return true;
             }
             if (runtime.Animator != null)
@@ -1567,7 +1610,8 @@ public static class WmvModelBuilder
 
         animator.Setup(model, runtime.Bones, runtime.BoneRestPositions, log);
         animator.Materials = runtime.MaterialAnimator;
-        if (animator.AnimatedBoneCount == 0 && !MaterialsAnimate(runtime))
+        animator.Emitters = runtime.Emitters;
+        if (animator.AnimatedBoneCount == 0 && !NeedsClock(runtime))
         {
             // A real sequence that happens to move nothing: the bones are already back at rest.
             UnityEngine.Object.Destroy(animator);
@@ -2330,6 +2374,102 @@ public static class WmvModelBuilder
         return runtime.MaterialAnimator != null && runtime.MaterialAnimator.AnimatedCount > 0;
     }
 
+    /// <summary>Does anything on this model need the animator's clock -- a material track, or an
+    /// emitter? A model with neither is posed once and left alone.</summary>
+    static bool NeedsClock(WmvRuntimeModel runtime)
+    {
+        return MaterialsAnimate(runtime) || HasEmitters(runtime);
+    }
+
+    static bool HasEmitters(WmvRuntimeModel runtime)
+    {
+        return runtime.Emitters != null && runtime.Emitters.HasAnything;
+    }
+
+    /// <summary>
+    /// Add the emitter runtime to a model that has emitters, and nothing at all to one that does
+    /// not -- no component, no GameObject, no per-frame call. That is the "models with no
+    /// particles or ribbons cost nothing" property, and it is structural rather than a fast path
+    /// inside a component that runs anyway.
+    /// </summary>
+    static void BuildEmitters(WmvRuntimeModel result, M2ParsedModel model, GameObject go,
+                              Transform[] boneTransforms,
+                              Dictionary<int, BlpImage> decodedTextures,
+                              Dictionary<int, Texture2D> textureCache, List<Texture2D> owned,
+                              string objectName, Action<string> log)
+    {
+        if (Debug_.NoEmitters)
+        {
+            if (log != null && (model.ParticleEmitterCount > 0 || model.RibbonEmitterCount > 0))
+                log("emitters: not drawn -- -wmvNoEmitters was passed");
+            return;
+        }
+        if (model.ParticleEmitters.Length == 0 && model.RibbonEmitters.Length == 0)
+        {
+            // Say so only when the model DECLARED some and none survived the parse, so a model
+            // with no emitters at all stays silent instead of adding a line to every load.
+            if (log != null && (model.ParticleEmitterCount > 0 || model.RibbonEmitterCount > 0))
+                log(string.Format("emitters: {0} particle and {1} ribbon emitter(s) declared, none "
+                                  + "readable", model.ParticleEmitterCount, model.RibbonEmitterCount));
+            return;
+        }
+
+        Shader shader = FindParticleShader(log);
+        if (shader == null)
+            return;
+
+        var runtime = go.AddComponent<WmvEmitterRuntime>();
+        // A particle's texture field indexes the model's texture array DIRECTLY -- the legacy
+        // resolves it with getGLTexture(mta.texture), which is textures[Tex] (WoWModel.cpp:3596).
+        // Not through TextureLookup, which is the batch's route and a different table.
+        //
+        // Address mode comes from the texture's own two flag bits, the same rule the mesh
+        // materials follow, except that a flipbook must never wrap: a tile's edge samples would
+        // pull in the opposite side of the sheet.
+        Func<int, Texture2D> textureFor = slot =>
+        {
+            if (slot < 0 || slot >= model.Textures.Length)
+                return null;
+            bool wrapX = model.Textures[slot].WrapX;
+            bool wrapY = model.Textures[slot].WrapY;
+            return GetTexture(decodedTextures, textureCache, owned, slot, false, wrapX, wrapY,
+                              objectName);
+        };
+        runtime.SetGlobalSequences(model.GlobalSequences);
+        runtime.Setup(model, go.transform, boneTransforms, textureFor, shader, objectName, log);
+        if (!runtime.HasAnything)
+        {
+            UnityEngine.Object.Destroy(runtime);
+            return;
+        }
+        result.Emitters = runtime;
+    }
+
+    /// <summary>
+    /// The particle pass, from Resources so a player build cannot strip it.
+    ///
+    /// No fallback chain, deliberately. The model shader can fall back to a pipeline Lit shader
+    /// and still show the model; a particle shader cannot, because a substitute bakes its own
+    /// blend state into the pass and every M2 blend mode this renderer sets would be ignored --
+    /// 56 % of emitters are additive and would come out as opaque squares over the model. Missing
+    /// is better than wrong, and it is said in the log.
+    /// </summary>
+    const string ParticleShaderResource = "WmvParticle";
+    static Shader cachedParticleShader;
+    static bool particleShaderResolved;
+
+    static Shader FindParticleShader(Action<string> log)
+    {
+        if (particleShaderResolved)
+            return cachedParticleShader;
+        particleShaderResolved = true;
+        cachedParticleShader = Resources.Load<Shader>(ParticleShaderResource);
+        if (cachedParticleShader == null && log != null)
+            log("emitters: not drawn -- the '" + ParticleShaderResource + "' shader is not in this "
+                + "build, and a substitute would bake its own blend state over every M2 blend mode");
+        return cachedParticleShader;
+    }
+
     /// <summary>
     /// Put the whole model -- bones and materials -- at one instant of its animation and hold it
     /// there. For the offscreen captures: two builds compared at "250 ms" must both mean the
@@ -2346,6 +2486,18 @@ public static class WmvModelBuilder
             runtime.Animator.ApplyPose(runtime.Animator.SequenceTimeAt(timeMs));   // drives the materials through its hook
         else if (runtime.MaterialAnimator != null)
             runtime.MaterialAnimator.Apply(timeMs);
+
+        // Bones and materials are functions of the instant; emitters are not. A particle at
+        // 250 ms exists because of what happened over the 250 ms before it, so holding the clock
+        // still leaves an emitter empty. Run it forward to the instant instead, deterministically,
+        // which is what makes two captures at "250 ms" comparable rather than merely labelled the
+        // same. See WmvEmitterRuntime.SimulateTo.
+        if (runtime.Emitters != null && runtime.Emitters.HasAnything && runtime.Animator != null)
+        {
+            WmvM2Animator anim = runtime.Animator;
+            runtime.Emitters.SimulateTo(timeMs, anim.SequenceTimeAt, anim.ApplyPose);
+            anim.ApplyPose(anim.SequenceTimeAt(timeMs));   // the simulation left the bones mid-run
+        }
     }
 
     static bool BatchIsVisible(M2ParsedModel model, M2Batch batch, out string reason)

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -278,7 +278,160 @@ namespace Wmv.Wow
         BlendAdd = 7,
     }
 
-    /// <summary>A parsed M2 (the parts this milestone needs).</summary>
+    /// <summary>
+    /// A particle emitter's shape. Measured across 34,873 emitters in the current client:
+    /// Plane 64.7 %, Sphere 34.5 %, Spline 0.8 %, and three emitters declaring 4.
+    /// </summary>
+    public enum M2EmitterType { Plane = 1, Sphere = 2, Spline = 3 }
+
+    /// <summary>
+    /// One M2 particle emitter. 492 bytes on disk -- MEASURED, not assumed: of the eight
+    /// candidate strides tried against real files, 492 validated every emitter of all 978
+    /// multi-emitter models in a 6,000-model sample and every other candidate failed on some
+    /// model (see M2Parser.ParticleEmitterStride). Both M2 versions this client ships, 272 and
+    /// 274, use it.
+    ///
+    /// The three "ramp" arrays below are the emitter's start / middle / end stops. On disk they
+    /// are FakeAnimationBlocks -- the same 16-byte shape as a track header, but the offsets point
+    /// straight at the values with no per-sequence indirection and no timestamps, because the
+    /// ramp is indexed by a particle's own age rather than by the clock.
+    /// </summary>
+    public struct M2ParticleEmitterDef
+    {
+        public int Flags;
+        public WowVec3 Position;        // model space, relative to Bone
+        public short Bone;
+        public short TextureId;         // a DIRECT index into Textures[], not through TextureLookup
+        public byte BlendMode;
+        public byte EmitterType;
+        public ushort ParticleColorIndex;   // 11, 12 or 13 select a ParticleColor override
+        public short TextureTileRotation;
+        public ushort Rows, Cols;
+
+        public M2Track<float> EmissionSpeed;
+        public M2Track<float> SpeedVariation;
+        public M2Track<float> VerticalRange;
+        public M2Track<float> HorizontalRange;
+        public M2Track<float> Gravity;
+        public M2Track<float> Lifespan;
+        public M2Track<float> EmissionRate;
+        public M2Track<float> EmissionAreaLength;
+        public M2Track<float> EmissionAreaWidth;
+        public M2Track<float> ZSource;
+        /// <summary>
+        /// Whether the emitter is emitting at all, as a track. ONE BYTE per key on disk, despite
+        /// modelheaders.h:506 declaring uint16 and particle.h:92 declaring Animated&lt;uint16&gt;:
+        /// read as uint16 the array yields 256 and 257 on 310 of 1,753 reads, which is exactly
+        /// what adjacent one-byte keys of 0 and 1 look like when paired. The byte values that
+        /// actually occur are 0 and 1 and nothing else.
+        /// </summary>
+        public M2Track<float> EnabledIn;
+
+        /// <summary>
+        /// The colour, opacity and size ramps, indexed by a particle's normalised AGE.
+        ///
+        /// NOT three stops at 0 / 0.5 / 1, which is what the legacy runtime assumes: it memcpys
+        /// exactly three keys whatever the count says and hardcodes the midpoint at 0.5
+        /// (particle.cpp:47-57, with its author's own "mid can't be 0 or 1, TODO" beside it).
+        /// Measured over 17,202 ramp tracks in 1,500 client models, neither half of that holds:
+        /// 42 % of ramps do not have three keys (2, 4, 5, 6, 7, 8 and up to 13 all occur), and
+        /// among those that do the middle stop sits at 0.5 only 55 % of the time -- 0.2, 0.25,
+        /// 0.3, 0.35, 0.6 and 0.75 all appear. A two-key ramp read the legacy's way takes its
+        /// third stop from whatever bytes follow the authored data.
+        ///
+        /// The times are stored as uint16 normalised by 32767, not as milliseconds. Over those
+        /// same 17,202 tracks the first key is 0 and the last is 32767 in 100.0 % of them, and
+        /// every one is monotonic; read as uint32 milliseconds, 0.0 % are either. Each of the
+        /// three ramps carries its own times, so they are kept separately rather than zipped.
+        /// </summary>
+        public float[] ColorTimes;
+        public WowVec3[] ColorKeys;      // 0..1 (stored 0..255)
+        public float[] AlphaTimes;
+        public float[] AlphaKeys;        // 0..1 (stored fixed16)
+        public float[] SizeTimes;
+        public WowVec2[] SizeKeys;       // already multiplied by ParticleScale
+
+        /// <summary>
+        /// ModelParticleParams.scales, read as the two-component quantity it measures as.
+        ///
+        /// The legacy runtime indexes this by RAMP STOP -- sizes[i] = key[i] * scales[i]
+        /// (particle.cpp:55) -- which is a category error: it is a per-AXIS scale applied to
+        /// every stop. The data settles it. Its x and y are equal on every emitter examined
+        /// (1.0/1.0 on Val'anyr, 0.1/0.1 and 1.3/1.3 on the Celestial cape) while the third
+        /// float is 519.0, -1.0 or 1.0 on different models -- not a scale at all. Under the
+        /// legacy's reading a 0.0556 particle on Val'anyr becomes 28.85 units across, and
+        /// another gets a NEGATIVE size.
+        /// </summary>
+        public WowVec2 ParticleScale;
+
+        public float Slowdown;
+        public float SpriteRotation;
+
+        public bool WorldSpace { get { return (Flags & 0x8) != 0; } }
+        public bool DoNotTrail { get { return (Flags & 0x10) != 0; } }
+        public bool ModelSpace { get { return (Flags & 0x80) != 0; } }
+        public bool Pinned { get { return (Flags & 0x400) != 0; } }
+        public bool DoNotBillboard { get { return (Flags & 0x1000) != 0; } }
+        public bool RandomTexture { get { return (Flags & 0x10000) != 0; } }
+        public bool Outward { get { return (Flags & 0x20000) != 0; } }
+        public bool RandomStart { get { return (Flags & 0x200000) != 0; } }
+
+        /// <summary>
+        /// Bit 0x800000. Set on 82.9 % of the client's emitters, and it changes how a Gravity KEY
+        /// is encoded -- not how big it is. See M2Parser.ReadCompressedGravity: reading these keys
+        /// as float32, which the legacy runtime does unconditionally (particle.cpp:38), produces
+        /// NaN or infinity on 47 % of them and |v| &gt; 1e6 on 65 %.
+        /// </summary>
+        public bool CompressedGravity { get { return (Flags & 0x800000) != 0; } }
+
+        public bool MultiTexture { get { return (Flags & 0x10000000) != 0; } }
+
+        /// <summary>Can this renderer draw it? Plane and Sphere, which is 99.2 % of the client.
+        /// The legacy runtime builds no emitter object for anything else either
+        /// (particle.cpp:109-121), so a Spline emitter has never been drawn by WMV.</summary>
+        public bool Supported
+        {
+            get { return EmitterType == (byte)M2EmitterType.Plane || EmitterType == (byte)M2EmitterType.Sphere; }
+        }
+    }
+
+    /// <summary>
+    /// One M2 ribbon emitter. 176 bytes on disk, measured the same way as the particle stride:
+    /// of four candidates it was the only one that validated, on 45 of the 94 multi-ribbon
+    /// models in a 12,000-model sample, and no other candidate scored at all.
+    /// </summary>
+    public struct M2RibbonEmitterDef
+    {
+        public int Bone;
+        public WowVec3 Position;        // model space, relative to Bone
+        public int[] TextureIds;        // direct indices into Textures[]
+
+        public M2Track<WowVec3> Color;
+        public M2Track<float> Opacity;  // fixed16 on disk
+        public M2Track<float> Above;
+        public M2Track<float> Below;
+
+        /// <summary>
+        /// Edges emitted per second, and how long an edge lives. NOT the legacy's reading -- see
+        /// WmvEmitterRuntime.RibbonState for why the data forces this one: across the client
+        /// these measure 30..100 and 0.1..2.0, which are an emission rate and a lifetime in
+        /// seconds, and give 5..200 edges.
+        /// </summary>
+        public float EdgesPerSecond;
+        public float EdgeLifetimeSeconds;
+
+        public float EmissionAngle;
+
+        /// <summary>
+        /// The ribbon's material, indexed into the model's materials ("texFlags") array at header
+        /// offset 0x70 -- NOT into the textures array, and not parallel to TextureIds. The count
+        /// is 1 on every ribbon measured (525 of 525). This is where a ribbon's blend mode comes
+        /// from; the legacy hardcodes SRC_ALPHA/ONE instead (particle.cpp:847) and so never reads
+        /// it. -1 when the array is absent or does not resolve.
+        /// </summary>
+        public int MaterialIndex;
+    }
+
     /// <summary>One AFID entry: which file holds animation (animId, subAnimId)'s keyframes.</summary>
     public struct AfidEntry
     {
@@ -326,6 +479,26 @@ namespace Wmv.Wow
         public ushort[] TextureTransformLookup = new ushort[0];
 
         public M2MaterialTrackSurvey MaterialSurvey;
+
+        /// <summary>
+        /// The model's particle emitters, with every track narrowed to the parsed sequence.
+        ///
+        /// THE SEQUENCE MATTERS HERE MORE THAN IT DOES FOR BONES. An emitter whose EmissionRate
+        /// has no keys in the playing sequence emits nothing at all, and that is authored, not a
+        /// fault: Val'anyr (253423) ships two sub-animations of Stand, and eleven of its thirteen
+        /// emitters carry EmissionRate keys only in the second. So these are re-read whenever the
+        /// sequence changes, exactly like the bone tracks.
+        /// </summary>
+        public M2ParticleEmitterDef[] ParticleEmitters = new M2ParticleEmitterDef[0];
+
+        /// <summary>The model's ribbon emitters, tracks narrowed to the parsed sequence.</summary>
+        public M2RibbonEmitterDef[] RibbonEmitters = new M2RibbonEmitterDef[0];
+
+        /// <summary>Counts as the header declares them, before anything was dropped as
+        /// unsupported or out of bounds. Reported so "we drew none" and "there were none" stay
+        /// distinguishable in the log.</summary>
+        public int ParticleEmitterCount, RibbonEmitterCount;
+
         public int SkinProfileCount;
         public int[] SkinFileDataIDs = new int[0];       // SFID chunk
         public int[] TextureFileDataIDs = new int[0];    // TXID chunk (0 where replaceable)

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
@@ -75,6 +75,89 @@ namespace Wmv.Wow
         const int ColorStride = 40;        // two M2Tracks
         const int TrackStride = 20;        // interpolation + globalSeq + two nested M2Arrays
 
+        // ---- emitters -------------------------------------------------------------------------
+        //
+        // These two arrays sit past every offset above, at the tail of the MD20 header. Their
+        // positions were computed from this repo's own ModelHeader (Source/games/wow/
+        // modelheaders.h) by summing the fields ahead of them, and the same arithmetic reproduces
+        // every offset already known here -- 0x14, 0x1C, 0x2C, 0x3C, 0x48, 0x50, 0x70 -- so the
+        // method is checked before it is trusted. They were then confirmed against real files:
+        // the counts and offsets land inside the MD21 chunk and decode to sane emitters.
+        const int OfsRibbonEmitters = 0x120;
+        const int OfsParticleEmitters = 0x128;
+
+        /// <summary>
+        /// The full MD20 header. The emitter arrays are the last two entries in it, so anything
+        /// reaching this far has them -- and anything not reaching it has no emitters, which is
+        /// not an error.
+        ///
+        /// The payload being long enough is NOT the same as the HEADER being long enough: a file
+        /// whose header stops earlier still has bytes at 0x120, they are just the next array's
+        /// contents. Nothing in the format records the header's length, so the emitters are
+        /// validated on their own contents instead -- see ParticleEmitterLooksReal.
+        /// </summary>
+        const int HeaderSize = 0x138;
+        const int EmitterHeaderSize = OfsParticleEmitters + 8;
+
+        // Both strides are MEASURED. See M2ParticleEmitterDef / M2RibbonEmitterDef for the
+        // sample sizes and for what the competing candidates did.
+        const int ParticleEmitterStride = 492;
+        const int RibbonEmitterStride = 176;
+
+        // Field offsets inside M2ParticleDef.
+        const int OfsParticlePos = 8;
+        const int OfsParticleBone = 20;          // int16 bone, int16 texture
+        const int OfsParticleBlend = 40;         // uint8 blend, uint8 emitterType, uint16 colorIndex
+        const int OfsParticleTileRotation = 46;  // int16 tileRotation, uint16 rows, uint16 cols
+        const int OfsParticleParams = 260;       // ModelParticleParams
+        const int OfsParticleEnabledIn = 456;    // the track after ModelParticleParams
+
+        /// <summary>
+        /// Where each of the ten float tracks starts inside M2ParticleDef. Not a simple stride:
+        /// the struct interleaves two int32s the header calls "unknown", one after Lifespan and
+        /// one after EmissionRate. Getting that wrong reads a track header out of the middle of
+        /// another track, which still parses and still produces plausible garbage -- so the shape
+        /// is written out rather than computed.
+        /// </summary>
+        static readonly int[] ParticleTrackOffsets =
+        {
+            52,      // EmissionSpeed
+            72,      // SpeedVariation
+            92,      // VerticalRange
+            112,     // HorizontalRange
+            132,     // Gravity
+            152,     // Lifespan
+            176,     // EmissionRate       (after int32 unknown at 172)
+            200,     // EmissionAreaLength (after int32 unknown2 at 196)
+            220,     // EmissionAreaWidth
+            240,     // zSource
+        };
+
+        // Field offsets inside ModelParticleParams (relative to OfsParticleParams). Each of the
+        // first three is a FakeAnimationBlock: {nTimes, ofsTimes, nKeys, ofsKeys}, sixteen bytes,
+        // FLAT -- no per-sequence indirection, because a ramp is indexed by a particle's own age
+        // rather than by the clock. The KEYS are at +8/+12 and the TIMES at +0/+4; reading the
+        // pair at +0 as the keys gives the times array and produces convincing garbage.
+        const int OfsParamsColor = 0;      // keys: WowVec3, stored 0..255
+        const int OfsParamsAlpha = 16;     // keys: int16, fixed16
+        const int OfsParamsSize = 32;      // keys: WowVec2
+        const int OfsParamsScales = 100;         // see M2ParticleEmitterDef.ParticleScale
+        const int OfsParamsSlowdown = 112;
+        const int OfsParamsRotation = 124;
+
+        // Field offsets inside ModelRibbonEmitterDef.
+        const int OfsRibbonPos = 8;
+        const int OfsRibbonTextures = 20;
+        const int OfsRibbonMaterials = 28;
+        const int OfsRibbonColor = 36;           // then opacity, above, below at +20 each
+        const int OfsRibbonRes = 116;            // float res, float length, float emissionAngle
+
+        /// <summary>
+        /// Ceiling on a ramp's stops. The client's longest is 13 (of 17,202 tracks measured), so
+        /// 16 truncates nothing real while bounding a corrupt count.
+        /// </summary>
+        const int MaxRampStops = 16;
+
         /// <summary>
         /// Parse an .m2 asset. Throws WowParseException on anything malformed.
         ///
@@ -216,6 +299,7 @@ namespace Wmv.Wow
 
             ReadVisibilityTracks(c, model);
             ReadMaterialTracks(c, model, externalAnim);
+            ReadEmittersForSequence(c, model);
 
             return model;
         }
@@ -299,6 +383,21 @@ namespace Wmv.Wow
             // transforms -- have to follow it here too, or a sequence change would leave them on
             // the previous animation's keys while the bones moved on.
             ReadMaterialTracks(c, model, externalAnim);
+
+            // Emitters likewise, and for them it is not a refinement: an emitter whose
+            // EmissionRate has no keys in the new sequence must STOP, and one that gains keys
+            // must start. See M2ParsedModel.ParticleEmitters.
+            ReadEmittersForSequence(c, model);
+        }
+
+        /// <summary>
+        /// Resolve which buffer this sequence's keyframes live in, then read both emitter arrays.
+        /// Shared by Parse and ReadAnimationInto so the two can never disagree about it.
+        /// </summary>
+        static void ReadEmittersForSequence(ByteCursor c, M2ParsedModel model)
+        {
+            int seq = model.AnimatedSequence >= 0 ? model.AnimatedSequence : 0;
+            ReadEmitters(c, model, seq);
         }
 
         /// <summary>
@@ -499,7 +598,7 @@ namespace Wmv.Wow
                     int rec = colors.Offset + i * ColorStride;
                     model.Colors[i].Color = ReadTrack<WowVec3>(c, rec, 0, Vec3Stride, ReadVec3, ext, extAt0);
                     model.Colors[i].Opacity = seq >= 0
-                        ? ReadTrack<float>(c, rec + TrackStride, seq, Fixed16Stride, ReadFixed16, ext, hasExt)
+                        ? ReadTrack<float>(c, rec + TrackStride, seq, Fixed16Stride, ReadFixed16, NoExternalKeys, false)
                         : EmptyTrack<float>();
                     if (model.Colors[i].Color.HasData) survey.ColorRgbTracks++;
                     if (model.Colors[i].Opacity.HasData) survey.ColorOpacityTracks++;
@@ -524,7 +623,7 @@ namespace Wmv.Wow
                     // The keys the legacy rule never reads. Counted, not used.
                     if (seq > 0 && !tracks[i].IsGlobal)
                     {
-                        M2Track<float> atSeq = ReadTrack<float>(c, rec, seq, Fixed16Stride, ReadFixed16, ext, hasExt);
+                        M2Track<float> atSeq = ReadTrack<float>(c, rec, seq, Fixed16Stride, ReadFixed16, NoExternalKeys, false);
                         survey.WeightPerSequenceChecked++;
                         if (!SameKeys(tracks[i], atSeq)) survey.WeightPerSequenceDiffers++;
                     }
@@ -546,9 +645,9 @@ namespace Wmv.Wow
                     int rec = xforms.Offset + i * TextureTransformStride;
                     if (seq >= 0)
                     {
-                        arr[i].Translation = ReadTrack<WowVec3>(c, rec, seq, Vec3Stride, ReadVec3, ext, hasExt);
-                        arr[i].Rotation = ReadTrack<WowQuat>(c, rec + TrackStride, seq, FloatQuatStride, ReadFloatQuat, ext, hasExt);
-                        arr[i].Scale = ReadTrack<WowVec3>(c, rec + 2 * TrackStride, seq, Vec3Stride, ReadVec3, ext, hasExt);
+                        arr[i].Translation = ReadTrack<WowVec3>(c, rec, seq, Vec3Stride, ReadVec3, NoExternalKeys, false);
+                        arr[i].Rotation = ReadTrack<WowQuat>(c, rec + TrackStride, seq, FloatQuatStride, ReadFloatQuat, NoExternalKeys, false);
+                        arr[i].Scale = ReadTrack<WowVec3>(c, rec + 2 * TrackStride, seq, Vec3Stride, ReadVec3, NoExternalKeys, false);
                     }
                     else
                     {
@@ -781,11 +880,11 @@ namespace Wmv.Wow
                 if (seq >= 0)
                 {
                     bones[i].Translation = ReadTrack<WowVec3>(c, bone + OfsBoneTranslation, seq,
-                                                              Vec3Stride, ReadVec3, ext, hasExt);
+                                                              Vec3Stride, ReadVec3, NoExternalKeys, false);
                     bones[i].Rotation = ReadTrack<WowQuat>(c, bone + OfsBoneRotation, seq,
-                                                           PackedQuatStride, ReadPackedQuat, ext, hasExt);
+                                                           PackedQuatStride, ReadPackedQuat, NoExternalKeys, false);
                     bones[i].Scale = ReadTrack<WowVec3>(c, bone + OfsBoneScale, seq,
-                                                        Vec3Stride, ReadVec3, ext, hasExt);
+                                                        Vec3Stride, ReadVec3, NoExternalKeys, false);
                 }
             }
 
@@ -915,6 +1014,443 @@ namespace Wmv.Wow
         }
 
         static readonly uint[] EmptyTimes = new uint[0];
+
+        // -----------------------------------------------------------------------------------
+        // Particle and ribbon emitters
+        // -----------------------------------------------------------------------------------
+
+        /// <summary>
+        /// Read both emitter arrays, with every track narrowed to <paramref name="sequence"/>.
+        ///
+        /// Called from Parse AND from ReadAnimationInto, because an emitter's tracks are stored
+        /// per animation sequence exactly like a bone's. See M2ParsedModel.ParticleEmitters for
+        /// the model that makes the difference visible.
+        ///
+        /// Nothing in here throws. A header too short to carry the arrays, a count that does not
+        /// fit, an emitter whose bone points off the end -- each yields fewer emitters, never a
+        /// model that refuses to load. Emitters are decoration; geometry is not.
+        /// </summary>
+        /// <summary>
+        /// EMITTER TRACKS ARE NEVER IN A .anim FILE, so no external cursor is threaded through
+        /// any of this. The legacy binds them to the GameFile* overload of Animated::init
+        /// (particle.cpp:33-43 and :744-747, animated.h:239), which reads the model buffer and
+        /// only the model buffer; the .anim-redirecting overload (animated.h:298) has no emitter
+        /// call site anywhere. Pointing an M2-relative offset at the .anim buffer would read
+        /// whatever happened to be at that offset in the other file.
+        /// </summary>
+        static readonly ByteCursor NoExternalKeys = default(ByteCursor);
+
+        static void ReadEmitters(ByteCursor c, M2ParsedModel model, int sequence)
+        {
+            model.ParticleEmitters = new M2ParticleEmitterDef[0];
+            model.RibbonEmitters = new M2RibbonEmitterDef[0];
+            model.ParticleEmitterCount = 0;
+            model.RibbonEmitterCount = 0;
+            if (c.Length < EmitterHeaderSize)
+                return;
+
+            c.Seek(OfsParticleEmitters);
+            M2Array particles = c.ReadArray();
+            model.ParticleEmitterCount = particles.Count;
+            // An array cannot begin inside the header, so an offset that does is a sign these
+            // bytes are not the emitter entry at all -- the header stops earlier and something
+            // else lives at 0x128. Only meaningful for a NON-EMPTY array: an M2 with no particle
+            // emitters stores count 0 AND offset 0, which is the common case and says nothing
+            // about the ribbons that may still follow.
+            if (particles.Count > 0 && particles.Offset < HeaderSize)
+                particles = new M2Array(0, 0);
+            model.ParticleEmitterCount = particles.Count;
+            if (particles.Count > 0 && Fits(c, particles.Offset, particles.Count, ParticleEmitterStride))
+            {
+                var kept = new List<M2ParticleEmitterDef>(particles.Count);
+                for (int i = 0; i < particles.Count; i++)
+                {
+                    M2ParticleEmitterDef def;
+                    if (ReadParticleEmitter(c, particles.Offset + i * ParticleEmitterStride, model,
+                                            sequence, out def))
+                        kept.Add(def);
+                }
+                model.ParticleEmitters = kept.ToArray();
+            }
+
+            c.Seek(OfsRibbonEmitters);
+            M2Array ribbons = c.ReadArray();
+            model.RibbonEmitterCount = ribbons.Count;
+            if (ribbons.Count > 0 && ribbons.Offset < HeaderSize)
+                ribbons = new M2Array(0, 0);
+            model.RibbonEmitterCount = ribbons.Count;
+            if (ribbons.Count > 0 && Fits(c, ribbons.Offset, ribbons.Count, RibbonEmitterStride))
+            {
+                var kept = new List<M2RibbonEmitterDef>(ribbons.Count);
+                for (int i = 0; i < ribbons.Count; i++)
+                {
+                    M2RibbonEmitterDef def;
+                    if (ReadRibbonEmitter(c, ribbons.Offset + i * RibbonEmitterStride, model,
+                                          sequence, out def))
+                        kept.Add(def);
+                }
+                model.RibbonEmitters = kept.ToArray();
+            }
+        }
+
+        static bool ReadParticleEmitter(ByteCursor c, int at, M2ParsedModel model, int sequence,
+                                        out M2ParticleEmitterDef def)
+        {
+            def = new M2ParticleEmitterDef();
+            try
+            {
+                c.Seek(at + 4);
+                def.Flags = c.ReadInt32();
+
+                c.Seek(at + OfsParticlePos);
+                def.Position = ReadVec3(c);
+
+                c.Seek(at + OfsParticleBone);
+                def.Bone = c.ReadInt16();
+                def.TextureId = c.ReadInt16();
+
+                c.Seek(at + OfsParticleBlend);
+                def.BlendMode = c.ReadByte();
+                def.EmitterType = c.ReadByte();
+                def.ParticleColorIndex = c.ReadUInt16();
+
+                c.Seek(at + OfsParticleTileRotation);
+                def.TextureTileRotation = c.ReadInt16();
+                def.Rows = c.ReadUInt16();
+                def.Cols = c.ReadUInt16();
+
+                // rows/cols of 0 would make the flipbook a division by zero. The legacy runtime
+                // promotes both to 1 (particle.cpp:66-70); so does this.
+                if (def.Rows == 0) def.Rows = 1;
+                if (def.Cols == 0) def.Cols = 1;
+
+                // 0xFFFF appears on three emitters in the client and is not one of the three
+                // override slots. Treat it as "no override" rather than letting it index.
+                if (def.ParticleColorIndex < 11 || def.ParticleColorIndex > 13)
+                    def.ParticleColorIndex = 0;
+            }
+            catch (WowParseException)
+            {
+                return false;
+            }
+
+            if (!ParticleEmitterLooksReal(def, model))
+                return false;
+
+            // ---- WHICH SEQUENCE THE EMITTER'S OWN TRACKS ARE READ AT --------------------
+            //
+            // ANIMATION 0, always -- not the sequence that is playing. That is the app's shipped
+            // behaviour, not an invention: GLOBALSETTINGS.bZeroParticle defaults to true
+            // (app.cpp:969, modelviewer.cpp:812, and it is a checkbox in the general settings),
+            // and the legacy runtime then forces the animation index to 0 for every one of these
+            // ten tracks and for a particle's lifespan at spawn (particle.cpp:194-196, :615-617,
+            // :724-726). EnabledIn is the one exception -- it is read at the PLAYING animation
+            // even then (particle.cpp:233-234) -- and it is read that way below.
+            //
+            // It matters, and not rarely: 122 of the 806 emitters in a 900-model sample have no
+            // EmissionRate keys in the sequence that resolves, and every one of them would emit
+            // nothing at all if this followed the sequence.
+            const int ParticleTrackSequence = 0;
+            for (int k = 0; k < ParticleTrackOffsets.Length; k++)
+            {
+                int off = at + ParticleTrackOffsets[k];
+                M2Track<float> t;
+                if (k == 4)   // Gravity, whose key encoding depends on a flag
+                    t = def.CompressedGravity
+                        ? ReadTrack<float>(c, off, ParticleTrackSequence, 4, ReadCompressedGravity, NoExternalKeys, false)
+                        : ReadTrack<float>(c, off, ParticleTrackSequence, 4, ReadFloat, NoExternalKeys, false);
+                else
+                    t = ReadTrack<float>(c, off, ParticleTrackSequence, 4, ReadFloat, NoExternalKeys, false);
+
+                switch (k)
+                {
+                    case 0: def.EmissionSpeed = t; break;
+                    case 1: def.SpeedVariation = t; break;
+                    case 2: def.VerticalRange = t; break;
+                    case 3: def.HorizontalRange = t; break;
+                    case 4: def.Gravity = t; break;
+                    case 5: def.Lifespan = t; break;
+                    case 6: def.EmissionRate = t; break;
+                    case 7: def.EmissionAreaLength = t; break;
+                    case 8: def.EmissionAreaWidth = t; break;
+                    default: def.ZSource = t; break;
+                }
+            }
+            // ONE byte per key, not two -- see M2ParticleEmitterDef.EnabledIn. Read at the
+            // PLAYING sequence, which is the one track above that is (particle.cpp:233-234).
+            def.EnabledIn = ReadTrack<float>(c, at + OfsParticleEnabledIn, sequence, 1,
+                                             ReadByteAsFloat, NoExternalKeys, false);
+
+            ReadParticleRamps(c, at + OfsParticleParams, ref def);
+            return true;
+        }
+
+        /// <summary>
+        /// Are these bytes really an emitter?
+        ///
+        /// Every one of these is a field whose range the format fixes, and together they are what
+        /// made the 492-byte stride measurable in the first place: of eight candidate strides,
+        /// only 492 satisfied all of them on all 978 multi-emitter models of a 6,000-model sample.
+        /// So they are not defensive noise -- they are the same test, kept, and they are what
+        /// stands between a model whose header stops short of 0x138 and thirteen invented
+        /// emitters welded to its origin.
+        ///
+        /// An emitter whose BONE points off the end would additionally be a wild read every
+        /// frame. The legacy clamps that one to the root bone and logs (particle.cpp:78-87);
+        /// dropping it is the better answer here, because a stray emitter at the model's origin
+        /// is a visible artefact and this renderer would rather show nothing than something wrong.
+        /// </summary>
+        static bool ParticleEmitterLooksReal(M2ParticleEmitterDef def, M2ParsedModel model)
+        {
+            if (model.BoneCount > 0 && (def.Bone < 0 || def.Bone >= model.BoneCount))
+                return false;
+            if (def.EmitterType < 1 || def.EmitterType > 3)
+                return false;
+            if (def.BlendMode > 7)
+                return false;
+            if (def.Rows > 64 || def.Cols > 64)
+                return false;
+            return true;
+        }
+
+        /// <summary>
+        /// The colour / alpha / size ramps, and the two scalars beside them.
+        ///
+        /// See M2ParticleEmitterDef.ColorTimes for why these are variable-length with real times
+        /// rather than the legacy's three fixed stops at 0 / 0.5 / 1.
+        /// </summary>
+        static void ReadParticleRamps(ByteCursor c, int p, ref M2ParticleEmitterDef def)
+        {
+            def.ColorTimes = new float[0];
+            def.ColorKeys = new WowVec3[0];
+            def.AlphaTimes = new float[0];
+            def.AlphaKeys = new float[0];
+            def.SizeTimes = new float[0];
+            def.SizeKeys = new WowVec2[0];
+            def.ParticleScale = new WowVec2(1f, 1f);
+
+            try
+            {
+                // scales: a per-AXIS multiplier applied to every stop, NOT one per stop. See
+                // M2ParticleEmitterDef.ParticleScale for what the legacy's reading does to a real
+                // emitter. A zero would erase the emitter, so it is treated as unset.
+                c.Seek(p + OfsParamsScales);
+                float sx = c.ReadSingle();
+                float sy = c.ReadSingle();
+                if (IsFinite(sx) && IsFinite(sy) && sx != 0f && sy != 0f)
+                    def.ParticleScale = new WowVec2(sx, sy);
+
+                c.Seek(p + OfsParamsSlowdown);
+                float slow = c.ReadSingle();
+                def.Slowdown = IsFinite(slow) ? slow : 0f;
+
+                c.Seek(p + OfsParamsRotation);
+                float rot = c.ReadSingle();
+                def.SpriteRotation = IsFinite(rot) ? rot : 0f;
+
+                def.ColorKeys = ReadRamp<WowVec3>(c, p + OfsParamsColor, 12, ReadColor255,
+                                                  out def.ColorTimes);
+                def.AlphaKeys = ReadRamp<float>(c, p + OfsParamsAlpha, 2, ReadFixed16,
+                                                out def.AlphaTimes);
+                def.SizeKeys = ReadRamp<WowVec2>(c, p + OfsParamsSize, 8, ReadVec2,
+                                                 out def.SizeTimes);
+            }
+            catch (WowParseException)
+            {
+                // Keep what was read. An empty ramp means "hold the neutral value", which the
+                // runtime reads as white, opaque and unit-sized.
+            }
+
+            for (int i = 0; i < def.SizeKeys.Length; i++)
+                def.SizeKeys[i] = new WowVec2(def.SizeKeys[i].X * def.ParticleScale.X,
+                                              def.SizeKeys[i].Y * def.ParticleScale.Y);
+        }
+
+        /// <summary>
+        /// Read one ramp: its normalised times and its values.
+        ///
+        /// The times are UINT16 over 32767, not milliseconds. Across 17,202 ramp tracks the first
+        /// key is 0 and the last is 32767 in 100.0 % of them and every one is monotonic; read as
+        /// uint32 milliseconds, 0.0 % are either. A times array that cannot be read, or that does
+        /// not ascend, falls back to stops spread evenly over the life -- the best available
+        /// reading of values whose positions are unknown, and exactly right for the two- and
+        /// three-stop cases that are most of the client.
+        /// </summary>
+        static T[] ReadRamp<T>(ByteCursor c, int blockAt, int valueStride, ReadValue<T> read,
+                               out float[] times)
+        {
+            times = new float[0];
+            c.Seek(blockAt);
+            int timeCount = (int)c.ReadUInt32();
+            int timeOffset = (int)c.ReadUInt32();
+            int count = (int)c.ReadUInt32();
+            int offset = (int)c.ReadUInt32();
+            if (count <= 0 || !Fits(c, offset, count, valueStride))
+                return new T[0];
+            int n = count < MaxRampStops ? count : MaxRampStops;
+
+            var values = new T[n];
+            for (int i = 0; i < n; i++)
+            {
+                c.Seek(offset + i * valueStride);
+                values[i] = read(c);
+            }
+
+            var t = new float[n];
+            bool haveTimes = timeCount >= count && Fits(c, timeOffset, timeCount, 2);
+            if (haveTimes)
+            {
+                for (int i = 0; i < n; i++)
+                {
+                    c.Seek(timeOffset + i * 2);
+                    t[i] = c.ReadUInt16() / 32767f;
+                }
+                for (int i = 1; i < n && haveTimes; i++)
+                    if (t[i] < t[i - 1])
+                        haveTimes = false;
+            }
+            if (!haveTimes)
+                for (int i = 0; i < n; i++)
+                    t[i] = n > 1 ? i / (float)(n - 1) : 0f;
+            times = t;
+            return values;
+        }
+
+        /// <summary>A ramp colour stop: three floats the file stores as 0..255.</summary>
+        static WowVec3 ReadColor255(ByteCursor c)
+        {
+            float r = c.ReadSingle();
+            float g = c.ReadSingle();
+            float b = c.ReadSingle();
+            return new WowVec3(r / 255f, g / 255f, b / 255f);
+        }
+
+        /// <summary>A ramp size stop: the x and y scale of the particle's quad.</summary>
+        static WowVec2 ReadVec2(ByteCursor c)
+        {
+            float x = c.ReadSingle();
+            float y = c.ReadSingle();
+            return new WowVec2(IsFinite(x) ? x : 0f, IsFinite(y) ? y : 0f);
+        }
+
+        static float ReadFloat(ByteCursor c)
+        {
+            return Finite(c.ReadSingle());
+        }
+
+        static float Finite(float v) { return IsFinite(v) ? v : 0f; }
+
+        static float ReadByteAsFloat(ByteCursor c) { return c.ReadByte(); }
+
+        /// <summary>
+        /// A Gravity key when the emitter sets flag 0x800000, which 82.9 % of the client's
+        /// emitters do.
+        ///
+        /// WHAT IS MEASURED, AND WHAT IS NOT. The key is FOUR bytes either way -- the packing gap
+        /// between consecutive key arrays comes out at 4 bytes per key, so the flag changes the
+        /// ENCODING and not the stride, and every track offset around it is unaffected. Read as
+        /// float32, which is what the legacy runtime does for every emitter unconditionally
+        /// (particle.cpp:38), the keys decode to NaN or infinity 47 % of the time and to |v| &gt;
+        /// 1e6 65 % of the time: that reading is definitively wrong, whatever the right one is.
+        /// Read as two int16, the second divided by 32767 -- the fixed16 convention this format
+        /// uses everywhere else -- the values come out as clean authored decimals (-0.017, 0.005,
+        /// 0.010, -0.080) and span roughly [-0.08, +0.01] between the 1st and 99th percentiles.
+        ///
+        /// WHAT IS NOT SETTLED is the scale of that number against the PLAIN float gravity, which
+        /// measures as N/36 for small integer N (0.694, 6.944, 41.667). The two are clean in
+        /// different units and no file in this repository relates them. So this decodes the form
+        /// it can defend and accepts that the magnitude may be conservative: a gentle drift is
+        /// wrong by a factor, whereas the float32 reading is wrong by infinity.
+        /// </summary>
+        static float ReadCompressedGravity(ByteCursor c)
+        {
+            c.ReadInt16();                       // see above: zero on 94 % of keys, unidentified
+            return c.ReadInt16() / 32767f;
+        }
+
+        static bool IsFinite(float v)
+        {
+            return !float.IsNaN(v) && !float.IsInfinity(v);
+        }
+
+        static bool ReadRibbonEmitter(ByteCursor c, int at, M2ParsedModel model, int sequence,
+                                      out M2RibbonEmitterDef def)
+        {
+            def = new M2RibbonEmitterDef();
+            def.TextureIds = new int[0];
+            try
+            {
+                c.Seek(at + 4);
+                def.Bone = c.ReadInt32();
+
+                c.Seek(at + OfsRibbonPos);
+                def.Position = ReadVec3(c);
+
+                // UINT16 per entry, not int32. Measured: read as uint16 every index is inside
+                // the model's texture array on 322 of 322 multi-texture ribbons; read as uint32,
+                // only 207 of 322. spells/11fx_infusiontether_aura.m2 stores 21 00 22 00 23 00 --
+                // [33, 34, 35] against 36 textures. particle.cpp:753 makes the same four-byte
+                // mistake ("int *texlist") and gets away with it only because a one-entry array
+                // is padded with zeroes; 48.8 % of the client's ribbons have three textures.
+                c.Seek(at + OfsRibbonTextures);
+                M2Array textures = c.ReadArray();
+                if (textures.Count > 0 && Fits(c, textures.Offset, textures.Count, 2))
+                {
+                    var ids = new List<int>(textures.Count);
+                    for (int i = 0; i < textures.Count; i++)
+                    {
+                        c.Seek(textures.Offset + i * 2);
+                        int id = c.ReadUInt16();
+                        if (id >= 0 && id < model.Textures.Length)
+                            ids.Add(id);
+                    }
+                    def.TextureIds = ids.ToArray();
+                }
+
+                // The ribbon's material, from the SECOND array -- uint16 indices into the
+                // materials table at header offset 0x70. Not parallel to the textures above, and
+                // one entry on every ribbon measured.
+                def.MaterialIndex = -1;
+                c.Seek(at + OfsRibbonMaterials);
+                M2Array materials = c.ReadArray();
+                if (materials.Count > 0 && Fits(c, materials.Offset, materials.Count, 2))
+                {
+                    c.Seek(materials.Offset);
+                    int m = c.ReadUInt16();
+                    if (m >= 0 && m < model.Materials.Length)
+                        def.MaterialIndex = m;
+                }
+
+                // ByteCursor is a STRUCT. Reading through a helper that takes it by value
+                // would leave this cursor where it was and read the same float three times, so
+                // these go through the cursor itself and are sanitised afterwards.
+                c.Seek(at + OfsRibbonRes);
+                def.EdgesPerSecond = Finite(c.ReadSingle());
+                def.EdgeLifetimeSeconds = Finite(c.ReadSingle());
+                def.EmissionAngle = Finite(c.ReadSingle());
+            }
+            catch (WowParseException)
+            {
+                return false;
+            }
+
+            // Same reasoning as ParticleEmitterLooksReal: a ribbon with no usable texture, or
+            // one bound to a bone that does not exist, is not a ribbon.
+            if (model.BoneCount > 0 && (def.Bone < 0 || def.Bone >= model.BoneCount))
+                return false;
+            if (def.TextureIds.Length == 0)
+                return false;
+
+            def.Color = ReadTrack<WowVec3>(c, at + OfsRibbonColor, sequence, Vec3Stride,
+                                           ReadVec3, NoExternalKeys, false);
+            def.Opacity = ReadTrack<float>(c, at + OfsRibbonColor + TrackStride, sequence,
+                                           Fixed16Stride, ReadFixed16, NoExternalKeys, false);
+            def.Above = ReadTrack<float>(c, at + OfsRibbonColor + 2 * TrackStride, sequence,
+                                         4, ReadFloat, NoExternalKeys, false);
+            def.Below = ReadTrack<float>(c, at + OfsRibbonColor + 3 * TrackStride, sequence,
+                                         4, ReadFloat, NoExternalKeys, false);
+            return true;
+        }
 
         /// <summary>Does an array of count*stride bytes at offset lie inside the payload?</summary>
         static bool Fits(ByteCursor c, int offset, int count, int stride)

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Synthetic.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Synthetic.cs
@@ -165,6 +165,171 @@ namespace Wmv.Wow
             return f.Done();
         }
 
+
+        /// <summary>
+        /// The size of the FULL MD20 header. TransformSwitchModel and friends stop at 0x100
+        /// because nothing they test lives past it; the emitter arrays are the last two entries
+        /// in the header, at 0x120 and 0x128, so a model that carries emitters must be built out
+        /// to here or those offsets land in whatever array came first.
+        /// </summary>
+        const int FullHeaderSize = 0x138;
+
+        public const int EmitterParticleStride = 492;
+        public const int EmitterRibbonStride = 176;
+
+        /// <summary>
+        /// A model with one particle emitter and one ribbon emitter, whose EMISSION RATE has keys
+        /// in exactly one of two sequences.
+        ///
+        /// That last part is the point of the fixture: an emitter with no rate keys in the
+        /// playing sequence emits nothing, which is authored behaviour rather than a fault (11 of
+        /// Val'anyr's 13 emitters are in exactly that state on its first sub-animation), and a
+        /// sequence change has to start and stop them accordingly. One bone, animated, so the
+        /// ribbon has something to trail behind.
+        /// </summary>
+        public static byte[] EmitterModel(int keyedSequence)
+        {
+            const int nSeq = 2;
+            const int boneCount = 1;
+            int oVerts = FullHeaderSize;
+            int oTex = oVerts + 3 * 48;
+            int oMat = oTex + 2 * 16;
+            int oTexLookup = oMat + 2 * 4;
+            int oSeqs = oTexLookup + 2;
+            int oBones = oSeqs + nSeq * 64;
+            int oRampTimes = oBones + boneCount * BoneStride;
+            int oRampColor = oRampTimes + 3 * 2;
+            int oRampAlpha = oRampColor + 3 * 12;
+            int oRampSize = oRampAlpha + 3 * 2;
+            int oRibbonTex = oRampSize + 3 * 8;
+            int oRibbonMat = oRibbonTex + 2;
+            int oParticle = oRibbonMat + 2;
+            int oRibbon = oParticle + EmitterParticleStride;
+            int fixedEnd = oRibbon + EmitterRibbonStride;
+
+            var f = new Image(fixedEnd);
+            byte[] b = f.B;
+            PutMagic(b, 0, "MD20");
+            PutU32(b, 0x04, 272);
+            PutU32(b, 0x1C, nSeq); PutU32(b, 0x20, (uint)oSeqs);
+            for (int i = 0; i < nSeq; i++)
+            {
+                int o = oSeqs + i * 64;
+                PutU16(b, o, (ushort)i);
+                PutU32(b, o + 4, 1000);
+                PutU32(b, o + 12, 0x20);
+            }
+            PutU32(b, 0x2C, boneCount); PutU32(b, 0x30, (uint)oBones);
+            PutU32(b, 0x3C, 3); PutU32(b, 0x40, (uint)oVerts);
+            for (int i = 0; i < 3; i++)
+            {
+                int o = oVerts + i * 48;
+                PutF32(b, o + 0, i == 1 ? 1f : 0f);
+                PutF32(b, o + 4, i == 2 ? 1f : 0f);
+                b[o + 12] = 255; b[o + 16] = 0;               // fully weighted to bone 0
+                PutF32(b, o + 28, 1f);                        // normal +Z
+            }
+            PutU32(b, 0x44, 1);
+            PutU32(b, 0x50, 2); PutU32(b, 0x54, (uint)oTex);
+            for (int i = 0; i < 2; i++) { PutU32(b, oTex + i * 16, 0); PutU32(b, oTex + i * 16 + 4, 3); }
+            PutU32(b, 0x70, 2); PutU32(b, 0x74, (uint)oMat);
+            PutU16(b, oMat, 0x01); PutU16(b, oMat + 2, 0);            // material 0: unlit opaque
+            PutU16(b, oMat + 4, 0x01); PutU16(b, oMat + 6, 4);        // material 1: additive
+            PutU32(b, 0x80, 1); PutU32(b, 0x84, (uint)oTexLookup);
+            PutU16(b, oTexLookup, 0);
+            PutU32(b, 0x120, 1); PutU32(b, 0x124, (uint)oRibbon);
+            PutU32(b, 0x128, 1); PutU32(b, 0x12C, (uint)oParticle);
+
+            // Bone 0: a translation track that MOVES in both sequences, so a ribbon has a spine.
+            int ob = oBones;
+            PutU32(b, ob, unchecked((uint)-1));
+            PutU16(b, ob + 8, unchecked((ushort)-1));         // no parent
+            var bT = new uint[nSeq][]; var bV = new byte[nSeq][];
+            for (int s = 0; s < nSeq; s++)
+            {
+                bT[s] = new uint[] { 0, 500, 1000 };
+                bV[s] = Concat(V3(0f, 0f, 0f), V3(1f, 0f, 0f), V3(0f, 0f, 0f));
+            }
+            Track(f, ob + 16, 1, -1, bT, bV);
+            Track(f, ob + 36, 0, -1, new uint[nSeq][], new byte[nSeq][]);
+            Track(f, ob + 56, 0, -1, new uint[nSeq][], new byte[nSeq][]);
+            b = f.B;                                          // Track may have grown the array
+
+            // Ramps: three stops, with the middle one at 0.25 rather than the halfway point.
+            PutU16(b, oRampTimes + 0, 0);
+            PutU16(b, oRampTimes + 2, 8192);
+            PutU16(b, oRampTimes + 4, 32767);
+            for (int i = 0; i < 3; i++)
+            {
+                PutF32(b, oRampColor + i * 12 + 0, 255f);
+                PutF32(b, oRampColor + i * 12 + 4, 128f);
+                PutF32(b, oRampColor + i * 12 + 8, 0f);
+                PutU16(b, oRampAlpha + i * 2, (ushort)(i == 1 ? 32767 : 0));
+                PutF32(b, oRampSize + i * 8 + 0, 0.2f);
+                PutF32(b, oRampSize + i * 8 + 4, 0.1f);
+            }
+            PutU16(b, oRibbonTex, 1);          // texture slot 1
+            PutU16(b, oRibbonMat, 1);          // material 1 -> blend 4
+
+            // ---- the particle emitter ----
+            int p = oParticle;
+            PutU32(b, p + 0, unchecked((uint)-1));
+            PutU32(b, p + 4, 0);
+            PutF32(b, p + 8, 0f); PutF32(b, p + 12, 0f); PutF32(b, p + 16, 0f);
+            PutU16(b, p + 20, 0);              // bone 0
+            PutU16(b, p + 22, 0);              // texture slot 0
+            b[p + 40] = 4;                     // blend: additive on alpha
+            b[p + 41] = 1;                     // plane emitter
+            PutU16(b, p + 48, 1); PutU16(b, p + 50, 1);     // 1x1
+            int pp = p + 260;
+            PutU32(b, pp + 0, 3); PutU32(b, pp + 4, (uint)oRampTimes);
+            PutU32(b, pp + 8, 3); PutU32(b, pp + 12, (uint)oRampColor);
+            PutU32(b, pp + 16, 3); PutU32(b, pp + 20, (uint)oRampTimes);
+            PutU32(b, pp + 24, 3); PutU32(b, pp + 28, (uint)oRampAlpha);
+            PutU32(b, pp + 32, 3); PutU32(b, pp + 36, (uint)oRampTimes);
+            PutU32(b, pp + 40, 3); PutU32(b, pp + 44, (uint)oRampSize);
+            PutF32(b, pp + 100, 1f); PutF32(b, pp + 104, 1f);
+
+            // Lifespan: keys in BOTH sequences, so only the rate decides whether anything emits.
+            var lT = new uint[nSeq][]; var lV = new byte[nSeq][];
+            for (int s = 0; s < nSeq; s++) { lT[s] = new uint[] { 0 }; lV[s] = F1(2f); }
+            Track(f, p + 152, 0, -1, lT, lV);
+
+            // EmissionRate: keys in ONE sequence only.
+            var rT = new uint[nSeq][]; var rV = new byte[nSeq][];
+            rT[keyedSequence] = new uint[] { 0 };
+            rV[keyedSequence] = F1(30f);
+            Track(f, p + 176, 0, -1, rT, rV);
+
+            // ---- the ribbon emitter ----
+            int r = oRibbon;
+            PutU32(f.B, r + 0, unchecked((uint)-1));
+            PutU32(f.B, r + 4, 0);                            // bone 0
+            PutU32(f.B, r + 20, 1); PutU32(f.B, r + 24, (uint)oRibbonTex);
+            PutU32(f.B, r + 28, 1); PutU32(f.B, r + 32, (uint)oRibbonMat);
+            PutF32(f.B, r + 116, 40f);                        // edges per second
+            PutF32(f.B, r + 120, 0.5f);                       // edge lifetime
+            var aT = new uint[nSeq][]; var aV = new byte[nSeq][];
+            for (int s = 0; s < nSeq; s++) { aT[s] = new uint[] { 0 }; aV[s] = F1(0.3f); }
+            Track(f, r + 76, 0, -1, aT, aV);                  // above
+            var bT2 = new uint[nSeq][]; var bV2 = new byte[nSeq][];
+            for (int s = 0; s < nSeq; s++) { bT2[s] = new uint[] { 0 }; bV2[s] = F1(0.3f); }
+            Track(f, r + 96, 0, -1, bT2, bV2);                // below
+            return f.Done();
+        }
+
+        static byte[] F1(float v) { return BitConverter.GetBytes(v); }
+
+        static byte[] Concat(params byte[][] parts)
+        {
+            int n = 0;
+            foreach (byte[] p in parts) n += p.Length;
+            var outp = new byte[n];
+            int o = 0;
+            foreach (byte[] p in parts) { Buffer.BlockCopy(p, 0, outp, o, p.Length); o += p.Length; }
+            return outp;
+        }
+
         /// <summary>
         /// A model with one triangle per submesh and nothing animated: the shape the geoset tests
         /// need, where each submesh can carry its own geoset id. Same single unlit opaque material

--- a/Tools/UnityRendererProject/Tests/WowParserTests.cs
+++ b/Tools/UnityRendererProject/Tests/WowParserTests.cs
@@ -355,6 +355,8 @@ namespace Wmv.Wow.Tests
             BoneTests();
             log.Add("Animation");
             AnimationTests();
+            log.Add("Emitters");
+            EmitterTests();
 
             log.Add(failures == 0 ? "ALL TESTS PASSED" : (failures + " TEST(S) FAILED"));
             if (output != null)
@@ -1681,6 +1683,277 @@ namespace Wmv.Wow.Tests
             WowCoordinateConverter.FlipWinding(tri);
             Check(tri[0] == 0 && tri[1] == 2 && tri[2] == 1, "coords: winding flipped (triangle 1)");
             Check(tri[3] == 3 && tri[4] == 5 && tri[5] == 4, "coords: winding flipped (triangle 2)");
+        }
+
+        // ---------------------------------------------------------------- emitters
+
+        const int ParticleStride = 492;
+        const int RibbonStride = 176;
+
+        /// <summary>
+        /// An M2 payload with a FULL 0x138 header plus one particle emitter and one ribbon
+        /// emitter, both with real nested tracks and real flat ramps.
+        ///
+        /// The header has to be the full length: the emitter arrays live at 0x120 and 0x128,
+        /// past where the other fixtures stop, and a parser that read those offsets out of the
+        /// vertex data would look like it worked.
+        /// </summary>
+        static byte[] BuildEmitterPayload(int particleFlags = 0, int rampStops = 3,
+                                          bool ribbonTexturesAsUint16 = true)
+        {
+            const int headerSize = 0x138;
+            const int boneCount = 2;
+            const int texCount = 4;
+            const int matCount = 2;
+
+            int boneOffset = headerSize;
+            int texOffset = boneOffset + boneCount * BoneStride;
+            int matOffset = texOffset + texCount * 16;
+            int seqOffset = matOffset + matCount * 4;
+            // The nested track arrays: one per animation sequence (one sequence here).
+            int nestedOffset = seqOffset + 64;
+            int keyTimesOffset = nestedOffset + 8 * 8;      // eight {count,offset} pairs
+            int keyValuesOffset = keyTimesOffset + 4 * 8;   // eight uint32 timestamps
+            int rampTimesOffset = keyValuesOffset + 4 * 8;  // eight floats of key value
+            int rampColorOffset = rampTimesOffset + 16 * 2; // uint16 normalised times
+            int rampAlphaOffset = rampColorOffset + 16 * 12;
+            int rampSizeOffset = rampAlphaOffset + 16 * 2;
+            int ribbonTexOffset = rampSizeOffset + 16 * 8;
+            int ribbonMatOffset = ribbonTexOffset + 8;
+            int particleOffset = ribbonMatOffset + 8;
+            int ribbonOffset = particleOffset + ParticleStride;
+            int total = ribbonOffset + RibbonStride;
+
+            var b = new byte[total];
+            PutMagic(b, 0, "MD20");
+            PutU32(b, 0x04, 272);
+            PutU32(b, 0x1C, 1); PutU32(b, 0x20, (uint)seqOffset);          // one sequence
+            PutU32(b, 0x2C, boneCount); PutU32(b, 0x30, (uint)boneOffset);
+            PutU32(b, 0x3C, 0); PutU32(b, 0x40, 0);                        // no vertices
+            PutU32(b, 0x44, 1);
+            PutU32(b, 0x50, texCount); PutU32(b, 0x54, (uint)texOffset);
+            PutU32(b, 0x70, matCount); PutU32(b, 0x74, (uint)matOffset);
+            PutU32(b, 0x120, 1); PutU32(b, 0x124, (uint)ribbonOffset);     // ribbon emitters
+            PutU32(b, 0x128, 1); PutU32(b, 0x12C, (uint)particleOffset);   // particle emitters
+
+            for (int i = 0; i < boneCount; i++)
+                PutBone(b, boneOffset + i * BoneStride, (short)(i - 1), i, 0f, 0f);
+            for (int i = 0; i < texCount; i++)
+            {
+                PutU32(b, texOffset + i * 16 + 0, 0);   // type 0: a named texture
+                PutU32(b, texOffset + i * 16 + 4, 0);
+            }
+            PutU16(b, matOffset, 0); PutU16(b, matOffset + 2, 2);          // material 0: blend 2
+            PutU16(b, matOffset + 4, 0); PutU16(b, matOffset + 6, 7);      // material 1: blend 7
+            PutU32(b, seqOffset + 4, 1000);                                 // sequence length
+            PutU32(b, seqOffset + 0x10, 0x20);                              // primary sequence
+
+            // One nested entry per track: {count, offset} into the times and values arrays.
+            for (int i = 0; i < 8; i++)
+            {
+                PutU32(b, nestedOffset + i * 8 + 0, 1);
+                PutU32(b, nestedOffset + i * 8 + 4, (uint)(keyTimesOffset + i * 4));
+            }
+            for (int i = 0; i < 8; i++)
+                PutU32(b, keyTimesOffset + i * 4, 0);
+
+            // The ramps. Times are uint16 over 32767; a deliberately UNEVEN middle stop, which is
+            // the case the legacy's hardcoded 0.5 gets wrong.
+            var stopTimes = new ushort[] { 0, 8192, 32767 };   // 0.0, 0.25, 1.0
+            for (int i = 0; i < rampStops; i++)
+                PutU16(b, rampTimesOffset + i * 2,
+                       i < stopTimes.Length ? stopTimes[i] : (ushort)32767);
+            for (int i = 0; i < rampStops; i++)
+            {
+                PutF32(b, rampColorOffset + i * 12 + 0, 255f);       // r -> 1.0
+                PutF32(b, rampColorOffset + i * 12 + 4, i * 100f);
+                PutF32(b, rampColorOffset + i * 12 + 8, 0f);
+                PutU16(b, rampAlphaOffset + i * 2, (ushort)(i == 1 ? 32767 : 0));
+                PutF32(b, rampSizeOffset + i * 8 + 0, 0.5f);         // x
+                PutF32(b, rampSizeOffset + i * 8 + 4, 0.25f);        // y, deliberately different
+            }
+
+            // Ribbon texture and material index arrays -- uint16 each.
+            PutU16(b, ribbonTexOffset + 0, 2);
+            PutU16(b, ribbonTexOffset + 2, 3);
+            PutU16(b, ribbonMatOffset + 0, 1);        // -> material 1, blend 7
+
+            // ---- the particle emitter ----
+            int p = particleOffset;
+            PutU32(b, p + 0, unchecked((uint)-1));               // id
+            PutU32(b, p + 4, (uint)particleFlags);
+            PutF32(b, p + 8, 1f); PutF32(b, p + 12, 2f); PutF32(b, p + 16, 3f);   // pos
+            PutU16(b, p + 20, 1);                                // bone 1
+            PutU16(b, p + 22, 2);                                // texture slot 2
+            b[p + 40] = 4;                                       // blend: additive on alpha
+            b[p + 41] = 2;                                       // emitter type: sphere
+            PutU16(b, p + 42, 12);                               // ParticleColorIndex
+            PutU16(b, p + 46, 0);                                // tile rotation
+            PutU16(b, p + 48, 2); PutU16(b, p + 50, 4);          // rows, cols
+            // The ten float tracks. Only EmissionRate (index 6, at +176) is given keys.
+            PutU16(b, p + 176, 1);                               // interpolation: linear
+            PutU16(b, p + 178, unchecked((ushort)-1));           // no global sequence
+            PutU32(b, p + 180, 1); PutU32(b, p + 184, (uint)nestedOffset);
+            PutU32(b, p + 188, 1); PutU32(b, p + 192, (uint)(nestedOffset + 8));
+            PutF32(b, keyValuesOffset + 4, 40f);                 // rate = 40
+            for (int i = 0; i < 8; i++)
+                PutU32(b, nestedOffset + i * 8 + 4,
+                       (uint)(i == 1 ? keyValuesOffset + 4 : keyTimesOffset + i * 4));
+            PutU32(b, nestedOffset + 0 * 8 + 4, (uint)keyTimesOffset);
+
+            // EnabledIn, at +456: ONE byte per key.
+            PutU16(b, p + 456, 0);
+            PutU16(b, p + 458, unchecked((ushort)-1));
+            PutU32(b, p + 460, 1); PutU32(b, p + 464, (uint)(nestedOffset + 16));
+            PutU32(b, p + 468, 1); PutU32(b, p + 472, (uint)(nestedOffset + 24));
+
+            // ModelParticleParams at +260: three FakeAnimationBlocks {nTimes,ofsTimes,nKeys,ofsKeys}
+            int pp = p + 260;
+            PutU32(b, pp + 0, (uint)rampStops); PutU32(b, pp + 4, (uint)rampTimesOffset);
+            PutU32(b, pp + 8, (uint)rampStops); PutU32(b, pp + 12, (uint)rampColorOffset);
+            PutU32(b, pp + 16, (uint)rampStops); PutU32(b, pp + 20, (uint)rampTimesOffset);
+            PutU32(b, pp + 24, (uint)rampStops); PutU32(b, pp + 28, (uint)rampAlphaOffset);
+            PutU32(b, pp + 32, (uint)rampStops); PutU32(b, pp + 36, (uint)rampTimesOffset);
+            PutU32(b, pp + 40, (uint)rampStops); PutU32(b, pp + 44, (uint)rampSizeOffset);
+            PutF32(b, pp + 100, 2f);      // scales.x
+            PutF32(b, pp + 104, 2f);      // scales.y
+            PutF32(b, pp + 108, 519f);    // the third float: NOT a scale
+            PutF32(b, pp + 112, 0.5f);    // slowdown
+            PutF32(b, pp + 124, 0.25f);   // sprite rotation
+
+            // ---- the ribbon emitter ----
+            int r = ribbonOffset;
+            PutU32(b, r + 0, unchecked((uint)-1));
+            PutU32(b, r + 4, 1);                                  // bone 1 (int32 here)
+            PutF32(b, r + 8, 4f); PutF32(b, r + 12, 5f); PutF32(b, r + 16, 6f);
+            PutU32(b, r + 20, 2); PutU32(b, r + 24, (uint)ribbonTexOffset);
+            PutU32(b, r + 28, 1); PutU32(b, r + 32, (uint)ribbonMatOffset);
+            PutF32(b, r + 116, 50f);       // edges per second
+            PutF32(b, r + 120, 0.2f);      // edge lifetime
+            PutF32(b, r + 124, 0f);        // emission angle
+            return b;
+        }
+
+        static void EmitterTests()
+        {
+            byte[] file = WrapChunked(BuildEmitterPayload(), new[] { 1 }, new[] { 10, 11, 12, 13 });
+            M2ParsedModel m = M2Parser.Parse(file);
+
+            Check(m.ParticleEmitterCount == 1 && m.ParticleEmitters.Length == 1,
+                  "emitters: particle array read at 0x128");
+            Check(m.RibbonEmitterCount == 1 && m.RibbonEmitters.Length == 1,
+                  "emitters: ribbon array read at 0x120");
+
+            M2ParticleEmitterDef p = m.ParticleEmitters[0];
+            Check(p.Bone == 1, "particle: bone index");
+            Check(p.TextureId == 2, "particle: texture is a DIRECT slot index");
+            Check(p.BlendMode == 4, "particle: blend mode");
+            Check(p.EmitterType == 2 && p.Supported, "particle: sphere emitter is supported");
+            Check(p.ParticleColorIndex == 12, "particle: ParticleColorIndex kept");
+            Check(p.Rows == 2 && p.Cols == 4, "particle: flipbook rows/cols");
+            Near(p.Position.X, 1f, "particle: position X");
+            Near(p.Position.Z, 3f, "particle: position Z");
+            Check(p.EmissionRate.HasData && p.EmissionRate.Values.Length == 1,
+                  "particle: EmissionRate track read through the nested arrays");
+            Near(p.EmissionRate.Values[0], 40f, "particle: EmissionRate value");
+
+            // The ramp: variable length, with the authored times, NOT three stops at 0/0.5/1.
+            Check(p.ColorKeys.Length == 3 && p.ColorTimes.Length == 3, "particle: colour ramp stops");
+            Near(p.ColorTimes[1], 8192f / 32767f, "particle: ramp times are uint16 over 32767");
+            Check(p.ColorTimes[1] < 0.3f, "particle: an uneven middle stop is NOT snapped to 0.5");
+            Near(p.ColorKeys[0].X, 1f, "particle: colour stored 0..255 becomes 0..1");
+            Near(p.AlphaKeys[1], 1f, "particle: alpha stored fixed16");
+
+            // scales is per-AXIS, applied to every stop -- and its third float is not a scale.
+            Near(p.ParticleScale.X, 2f, "particle: scales.x read");
+            Near(p.ParticleScale.Y, 2f, "particle: scales.y read");
+            Near(p.SizeKeys[0].X, 1f, "particle: size x scaled by scales.x (0.5 * 2)");
+            Near(p.SizeKeys[0].Y, 0.5f, "particle: size y scaled by scales.y (0.25 * 2)");
+            Check(Math.Abs(p.SizeKeys[2].X - 0.5f * 519f) > 1f,
+                  "particle: the third scales float is NOT applied to the last stop");
+            Near(p.Slowdown, 0.5f, "particle: slowdown");
+            Near(p.SpriteRotation, 0.25f, "particle: sprite rotation");
+
+            M2RibbonEmitterDef rb = m.RibbonEmitters[0];
+            Check(rb.Bone == 1, "ribbon: bone index (int32)");
+            Near(rb.Position.Y, 5f, "ribbon: position Y");
+            Check(rb.TextureIds.Length == 2 && rb.TextureIds[0] == 2 && rb.TextureIds[1] == 3,
+                  "ribbon: texture indices are UINT16, not int32");
+            Check(rb.MaterialIndex == 1, "ribbon: material index read from its own array");
+            Near(rb.EdgesPerSecond, 50f, "ribbon: res is edges per second");
+            Near(rb.EdgeLifetimeSeconds, 0.2f, "ribbon: length is an edge lifetime in seconds");
+            Check(rb.EmissionAngle == 0f,
+                  "ribbon: the three floats are read separately (a struct cursor is by value)");
+
+            // A two-stop ramp must stay two stops -- the legacy copies three regardless.
+            M2ParsedModel two = M2Parser.Parse(
+                WrapChunked(BuildEmitterPayload(rampStops: 2), new[] { 1 }, new[] { 10, 11, 12, 13 }));
+            Check(two.ParticleEmitters[0].ColorKeys.Length == 2,
+                  "particle: a two-stop ramp is not padded to three");
+
+            // A spline emitter is PARSED -- the parser reports what the file holds -- but marks
+            // itself unsupported, and the runtime is what declines to draw it (as the legacy
+            // builds no emitter object for one either, particle.cpp:117-120).
+            byte[] spline = BuildEmitterPayload();
+            spline[FindParticleOffset(spline) + 41] = 3;
+            M2ParsedModel sp = M2Parser.Parse(WrapChunked(spline, new[] { 1 }, new[] { 10, 11, 12, 13 }));
+            Check(sp.ParticleEmitters.Length == 1, "particle: a spline emitter still parses");
+            Check(!sp.ParticleEmitters[0].Supported,
+                  "particle: a spline emitter reports itself unsupported");
+
+            // An out-of-range bone is dropped rather than left to index off the end.
+            byte[] badBone = BuildEmitterPayload();
+            PutU16(badBone, FindParticleOffset(badBone) + 20, 900);
+            M2ParsedModel bb = M2Parser.Parse(WrapChunked(badBone, new[] { 1 }, new[] { 10, 11, 12, 13 }));
+            Check(bb.ParticleEmitters.Length == 0, "particle: an out-of-range bone is dropped");
+
+            // Flags.
+            M2ParticleEmitterDef f = M2Parser.Parse(
+                WrapChunked(BuildEmitterPayload(0x10 | 0x1000 | 0x800000 | 0x20000),
+                            new[] { 1 }, new[] { 10, 11, 12, 13 })).ParticleEmitters[0];
+            Check(f.DoNotTrail, "particle: DONOTTRAIL flag");
+            Check(f.DoNotBillboard, "particle: DONOTBILLBOARD flag");
+            Check(f.Outward, "particle: OUTWARD flag");
+            Check(f.CompressedGravity, "particle: compressed-gravity flag");
+
+            // The synthetic fixture the runtime lifecycle test drives, checked here so a failure
+            // in it is attributed to the fixture rather than to the runtime.
+            for (int keyed = 0; keyed < 2; keyed++)
+            {
+                byte[] synth = M2Synthetic.EmitterModel(keyed);
+                M2ParsedModel s0 = M2Parser.Parse(synth, 0);
+                M2ParsedModel s1 = M2Parser.Parse(synth, 1);
+                Check(s0.ParticleEmitters.Length == 1 && s0.RibbonEmitters.Length == 1,
+                      "synthetic[" + keyed + "]: one particle and one ribbon emitter in sequence 0");
+                Check(s1.ParticleEmitters.Length == 1 && s1.RibbonEmitters.Length == 1,
+                      "synthetic[" + keyed + "]: same in sequence 1");
+                // The float tracks are read at ANIMATION 0 whichever sequence is playing --
+                // WMV's bZeroParticle default, see M2Parser. So the rate is the same in both,
+                // and it is present exactly when animation 0 is the keyed one.
+                Check(s0.ParticleEmitters[0].EmissionRate.HasData == (keyed == 0),
+                      "synthetic[" + keyed + "]: rate read at animation 0, present == " + (keyed == 0));
+                Check(s1.ParticleEmitters[0].EmissionRate.HasData ==
+                      s0.ParticleEmitters[0].EmissionRate.HasData,
+                      "synthetic[" + keyed + "]: the played sequence does not change it");
+                Check(s0.ParticleEmitters[0].Lifespan.HasData && s1.ParticleEmitters[0].Lifespan.HasData,
+                      "synthetic[" + keyed + "]: lifespan keys in BOTH sequences");
+                Check(s0.RibbonEmitters[0].MaterialIndex == 1,
+                      "synthetic[" + keyed + "]: ribbon material index");
+            }
+
+            // A header too short to carry the arrays yields no emitters and no exception.
+            M2ParsedModel shortHeader = M2Parser.Parse(
+                WrapChunked(BuildM2Payload(3), new[] { 473370 }, new[] { 0 }));
+            Check(shortHeader.ParticleEmitters.Length == 0 && shortHeader.RibbonEmitters.Length == 0,
+                  "emitters: a model without emitter arrays parses to none");
+        }
+
+        /// <summary>Where BuildEmitterPayload put the particle emitter, read back out of the
+        /// header so the test does not restate the fixture's arithmetic.</summary>
+        static int FindParticleOffset(byte[] payload)
+        {
+            return (int)(payload[0x12C] | (payload[0x12D] << 8) |
+                         (payload[0x12E] << 16) | (payload[0x12F] << 24));
         }
 
     }


### PR DESCRIPTION
The Unity renderer parsed neither and drew neither: a search of the builder for "particle" or "ribbon" returned one hit, and it was a comment about shader names. The Lich King's four emitters, the phoenix's thirty-four, and the glow motes on every raid weapon were simply absent.

PARSER. The two emitter arrays sit at the tail of the MD20 header, at 0x120 and 0x128. Both strides are MEASURED rather than assumed: of eight candidate particle strides tried against real files, 492 validated every emitter of all 978 multi-emitter models in a 6,000-model sample and every other candidate failed somewhere; the ribbon's 176 was the only one of four to validate at all. Tracks are read through the existing nested-per-sequence reader.

RUNTIME. One GameObject, one Material and one Mesh PER EMITTER -- not per particle. A particle is sixteen floats in a flat array; a frame writes four vertices per live one into buffers allocated at load and never reallocated. A 21-emitter staff is 21 draw calls whatever the particle count, and the steady state allocates nothing measurable: the phoenix, at 44 emitter draw calls, runs at 478 bytes/frame against 341 for a model with no emitters at all, with no gen-0 collections in the window.

THE CLOCK IS THE MODEL'S. Tick runs from WmvM2Animator's LateUpdate after the bones are posed, with the animation's own advance -- scaled by playback speed, and exactly zero while paused, which is what the legacy viewport does (modelcanvas.cpp:1515-1522). Nothing here reads Time.time. A pinned capture simulates forward to its instant deterministically, because an emitter's state is a history and a held clock would leave it empty.

WHERE THIS DIVERGES FROM particle.cpp, and why, is listed in full at the head of WmvEmitterRuntime.cs -- ten items, each one a case where measurement against client data shows the legacy is wrong rather than a preference. The three that matter most:

  * GRAVITY. 82.9 % of the client's emitters set flag 0x800000, which changes how a gravity key is encoded. particle.cpp:38 reads them all as float32; on those emitters that decodes to NaN or infinity 47 % of the time.
  * THE LIFE RAMP is not three stops at 0 / 0.5 / 1. Its times are uint16 over 32767 (first key 0 and last 32767 in 100.0 % of 17,202 tracks measured), 42 % of ramps do not have three stops, and among those that do the middle one sits at 0.5 only 55 % of the time. Colour and alpha are separate tracks with separate times and are sampled separately.
  * PARTICLE SIZE. params.scales is a per-AXIS scale, not one per ramp stop. Under the legacy's indexing a 0.0556 particle on Val'anyr comes out 28.85 units across and another gets a negative size.

Emitter float tracks are read at ANIMATION 0 whichever sequence plays, which is the app's own shipped default (GLOBALSETTINGS.bZeroParticle, app.cpp:969); without it 122 of 806 emitters in a 900-model sample emit nothing at all.

PARTICLECOLOR. An emitter opts into an item colour override with ParticleColorIndex 11, 12 or 13. WMV has always parsed that index and never resolved a colour for it -- replaceParticleColors is initialised false and nothing assigns it. The host now resolves ItemDisplayInfo.ParticleColorID -> ParticleColor for the displayed model and sends it with the textures; the override replaces RGB and keeps the authored alpha, as the legacy does.

Verified on the real embedded viewport, same camera, light, instant and skin, emitters the only variable: phoenix 3.15 % of the frame changed (ten ribbon trails), Blockade's Lost Shield 1.11 %, the Celestial cape 0.83 %, Battle Magister's Orbs 0.42 %, the priest staff 0.11 %. The negative control, Drakestalker's Trophy Pauldrons, is byte-identical.

353 parser cases and 142 runtime lifecycle assertions pass; 900 real models parse with no NaN gravity, no bad sizes or alphas and every declared emitter kept.