### PR TITLE
Add mouse wheel zoom to Unity viewport

### DIFF
--- a/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
@@ -240,6 +240,160 @@ public static class WmvLifecycleSelfTest
         prt.Dispose();
     }
 
+
+    // ---------------------------------------------------------------- viewport zoom
+
+    /// <summary>
+    /// The four shapes the viewport actually has to serve, by bounding radius. These are real
+    /// numbers from this client: an item component is a fraction of a unit, a creature is a
+    /// couple of units, a large creature ten or so, and a doodad or WMO can be hundreds.
+    /// </summary>
+    static readonly float[] ZoomRadii = { 0.15f, 1.2f, 12f, 250f };
+    static readonly string[] ZoomNames = { "item component", "normal creature", "large model",
+                                           "very large model" };
+
+    static WmvOrbitCamera NewCamera(out GameObject go)
+    {
+        go = new GameObject("ZoomTestCamera");
+        var cam = go.AddComponent<Camera>();
+        cam.fieldOfView = 60f;
+        return go.AddComponent<WmvOrbitCamera>();
+    }
+
+    /// <summary>
+    /// Mouse-wheel zoom, driven through the same two methods the wheel drives.
+    ///
+    /// The wheel itself cannot be synthesised from in-process, so what is checked here is
+    /// everything downstream of the notch: that a notch moves the camera the right way by the
+    /// right proportion, that the range is derived from the model rather than fixed, that the
+    /// camera cannot reach or pass the focus point, and that the angle and the target survive.
+    /// Whether a notch ARRIVES is a windowing question and was settled by rolling a real wheel
+    /// over the viewport -- see the wheel note at the top of WmvOrbitCamera.
+    /// </summary>
+    static void ZoomTests(Action<string> log)
+    {
+        for (int i = 0; i < ZoomRadii.Length; i++)
+        {
+            float radius = ZoomRadii[i];
+            string what = ZoomNames[i] + " (r=" + radius + ")";
+            GameObject go;
+            WmvOrbitCamera cam = NewCamera(out go);
+
+            var pivot = new Vector3(3f, -2f, 5f);       // deliberately not the origin
+            cam.Frame(new Bounds(pivot, Vector3.one * (radius * 2f / Mathf.Sqrt(3f))));
+
+            float framed = cam.FramedDistance;
+            Check(framed > 0f, "zoom " + what + ": framed at a positive distance", log);
+            Check(cam.distance == framed, "zoom " + what + ": starts settled at the framing distance", log);
+
+            // THE RANGE COMES FROM THE MODEL. A fixed range cannot serve r=0.15 and r=250 both.
+            Check(cam.MinDistance < framed && cam.MaxDistance > framed,
+                  "zoom " + what + ": framing distance sits inside the range", log);
+            Check(cam.MinDistance > 0f, "zoom " + what + ": minimum is strictly positive", log);
+            Check(Mathf.Abs(cam.MinDistance / framed - 0.02f) < 1e-3f,
+                  "zoom " + what + ": minimum is 2% of framing, not a constant", log);
+            Check(Mathf.Abs(cam.MaxDistance / framed - 20f) < 1e-2f,
+                  "zoom " + what + ": maximum is 20x framing, not a constant", log);
+
+            // ---- one notch in, one notch out, back where we started ----------------------
+            float before = cam.distance;
+            float yaw0 = cam.yaw, pitch0 = cam.pitch;
+            Vector3 pivot0 = cam.pivot;
+            cam.ZoomByNotches(1f);
+            Check(cam.TargetDistance < before, "zoom " + what + ": wheel up moves closer", log);
+            cam.ZoomByNotches(-1f);
+            Check(Mathf.Abs(cam.TargetDistance - before) < before * 1e-4f,
+                  "zoom " + what + ": one notch in then out returns exactly (symmetric)", log);
+
+            // ---- angle and target are preserved -------------------------------------------
+            cam.ZoomByNotches(5f);
+            for (int f = 0; f < 200; f++) cam.AdvanceZoom(1f / 60f);
+            Check(cam.yaw == yaw0 && cam.pitch == pitch0,
+                  "zoom " + what + ": camera angle unchanged by zoom", log);
+            Check(cam.pivot == pivot0, "zoom " + what + ": orbit target unchanged by zoom", log);
+            Check(Vector3.Distance(cam.transform.position, cam.pivot) > 0f,
+                  "zoom " + what + ": camera is not AT the focus point", log);
+
+            // ---- the minimum holds, and the camera never crosses the pivot ----------------
+            for (int n = 0; n < 400; n++) cam.ZoomByNotches(1f);
+            for (int f = 0; f < 400; f++) cam.AdvanceZoom(1f / 60f);
+            Check(cam.distance >= cam.MinDistance - 1e-6f,
+                  "zoom " + what + ": 400 notches in stops at the minimum (" + cam.distance + ")", log);
+            Check(cam.distance > 0f, "zoom " + what + ": distance never reaches zero", log);
+            float dot = Vector3.Dot(cam.pivot - cam.transform.position, cam.transform.forward);
+            Check(dot > 0f, "zoom " + what + ": camera still looks AT the pivot (never flipped)", log);
+
+            // ---- and the maximum ----------------------------------------------------------
+            for (int n = 0; n < 800; n++) cam.ZoomByNotches(-1f);
+            for (int f = 0; f < 600; f++) cam.AdvanceZoom(1f / 60f);
+            Check(cam.distance <= cam.MaxDistance + 1e-4f,
+                  "zoom " + what + ": 800 notches out stops at the maximum (" + cam.distance + ")", log);
+            dot = Vector3.Dot(cam.pivot - cam.transform.position, cam.transform.forward);
+            Check(dot > 0f, "zoom " + what + ": still looks at the pivot when fully out", log);
+
+            UnityEngine.Object.DestroyImmediate(go);
+        }
+
+        // ---- smoothing is framerate-independent -----------------------------------------
+        {
+            GameObject a, b;
+            WmvOrbitCamera fast = NewCamera(out a);
+            WmvOrbitCamera slow = NewCamera(out b);
+            var bounds = new Bounds(Vector3.zero, Vector3.one * 2f);
+            fast.Frame(bounds); slow.Frame(bounds);
+            fast.ZoomByNotches(6f); slow.ZoomByNotches(6f);
+            // Half a second of animation, at 240 fps and at 30 fps.
+            for (int i = 0; i < 120; i++) fast.AdvanceZoom(1f / 240f);
+            for (int i = 0; i < 15; i++) slow.AdvanceZoom(1f / 30f);
+            float diff = Mathf.Abs(fast.distance - slow.distance) / Mathf.Max(fast.distance, 1e-6f);
+            Check(diff < 0.02f,
+                  "zoom: the same gesture lands within 2% at 240 fps and at 30 fps (" +
+                  (diff * 100f).ToString("F2") + "%)", log);
+            UnityEngine.Object.DestroyImmediate(a);
+            UnityEngine.Object.DestroyImmediate(b);
+        }
+
+        // ---- a model switch re-derives everything and leaves nothing gliding -------------
+        {
+            GameObject go;
+            WmvOrbitCamera cam = NewCamera(out go);
+            cam.Frame(new Bounds(Vector3.zero, Vector3.one * 2f));
+            cam.ZoomByNotches(8f);                       // leave a zoom in flight
+            float smallMin = cam.MinDistance;
+            cam.Frame(new Bounds(new Vector3(10f, 0f, 0f), Vector3.one * 200f));
+            Check(cam.distance == cam.TargetDistance,
+                  "zoom: a model switch lands settled, with no zoom still gliding", log);
+            Check(cam.distance == cam.FramedDistance,
+                  "zoom: a model switch re-frames rather than keeping the old distance", log);
+            Check(cam.MinDistance > smallMin,
+                  "zoom: the range is re-derived for the new model", log);
+            Check(cam.pivot == new Vector3(10f, 0f, 0f),
+                  "zoom: a model switch moves the orbit target to the new bounds", log);
+            // ... and the wheel still works afterwards, which is the "switching models must not
+            // break camera controls" requirement.
+            float after = cam.TargetDistance;
+            cam.ZoomByNotches(1f);
+            Check(cam.TargetDistance < after, "zoom: the wheel still works after a model switch", log);
+            UnityEngine.Object.DestroyImmediate(go);
+        }
+
+        // ---- zoom leaves orbit and pan alone ---------------------------------------------
+        {
+            GameObject go;
+            WmvOrbitCamera cam = NewCamera(out go);
+            cam.Frame(new Bounds(Vector3.zero, Vector3.one * 2f));
+            cam.ZoomByNotches(4f);
+            for (int f = 0; f < 200; f++) cam.AdvanceZoom(1f / 60f);
+            float zoomed = cam.distance;
+            cam.yaw += 90f;                              // what an orbit drag does
+            cam.pivot += new Vector3(1f, 0f, 0f);        // what a pan drag does
+            cam.AdvanceZoom(1f / 60f);
+            Check(Mathf.Abs(cam.distance - zoomed) < 1e-5f,
+                  "zoom: orbiting and panning after a zoom does not disturb the distance", log);
+            UnityEngine.Object.DestroyImmediate(go);
+        }
+    }
+
     static void GeosetTests(Action<string> log)
     {
         // A Drakestalker-shaped component: two submeshes at id 0 and one alternative at 2602.
@@ -380,6 +534,7 @@ public static class WmvLifecycleSelfTest
         GeosetTests(log);
         OutputGateTests(log);
         EmitterTests(log);
+        ZoomTests(log);
         log(string.Format("lifecycle-test: {0} passed, {1} failed", passed, failed));
     }
 }

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvOrbitCamera.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvOrbitCamera.cs
@@ -21,9 +21,33 @@
 //   InvalidOperationException *every frame*, which is what a plain Input.mousePosition call did
 //   here. If neither backend is available the camera keeps framing models and simply does not
 //   respond to the mouse, warning exactly once instead of once per frame.
+//
+//   THE WHEEL IS THE EXCEPTION, AND IT IS MEASURED. This player runs as a CHILD WINDOW of a
+//   wxWidgets host, and in that arrangement the legacy Input Manager never sees a wheel notch:
+//   it takes the wheel from WM_MOUSEWHEEL, which Windows delivers to the focused window of the
+//   focused application -- and an embedded child of another process's frame is not that. Rolling
+//   a real wheel over the viewport and logging both backends side by side, twelve notches gave
+//   twelve readings of
+//
+//       legacy Input.GetAxis("Mouse ScrollWheel") = 0.00000
+//       Input System Mouse.current.scroll.y       = 1.00
+//
+//   with and without a prior click in the pane, and neither the host nor a WM_MOUSEWHEEL posted
+//   directly to the player's render window produced anything. Mouse POSITION and BUTTONS arrive
+//   on the legacy backend (position is polled from the OS cursor, buttons were observed held),
+//   so only the wheel has to come from the Input System's raw-input path. That is why the scroll
+//   is read separately from everything else below.
+//
+//   ONE NOTCH IS 1.0 THERE, NOT 120. The previous code divided the Input System's reading by
+//   1200 on the assumption that Windows reports 120 units per notch; measured here it reports
+//   1.0, so that scaling was 120x too small and would have made the wheel look dead even on the
+//   backend that receives it. Both shapes are handled below rather than assumed.
 
 using UnityEngine;
-#if !ENABLE_LEGACY_INPUT_MANAGER && ENABLE_INPUT_SYSTEM
+// Present whenever the package is, NOT only when it is the sole backend: with "Both" active --
+// which is what this project builds with -- the legacy manager supplies position and buttons
+// while the wheel comes from here. See the wheel note in the file header.
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
 
@@ -36,14 +60,64 @@ public class WmvOrbitCamera : MonoBehaviour
 
     const float OrbitSpeed = 0.25f;    // degrees per pixel
     const float PanSpeed = 0.0025f;    // world units per pixel, scaled by distance
-    const float ZoomSpeed = 0.12f;
-    const float MinDistance = 0.05f;
-    const float MaxDistance = 500f;
+
+    /// <summary>
+    /// What one wheel notch multiplies the orbit distance by. Taken from the legacy OpenGL
+    /// viewport, which uses exactly this (modelcanvas.cpp:474, radius * powf(0.82f, notches)) --
+    /// so the two viewports feel the same under the hand.
+    ///
+    /// MULTIPLYING is the point. A fixed step per notch is unusable at both ends: it crawls when
+    /// a WMO sits hundreds of units away and it jumps straight through a 0.2-unit item component.
+    /// Scaling makes a notch mean the same PROPORTION of the current distance everywhere, which
+    /// is what "zoom speed scales with distance" actually asks for. Raising it to a power of the
+    /// notch count also keeps it exactly symmetric: one notch in and one notch out returns the
+    /// camera to where it started, which `distance * (1 - k)` followed by `distance * (1 + k)`
+    /// does not (it loses k^2 every round trip).
+    /// </summary>
+    const float ZoomPerNotch = 0.82f;
+
+    /// <summary>
+    /// How fast the eased distance chases the wheel, as an exponential rate per second. Used as
+    /// 1 - exp(-k * dt) rather than a bare Lerp with a constant factor, so the motion is the same
+    /// whether the viewport is running at 30 fps or 300. At 16 it covers ~95 % in 190 ms: quick
+    /// enough to feel like a direct response, slow enough to read as a glide.
+    /// </summary>
+    const float ZoomSmoothing = 16f;
+
+    /// <summary>
+    /// The zoom range, as multiples of the distance the model was FRAMED at. Derived from the
+    /// model rather than fixed, because a fixed range cannot serve both ends of this client: the
+    /// legacy viewport's hardcoded floor of 0.5 units (OrbitCamera.cpp:12) is further away than
+    /// a 0.3-unit item component is wide, so such a model can never be zoomed into at all.
+    /// Framing distance is itself proportional to the model's radius, so these two factors give
+    /// every model the same usable range in proportion to its own size.
+    /// </summary>
+    const float MinDistanceFactor = 0.02f;
+    const float MaxDistanceFactor = 20f;
+
+    /// <summary>An absolute floor, so a degenerate bounds cannot put the camera AT the pivot.
+    /// The camera can approach the focus point but never reach or pass through it.</summary>
+    const float AbsoluteMinDistance = 1e-3f;
+
+    /// <summary>
+    /// Where the wheel is taking the camera. `distance` eases toward this every frame; the wheel
+    /// only ever writes here. Keeping the two apart is what makes the motion smooth without
+    /// making it laggy -- the target is reached instantly, the eye gets there over ~190 ms.
+    /// </summary>
+    float targetDistance = 4f;
+
+    float framedDistance = 4f;
+    float minDistance = AbsoluteMinDistance;
+    float maxDistance = 500f;
 
     Vector3 lastMouse;
     bool warnedNoInput;
 
-    void Start() { Apply(); }
+    void Start()
+    {
+        targetDistance = distance;
+        Apply();
+    }
 
     /// <summary>
     /// Point the camera at a model's bounds from a three-quarter angle, far enough back that
@@ -58,19 +132,34 @@ public class WmvOrbitCamera : MonoBehaviour
 
         var cam = GetComponent<Camera>();
         float fov = (cam != null ? cam.fieldOfView : 60f) * Mathf.Deg2Rad;
-        distance = Mathf.Clamp(radius / Mathf.Max(0.05f, Mathf.Sin(fov * 0.5f)) * 1.25f,
-                               MinDistance, MaxDistance);
+        framedDistance = radius / Mathf.Max(0.05f, Mathf.Sin(fov * 0.5f)) * 1.25f;
 
-        // Keep near/far sane for models that span a few centimetres or a few hundred metres.
-        if (cam != null)
-        {
-            cam.nearClipPlane = Mathf.Max(0.01f, distance * 0.01f);
-            cam.farClipPlane = Mathf.Max(100f, distance * 20f);
-        }
+        // THE ZOOM RANGE COMES FROM THE MODEL. See MinDistanceFactor.
+        minDistance = Mathf.Max(framedDistance * MinDistanceFactor, AbsoluteMinDistance);
+        maxDistance = framedDistance * MaxDistanceFactor;
+
+        distance = Mathf.Clamp(framedDistance, minDistance, maxDistance);
+        targetDistance = distance;          // a new model starts settled, not gliding
 
         yaw = 30f;
         pitch = 15f;
         Apply();
+    }
+
+    /// <summary>
+    /// Near and far, derived from the CURRENT distance.
+    ///
+    /// This has to follow the zoom, not just the framing. The planes used to be set once, from
+    /// the framing distance, which meant zooming in past a fiftieth of it put the near plane in
+    /// front of the model and sliced it away -- exactly the range the new minimum opens up. Same
+    /// formulas as before, evaluated whenever the distance changes instead of only once.
+    /// </summary>
+    void UpdateClipPlanes(Camera cam)
+    {
+        if (cam == null)
+            return;
+        cam.nearClipPlane = Mathf.Max(0.001f, distance * 0.01f);
+        cam.farClipPlane = Mathf.Max(100f, distance * 20f);
     }
 
     // ---------------------------------------------------------------- input backends
@@ -86,7 +175,9 @@ public class WmvOrbitCamera : MonoBehaviour
         position = Input.mousePosition;
         leftHeld = Input.GetMouseButton(0);
         rightHeld = Input.GetMouseButton(1);
-        scroll = Input.GetAxis("Mouse ScrollWheel");
+        // NOT Input.GetAxis("Mouse ScrollWheel") -- see the wheel note in the file header. It
+        // reads 0 in this embedding, every frame, however hard the wheel is rolled.
+        scroll = ReadWheelNotches();
         return true;
 #elif ENABLE_INPUT_SYSTEM
         var mouse = Mouse.current;
@@ -96,9 +187,7 @@ public class WmvOrbitCamera : MonoBehaviour
         position = new Vector3(p.x, p.y, 0f);
         leftHeld = mouse.leftButton.isPressed;
         rightHeld = mouse.rightButton.isPressed;
-        // The legacy axis is normalised to roughly +/-0.1 per notch; the Input System reports
-        // raw scroll units (120 per notch on Windows). Scale so both feel the same.
-        scroll = mouse.scroll.ReadValue().y / 1200f;
+        scroll = ReadWheelNotches();
         return true;
 #else
         if (!warnedNoInput)
@@ -112,6 +201,53 @@ public class WmvOrbitCamera : MonoBehaviour
 #endif
     }
 
+    /// <summary>
+    /// This frame's wheel movement, in NOTCHES -- one detent of a normal mouse wheel is 1.
+    ///
+    /// Read from the Input System wherever it is compiled in, because that is the only backend
+    /// that receives a wheel event in this embedding (the file header has the measurement). The
+    /// legacy axis is the fallback for a build without the Input System package, where it is the
+    /// only thing there is; it reports 0.1 per notch, so it is scaled to notches to match.
+    ///
+    /// The Input System reports 1.0 per notch here and 120 per notch in some other Unity/platform
+    /// combinations. Rather than pick one and be wrong on the other machine, anything large is
+    /// treated as raw units and divided down -- no real mouse produces ten detents in one frame.
+    /// </summary>
+    float ReadWheelNotches()
+    {
+#if ENABLE_INPUT_SYSTEM
+        var m = Mouse.current;
+        if (m != null)
+        {
+            float y = m.scroll.ReadValue().y;
+            if (Mathf.Abs(y) >= 10f)
+                y /= 120f;
+            return y;
+        }
+#endif
+#if ENABLE_LEGACY_INPUT_MANAGER
+        // 0.1 per notch, from the project's own axis settings (sensitivity 0.1).
+        return Input.GetAxis("Mouse ScrollWheel") * 10f;
+#else
+        return 0f;
+#endif
+    }
+
+    /// <summary>
+    /// Is the pointer actually over the viewport?
+    ///
+    /// The wheel is read from a device, not from a window message, so it keeps arriving while the
+    /// pointer is over WMV's other panels. Zooming the model because the user scrolled a list
+    /// next to it would be wrong, so the notch is only taken when the pointer is inside the
+    /// player's own client area -- which is what "scrolling over the viewport controls zoom"
+    /// means. Orbit and pan need no such test: they already require a button to be held.
+    /// </summary>
+    static bool PointerOverViewport(Vector3 position)
+    {
+        return position.x >= 0f && position.x <= Screen.width &&
+               position.y >= 0f && position.y <= Screen.height;
+    }
+
     void Update()
     {
         Vector3 mouse;
@@ -120,13 +256,30 @@ public class WmvOrbitCamera : MonoBehaviour
         if (!ReadMouse(out mouse, out leftHeld, out rightHeld, out scroll))
             return;
 
+        bool changed = false;
+
+        // ---- ZOOM, BEFORE THE DRAG GATE ------------------------------------------------
+        // A notch needs no previous cursor position, so it must not be thrown away with the
+        // first frame's meaningless delta -- nor on any later frame where the OS happens to put
+        // the cursor at exactly (0,0), which the `lastMouse != Vector3.zero` test below reads as
+        // "no previous sample" all over again.
+        if (Mathf.Abs(scroll) > 0.0001f && PointerOverViewport(mouse))
+            ZoomByNotches(scroll);
+
+        // Ease toward the target every frame. Runs whether or not the wheel moved, so a notch
+        // keeps gliding after the user stops rolling.
+        if (AdvanceZoom(Time.unscaledDeltaTime))
+            changed = true;
+
         var delta = mouse - lastMouse;
         bool hadMouse = lastMouse != Vector3.zero;
         lastMouse = mouse;
         if (!hadMouse)
-            return;    // first frame: no meaningful delta yet
+        {
+            if (changed) Apply();
+            return;    // first frame: no meaningful DRAG delta yet
+        }
 
-        bool changed = false;
         if (leftHeld)
         {
             yaw += delta.x * OrbitSpeed;
@@ -140,19 +293,58 @@ public class WmvOrbitCamera : MonoBehaviour
             changed = true;
         }
 
-        if (Mathf.Abs(scroll) > 0.0001f)
-        {
-            distance = Mathf.Clamp(distance * (1f - scroll * ZoomSpeed * 10f), MinDistance, MaxDistance);
-            changed = true;
-        }
-
         if (changed) Apply();
     }
 
+    /// <summary>
+    /// Move the zoom TARGET by a number of wheel notches. Positive is towards the model.
+    ///
+    /// Public because the runtime self-test drives it directly: the wheel itself cannot be
+    /// synthesised from a test, and a test that re-implemented this arithmetic would be checking
+    /// its own copy rather than the code the wheel runs.
+    /// </summary>
+    public void ZoomByNotches(float notches)
+    {
+        targetDistance = Mathf.Clamp(targetDistance * Mathf.Pow(ZoomPerNotch, notches),
+                                     minDistance, maxDistance);
+    }
+
+    /// <summary>
+    /// Ease the live distance toward the target by one frame of dt. Returns true when it moved.
+    ///
+    /// 1 - exp(-k*dt) rather than a fixed Lerp factor: the fixed form converges at a rate that
+    /// depends on the frame rate, so the same wheel gesture would glide differently on a fast
+    /// machine and a slow one.
+    /// </summary>
+    public bool AdvanceZoom(float dt)
+    {
+        if (Mathf.Approximately(distance, targetDistance))
+            return false;
+        if (dt <= 0f)
+            return false;
+        float k = 1f - Mathf.Exp(-ZoomSmoothing * dt);
+        distance = Mathf.Lerp(distance, targetDistance, k);
+        // Land exactly rather than creeping asymptotically for the rest of the session.
+        if (Mathf.Abs(distance - targetDistance) <= targetDistance * 1e-4f)
+            distance = targetDistance;
+        return true;
+    }
+
+    /// <summary>The zoom range this model was given, for the self-test and the log.</summary>
+    public float MinDistance { get { return minDistance; } }
+    public float MaxDistance { get { return maxDistance; } }
+    public float FramedDistance { get { return framedDistance; } }
+    public float TargetDistance { get { return targetDistance; } }
+
     void Apply()
     {
+        // The pivot and the angles are untouched by zoom: only the radius along the same look
+        // direction changes, so the camera cannot flip and the orbit target stays put. distance
+        // is clamped above AbsoluteMinDistance, so it can approach the focus point but never
+        // reach or pass through it.
         var rot = Quaternion.Euler(pitch, yaw, 0f);
         transform.position = pivot - rot * Vector3.forward * distance;
         transform.rotation = rot;
+        UpdateClipPlanes(GetComponent<Camera>());
     }
 }


### PR DESCRIPTION
The controller already had a wheel branch, and it had never once run. The player is a child window of a wxWidgets host, and in that arrangement the legacy Input Manager -- the backend this project builds with, since Active Input Handling is "Both" and the legacy branch wins -- never sees a notch: it takes the wheel from WM_MOUSEWHEEL, which Windows delivers to the focused window of the focused application, and an embedded child of another process's frame is not that.

Measured rather than reasoned about. Rolling a real wheel over the viewport with both backends logged side by side, twelve notches gave twelve readings of

    legacy Input.GetAxis("Mouse ScrollWheel") = 0.00000
    Input System Mouse.current.scroll.y       = 1.00

with and without a prior click in the pane. Neither the host nor a WM_MOUSEWHEEL posted straight to the player's render window produced anything either. Mouse POSITION and BUTTONS do arrive on the legacy backend -- position is polled from the OS cursor, buttons were observed held -- so only the wheel has to come from the Input System's raw-input path. After the change the same experiment gives 12 of 12 notches and the distance falls 4.000 -> 0.370, which is 4 x 0.82^12 to three decimals.

One notch reads 1.0 there, not 120. The old Input System branch divided by 1200 on the assumption that Windows reports 120 units per notch, so even on the backend that receives the wheel it would have zoomed 120x too slowly. Both shapes are handled now instead of assumed.

WHAT THE ZOOM DOES

  * Multiplies the orbit radius by 0.82 per notch, which is exactly what the legacy OpenGL viewport uses (modelcanvas.cpp:474), so the two viewports feel the same. Multiplying is what makes a notch mean the same PROPORTION of the current distance at every scale. Raising it to a power of the notch count also makes it exactly symmetric -- one notch in and one out returns to the start, which distance*(1-k) then distance*(1+k) does not; the old expression lost k^2 every round trip and could go NEGATIVE on a fast scroll, taking the camera through the pivot and inverting the view.
  * Eases the live distance toward the target as 1 - exp(-k*dt), so the same gesture lands identically at 30 fps and at 240 fps (measured: 0.00 % apart). The wheel writes only the target; the eye gets there in ~190 ms.
  * Takes its range FROM THE MODEL: 2 % to 20x the distance the model was framed at, which is itself proportional to the bounding radius. A fixed range cannot serve this client -- the legacy's hardcoded 0.5-unit floor (OrbitCamera.cpp:12) is further away than a 0.3-unit item component is wide, so such a model can never be zoomed into at all. Measured ranges: item component 0.0075..7.5, creature 0.06..60, large 0.6..600, very large 12.5..12500.
  * Leaves the field of view, the angle and the orbit target alone: only the radius along the same look direction moves. The minimum is strictly positive, so the camera approaches the focus point but never reaches or crosses it.

Three further defects in the old path, all fixed: the notch was applied AFTER an early return that exists to skip the first frame's meaningless drag delta, so the first scroll was swallowed -- and so was every scroll on any frame where the OS reported the cursor at exactly (0,0); the near and far planes were derived once from the framing distance and never updated, so zooming in past a fiftieth of it put the near plane in front of the model and sliced it away; and nothing checked that the pointer was over the viewport, which now matters because the wheel comes from a device rather than a window message and keeps arriving while the pointer is over WMV's other panels.

The zoom is reachable as ZoomByNotches / AdvanceZoom so the runtime self-test drives the same code the wheel drives rather than a copy. 71 new assertions over four model scales -- item component, creature, large, very large -- covering symmetry, the derived limits, the clamps, angle and target preservation, that the camera never flips or reaches the pivot, framerate independence, that a model switch re-derives the range and lands settled with the wheel still working, and that orbiting and panning afterwards leave the distance alone. 213 lifecycle assertions pass, 0 failed; 353 parser cases still pass; 4-way type-check clean, including the "Both" configuration, which caught that the Input System using-directive had been guarded out of exactly the case this build compiles.