### PR TITLE
Layered M2 material parity: combiners, billboards, particles, draw order, authored-domain blending

### DIFF
--- a/Tools/UnityRendererProject/Assets/Resources/WmvFrameDecode.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvFrameDecode.shader
@@ -1,0 +1,72 @@
+// WmvFrameDecode.shader
+//
+// One full-screen pass that turns the whole frame from the AUTHORED domain into linear light,
+// once, after every model and emitter has been composited and before post-processing.
+//
+// WHY THE FRAME AND NOT THE FRAGMENT
+//   The M2 shaders work in the authored (display) domain -- textures are uploaded undecoded and the
+//   maths is the client's -- and the swapchain expects linear. Converting at the END OF EACH
+//   FRAGMENT was exact for a lone fragment and wrong for every stack: the hardware blend then
+//   executed on linear numbers, while Wowhead's viewer, the legacy OpenGL viewport and the game
+//   all blend the authored values themselves. Two additive layers authored at 0.5 reach 255 in
+//   all three references and 175 when summed in linear; a lone additive particle fading at
+//   alpha a displays a in the references and OETF(a) here (0.735 for 0.5).
+//
+//   So the fragments now write authored values, the blend runs on them, and THIS pass decodes the
+//   finished composite exactly once. A lone fragment lands at exactly the same byte as before --
+//   the same EOTF, applied to the same value, just later -- and a stack lands where the references
+//   put it.
+//
+// THE CURVE
+//   The exact sRGB EOTF, not the pow(2.2) approximation: it has to invert the swapchain's encode
+//   exactly or every mid-tone shifts. Values above 1 are deliberately left unclamped so an authored
+//   glow can still blow out and can still feed bloom, which runs after this pass and therefore sees
+//   what it saw before for unblended pixels.
+//
+// Drawn by WmvFrameDecodePass through RenderGraph's material blit; the vertex stage is URP's own
+// full-screen triangle and the source is bound as _BlitTexture.
+
+Shader "Wmv/FrameDecode"
+{
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline" }
+        ZWrite Off
+        ZTest Always
+        Cull Off
+        Blend Off
+
+        Pass
+        {
+            Name "WmvFrameDecode"
+
+            HLSLPROGRAM
+            #pragma vertex Vert
+            #pragma fragment Frag
+            #pragma target 3.0
+
+            // The pipeline's Core.hlsl first, as URP's own CoreBlit.shader does: it brings in the
+            // platform API header and the TEXTURE2D_X macros that Blit.hlsl is written against.
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/Runtime/Utilities/Blit.hlsl"
+
+            float3 WmvAuthoredToLinear(float3 c)
+            {
+                float3 lo = c * (1.0 / 12.92);
+                float3 hi = pow(max((c + 0.055) * (1.0 / 1.055), 0.0), 2.4);
+                return lerp(lo, hi, step(0.04045, c));
+            }
+
+            float4 Frag(Varyings input) : SV_Target
+            {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+                float4 c = SAMPLE_TEXTURE2D_X(_BlitTexture, sampler_PointClamp, input.texcoord);
+                c.rgb = WmvAuthoredToLinear(c.rgb);
+                return c;
+            }
+            ENDHLSL
+        }
+    }
+
+    Fallback Off
+}

--- a/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvOpaque.shader
@@ -243,6 +243,11 @@ Shader "WMV/Opaque Textured"
             // 0 = the old behaviour, kept only so the two can be rendered from one build. See the
             // block above frag() and WmvMain.ConfigureDisplayTransform.
             float _WmvAuthoredDomain;
+            // 1 = convert to linear at the end of this fragment (the behaviour before the frame
+            // decode existed; WMV_DISPLAY=fragment). 0 = write the authored value and let
+            // WmvFrameDecodePass convert the finished frame once, so blending happens in the
+            // authored domain like the references. Set by ConfigureDisplayTransform.
+            float _WmvShaderEncode;
             float _Unit2UV, _ThirdUnitLobe, _ThirdUnitWeight, _SecondUnitLobe, _SecondUnitWeight;
             float _FirstUnitLobe, _FirstUnitWeight;
             float4 _UvXf0, _UvOff0, _UvXf1, _UvOff1, _UvXf2, _UvOff2;
@@ -480,6 +485,15 @@ Shader "WMV/Opaque Textured"
             // domains. An authored emissive of 0.8 over a base lit at 0.55 reaches 253/255 added
             // in the authored domain and 212/255 added in linear -- and 173/255 once the Neutral
             // tone curve has had it as well. "The glow does not read like the game" IS that gap.
+            //
+            // WHERE THE CONVERSION NOW HAPPENS. Converting at the end of each fragment closed the
+            // gap inside a fragment and left it open between fragments: the hardware blend then
+            // ran on linear numbers, while Wowhead's viewer, the legacy OpenGL viewport and the
+            // game all blend the authored values themselves. Two additive layers authored at 0.5
+            // reach 255 in the references and 175 summed in linear. So the shipped path writes
+            // the authored value from this fragment and WmvFrameDecodePass converts the finished
+            // frame once, before post-processing; this function is kept for WMV_DISPLAY=fragment,
+            // the per-fragment behaviour, so the two can be differenced from one build.
             //
             // The exact curve, not the pow(2.2) approximation: it has to invert the swapchain's
             // encode exactly, or every mid-tone shifts. Values above 1 are deliberately left
@@ -892,8 +906,10 @@ Shader "WMV/Opaque Textured"
                 // an OpenGL reference render to measure the top end against.
                 c.a = (_OpaqueAlpha > 0.5) ? 1.0 : a;
 
-                // Authored domain -> linear, once, last. See the block above frag().
-                if (_WmvAuthoredDomain > 0.5)
+                // Authored domain -> linear here ONLY when the frame is not decoded as a whole
+                // (WMV_DISPLAY=fragment). See the block above frag(), and WmvFrameDecodePass for
+                // why the frame-level decode is the shipped one.
+                if (_WmvShaderEncode > 0.5)
                     c.rgb = WmvAuthoredToLinear(c.rgb);
                 return c;
             }

--- a/Tools/UnityRendererProject/Assets/Resources/WmvParticle.shader
+++ b/Tools/UnityRendererProject/Assets/Resources/WmvParticle.shader
@@ -15,11 +15,14 @@
 //   The project renders in LINEAR space, so the framebuffer holds linear light and the swapchain
 //   applies the sRGB curve on write. Model textures are uploaded UNDECODED (WmvModelBuilder.
 //   CreateTexture passes linear:true, which in Unity's vocabulary means "hand the shader the
-//   stored value"), so the whole shader runs in the AUTHORED domain and converts once, at the
-//   end, with the exact sRGB EOTF. Doing the multiply in the authored domain matters here more
-//   than anywhere: 56 % of the client's particle emitters are additive, and an additive term is
-//   not scale-invariant between the two domains -- the same authored value lands at a different
-//   framebuffer level depending on which space the sum is taken in.
+//   stored value"), so the whole shader runs in the AUTHORED domain. The conversion to linear
+//   happens ONCE PER FRAME, in WmvFrameDecodePass, after every particle has been blended -- not
+//   at the end of this fragment. That is the whole point for particles: 56 % of the client's
+//   emitters are additive, an additive sum is not scale-invariant between the two domains, and
+//   the references (Wowhead's viewer, the legacy viewport, the game) take the sum in the
+//   authored domain. Summed in linear, two authored-0.5 layers reach 175 instead of 255, and a
+//   lone particle fading at alpha a displays OETF(a) instead of a. The per-fragment conversion
+//   below is kept for WMV_DISPLAY=fragment so the two can be differenced from one build.
 //
 //   Values above 1 are left unclamped so an additive stack can still blow out and still feed
 //   bloom, which is what makes a dense emitter read as bright rather than as flat white.
@@ -43,10 +46,6 @@ Shader "Wmv/Particle"
         [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend ("Dst blend", Float) = 1   // One
         [Toggle] _AlphaTest ("Alpha test", Float) = 0
         _Cutoff ("Alpha cutoff", Range(0,1)) = 0.5
-
-        /// Matches WmvOpaque's switch of the same name, so both passes can be put back into the
-        /// linear-composited behaviour together if the project's colour space ever changes.
-        [Toggle] _WmvAuthoredDomain ("Composite in the authored domain", Float) = 1
     }
 
     SubShader
@@ -88,7 +87,13 @@ Shader "Wmv/Particle"
             float4 _MainTex_ST;
             half _AlphaTest;
             half _Cutoff;
-            half _WmvAuthoredDomain;
+            // A GLOBAL, deliberately not a material property: ConfigureDisplayTransform sets it
+            // with Shader.SetGlobalFloat, and a property of the same name on the material would
+            // shadow the global and pin every particle to whatever the property defaulted to --
+            // which is exactly what the previous _WmvAuthoredDomain property did. Same meaning as
+            // WmvOpaque's: 1 = convert to linear at the end of this fragment, 0 = write the
+            // authored value and let WmvFrameDecodePass convert the finished frame once.
+            float _WmvShaderEncode;
 
             v2f vert (appdata v)
             {
@@ -121,7 +126,7 @@ Shader "Wmv/Particle"
                 if (_AlphaTest > 0.5 && c.a < _Cutoff)
                     discard;
 
-                if (_WmvAuthoredDomain > 0.5)
+                if (_WmvShaderEncode > 0.5)
                     c.rgb = WmvAuthoredToLinear(c.rgb);
                 return c;
             }

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
@@ -753,10 +753,32 @@ public class WmvEmitterRuntime : MonoBehaviour
                           float seqMs, float globalMs)
     {
         // ---- emission -----------------------------------------------------------------------
-        // (dt * rate / lifespan) + carry, from particle.cpp:203-224. Dividing by the lifespan is
-        // what makes "rate" the number ALIVE at once rather than the number spawned per second:
-        // at equilibrium, rate/lifespan spawns per second times lifespan seconds of life is rate
-        // particles standing.
+        // (dt * rate) + carry. emissionRate IS particles per second, so the population settles at
+        // rate * lifespan.
+        //
+        // THIS DELIBERATELY DEPARTS FROM THE LEGACY, which divides by the lifespan
+        // (particle.cpp:203-211, `ftospawn = (dt * frate / flife) + rem`) and so settles at rate
+        // particles however long they live. That is a bug in the legacy, and three independent
+        // witnesses say so:
+        //
+        //   THE CLIENT. Instrumenting Wowhead's WebGL viewer -- which loads this very file, with
+        //   batches confirmed identical -- on Algalon the Observer shows its particle draw issue
+        //   1866 indices, i.e. 311 live quads. Algalon authors rate 45 and lifespan 7 s. 45 * 7 is
+        //   315; 45 is not 311. Measured here, the same model plateaus at exactly 315.
+        //
+        //   THIS FILE. CapacityFor (below) sizes the pool as "the largest rate it reaches times
+        //   the longest lifespan it reaches, WHICH IS THE STEADY STATE BY DEFINITION" -- rate *
+        //   life * 1.25 + 4, which is 398 for Algalon and is what the log prints. The allocator
+        //   and the simulator were disagreeing with each other by exactly one lifespan: the pool
+        //   was sized for 315 and never held more than 45.
+        //
+        //   THE RIBBON HALF. Ribbons in this same runtime read edgesPerSecond as a per-second rate
+        //   and size themselves rate * lifetime (BuildRibbon). Particles are the same shape of
+        //   quantity and were the only ones divided.
+        //
+        // What it looked like: Algalon's sparkle cloud was a seventh of its authored density -- a
+        // dozen specks where the game has a few hundred -- and every emitter in the viewer was
+        // thinned by its own lifespan.
         if (dt > 0f)
         {
             float rate = Sample(s.Def.EmissionRate, seqMs, globalMs, 0f);
@@ -764,7 +786,10 @@ public class WmvEmitterRuntime : MonoBehaviour
             bool enabled = !s.Def.EnabledIn.HasData
                            || Sample(s.Def.EnabledIn, seqMs, globalMs, 1f) != 0f;
 
-            float toSpawn = lifespan > 0f ? (dt * rate / lifespan) + s.SpawnRemainder
+            // The lifespan is still what decides whether anything spawns at all: a zero
+            // lifespan means a particle dies the instant it is born, and the legacy spawns none
+            // rather than dividing by zero (particle.cpp:206-211).
+            float toSpawn = lifespan > 0f ? (dt * rate) + s.SpawnRemainder
                                           : s.SpawnRemainder;
             if (toSpawn < 1f)
             {

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
@@ -1345,11 +1345,20 @@ public class WmvEmitterRuntime : MonoBehaviour
     /// <summary>
     /// Throw away every live particle and every ribbon edge, keeping the emitters themselves.
     ///
-    /// Called when the sequence changes and when a pinned simulation restarts. Without it a
-    /// ribbon would draw a straight line from wherever the bone was in the old animation to
-    /// wherever it is in the new one -- a smear across the model that no bone ever traced.
+    /// For a restart of the WHOLE simulation -- a pinned capture, or the lifecycle self-test.
+    /// A change of sequence resets only the ribbons; see Rebind for why the particles survive it.
     /// </summary>
     public void ResetState()
+    {
+        ResetParticles();
+        ResetRibbons();
+    }
+
+    /// <summary>
+    /// Throw away every live particle. Only for a restart of the whole simulation -- NOT for a
+    /// change of animation, which is what ResetRibbons is for.
+    /// </summary>
+    void ResetParticles()
     {
         for (int i = 0; i < particles.Count; i++)
         {
@@ -1359,6 +1368,11 @@ public class WmvEmitterRuntime : MonoBehaviour
             s.Rng = (uint)(0x9E3779B9u * (uint)(i + 1) + 0x85EBCA6Bu);
             s.Mesh.Clear(false);
         }
+    }
+
+    /// <summary>Throw away every ribbon segment. See ResetState for why this half is different.</summary>
+    void ResetRibbons()
+    {
         for (int i = 0; i < ribbons.Count; i++)
         {
             RibbonState s = ribbons[i];
@@ -1399,7 +1413,22 @@ public class WmvEmitterRuntime : MonoBehaviour
             s.EdgeInterval = 1f / (s.Def.EdgesPerSecond > 0f ? s.Def.EdgesPerSecond : 30f);
         }
         SetGlobalSequences(model.GlobalSequences);
-        ResetState();
+        // THE RIBBONS RESTART; THE PARTICLES DO NOT.
+        //
+        // A ribbon is a trail of segments left behind by a bone, so a sequence change has to
+        // clear it or the first frame of the new animation draws a straight edge from wherever
+        // the bone was in the old one -- a smear across the model that no bone ever traced.
+        //
+        // A particle owes nothing to the previous frame's bone. It is a free body with its own
+        // position, velocity and remaining life, and in the game changing animation does not put
+        // a torch out: the legacy viewport holds one std::list<Particle> for the life of the
+        // model (particle.h:74) and WoWModel::animate never touches it (WoWModel.cpp:2210-2224).
+        // Clearing it here was costing the whole cloud on every sequence change, and because the
+        // authored rate IS the number alive at once -- Algalon's emitter is 45 particles over a
+        // 7-second life -- the cloud then needed seven seconds of animation to build back up.
+        // Anyone who changed animation, or looked at a model in the first seconds after it
+        // loaded, saw no particles at all.
+        ResetRibbons();
         return true;
     }
 

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
@@ -157,6 +157,11 @@ public class WmvEmitterRuntime : MonoBehaviour
         public float SpawnRemainder;
         public uint Rng;
 
+        /// <summary>Which quads each particle is drawn as. An emitter that names neither style
+        /// gets a head, which is what every particle was before the styles were read.</summary>
+        public bool DrawHead, DrawTail;
+        public int QuadsPerParticle;
+
         public Vector3[] Verts;
         public Vector2[] Uvs;
         public Color32[] Colors;
@@ -389,6 +394,9 @@ public class WmvEmitterRuntime : MonoBehaviour
         s.BoneLocal = def.DoNotTrail || def.Pinned;
         s.TileCount = Mathf.Max(1, def.Rows * def.Cols);
         s.Capacity = CapacityFor(def);
+        s.DrawTail = def.TailStyle;
+        s.DrawHead = def.HeadStyle || !def.TailStyle;
+        s.QuadsPerParticle = (s.DrawHead ? 1 : 0) + (s.DrawTail ? 1 : 0);
         s.Rng = (uint)(0x9E3779B9u * (uint)(index + 1) + 0x85EBCA6Bu);
 
         s.Pos = new Vector3[s.Capacity];
@@ -402,13 +410,14 @@ public class WmvEmitterRuntime : MonoBehaviour
             s.QuadUp = new Vector3[s.Capacity];
         }
 
-        s.Verts = new Vector3[s.Capacity * 4];
-        s.Uvs = new Vector2[s.Capacity * 4];
-        s.Colors = new Color32[s.Capacity * 4];
-        s.Indices = BuildQuadIndices(s.Capacity);
+        int quads = s.Capacity * s.QuadsPerParticle;
+        s.Verts = new Vector3[quads * 4];
+        s.Uvs = new Vector2[quads * 4];
+        s.Colors = new Color32[quads * 4];
+        s.Indices = BuildQuadIndices(quads);
 
         s.Go = NewChild(objectName + "_particles" + index);
-        s.Mesh = NewMesh(objectName + "_particleMesh" + index, s.Capacity * 4);
+        s.Mesh = NewMesh(objectName + "_particleMesh" + index, quads * 4);
         s.Material = NewMaterial(shader, tex, def.BlendMode, objectName + "_particleMat" + index);
         s.Renderer = Attach(s.Go, s.Mesh, s.Material);
         ResolveRamp(s);
@@ -973,9 +982,17 @@ public class WmvEmitterRuntime : MonoBehaviour
         return new WowVec2(Mathf.Lerp(keys[a].X, keys[b].X, r), Mathf.Lerp(keys[a].Y, keys[b].Y, r));
     }
 
+    /// <summary>
+    /// The squared length, in model units, below which a tail's screen-plane projection counts as
+    /// nothing and the particle is drawn as a 5 % speck instead. The client's builder tests
+    /// dot(a, a) > 1e-4 in its own view space; Wowhead's viewer runs that space at 3x model
+    /// units, so the same rule in model units is 1e-4 / 9.
+    /// </summary>
+    const float TailDegenerateSq = 1.1e-5f;
+
     void BuildParticleMesh(ParticleState s, Matrix4x4 boneMatrix, Vector3 camRight, Vector3 camUp)
     {
-        int v = 0;
+        int v = 0, quads = 0;
         Vector3 min = Vector3.positiveInfinity, max = Vector3.negativeInfinity;
         bool billboard = !s.Def.DoNotBillboard;
         float spin = s.Def.SpriteRotation;
@@ -985,6 +1002,7 @@ public class WmvEmitterRuntime : MonoBehaviour
             spinCos = Mathf.Cos(spin);
             spinSin = Mathf.Sin(spin);
         }
+        float slowdown = s.Def.Slowdown;
 
         for (int i = 0; i < s.Count; i++)
         {
@@ -1040,21 +1058,89 @@ public class WmvEmitterRuntime : MonoBehaviour
             // mesh UVs take (WowCoordinateConverter.ConvertTexCoord).
             float v1 = 1f - row / (float)s.Def.Rows, v0 = 1f - (row + 1) / (float)s.Def.Rows;
 
-            Vector3 p0 = centre - right - up;
-            Vector3 p1 = centre + right - up;
-            Vector3 p2 = centre + right + up;
-            Vector3 p3 = centre - right + up;
+            if (s.DrawHead)
+            {
+                Vector3 p0 = centre - right - up;
+                Vector3 p1 = centre + right - up;
+                Vector3 p2 = centre + right + up;
+                Vector3 p3 = centre - right + up;
 
-            s.Verts[v] = p0; s.Uvs[v] = new Vector2(u0, v0); s.Colors[v++] = c32;
-            s.Verts[v] = p1; s.Uvs[v] = new Vector2(u1, v0); s.Colors[v++] = c32;
-            s.Verts[v] = p2; s.Uvs[v] = new Vector2(u1, v1); s.Colors[v++] = c32;
-            s.Verts[v] = p3; s.Uvs[v] = new Vector2(u0, v1); s.Colors[v++] = c32;
+                s.Verts[v] = p0; s.Uvs[v] = new Vector2(u0, v0); s.Colors[v++] = c32;
+                s.Verts[v] = p1; s.Uvs[v] = new Vector2(u1, v0); s.Colors[v++] = c32;
+                s.Verts[v] = p2; s.Uvs[v] = new Vector2(u1, v1); s.Colors[v++] = c32;
+                s.Verts[v] = p3; s.Uvs[v] = new Vector2(u0, v1); s.Colors[v++] = c32;
+                quads++;
 
-            Grow(ref min, ref max, p0);
-            Grow(ref min, ref max, p2);
+                Grow(ref min, ref max, p0);
+                Grow(ref min, ref max, p2);
+            }
+
+            if (s.DrawTail)
+            {
+                // A TAIL PARTICLE IS A STREAK, NOT A SPRITE. The quad runs from the particle back
+                // along the path it just travelled: -velocity * TailLength long, and as wide as
+                // the size ramp says, turned to lie in the screen plane. Its length is therefore
+                // its speed, so a fresh spark is a streak and a spark that drag has stopped is
+                // nothing -- which is how the game empties Algalon's cloud of the two thirds of
+                // it that has stalled, and why a viewer drawing every one of them as a head
+                // shows a couple of hundred bright motes hanging in the air.
+                //
+                // This is the client's rule as Wowhead's viewer implements it, read out of the
+                // live page: tail = -v * tailLength (min(age, tailLength) under 0x400); if the
+                // projection of that onto the screen plane has any length, the long half-axis is
+                // half the tail and the centre moves half a tail back so the quad starts AT the
+                // particle; the short half-axis is the size, perpendicular to the projection.
+                // Otherwise the particle is a speck of 5 % of its size. Measured on Algalon that
+                // is 0.082 units wide at birth and 0.0048 once stalled, and the switch lands at
+                // 2.5 s, exactly where drag takes the projection under the threshold.
+                //
+                // The stored velocity is the launch velocity; the integrator damps the
+                // displacement rather than the velocity (see AdvanceParticles), so the speed the
+                // particle actually has now is Vel * exp(-slowdown * life).
+                Vector3 vel = s.Vel[i] * (slowdown > 0f ? Mathf.Exp(-slowdown * s.Life[i]) : 1f);
+                if (s.BoneLocal)
+                    vel = boneMatrix.MultiplyVector(vel);
+                float tailLen = s.Def.TailLength;
+                if (s.Def.ClampTailToAge)
+                    tailLen = Mathf.Min(s.Life[i], tailLen);
+                Vector3 tail = vel * -tailLen;
+
+                float ax = Vector3.Dot(tail, camRight), ay = Vector3.Dot(tail, camUp);
+                float a2 = ax * ax + ay * ay;
+                Vector3 tRight, tUp, tCentre;
+                if (a2 > TailDegenerateSq)
+                {
+                    float inv = 1f / Mathf.Sqrt(a2);
+                    float ux = ax * inv, uy = ay * inv;
+                    tRight = tail * 0.5f;
+                    tUp = camRight * (-uy * halfY) + camUp * (ux * halfX);
+                    tCentre = centre + tail * 0.5f;
+                }
+                else
+                {
+                    tRight = camRight * (0.05f * halfX);
+                    tUp = camUp * (0.05f * halfY);
+                    tCentre = centre;
+                }
+
+                // U runs along the streak and V across it, the client's corner order.
+                Vector3 q0 = tCentre - tRight - tUp;
+                Vector3 q1 = tCentre + tRight - tUp;
+                Vector3 q2 = tCentre + tRight + tUp;
+                Vector3 q3 = tCentre - tRight + tUp;
+
+                s.Verts[v] = q0; s.Uvs[v] = new Vector2(u0, v0); s.Colors[v++] = c32;
+                s.Verts[v] = q1; s.Uvs[v] = new Vector2(u1, v0); s.Colors[v++] = c32;
+                s.Verts[v] = q2; s.Uvs[v] = new Vector2(u1, v1); s.Colors[v++] = c32;
+                s.Verts[v] = q3; s.Uvs[v] = new Vector2(u0, v1); s.Colors[v++] = c32;
+                quads++;
+
+                Grow(ref min, ref max, q0);
+                Grow(ref min, ref max, q2);
+            }
         }
 
-        Upload(s.Mesh, s.Verts, s.Uvs, s.Colors, s.Indices, v, s.Count * 6, min, max);
+        Upload(s.Mesh, s.Verts, s.Uvs, s.Colors, s.Indices, v, quads * 6, min, max);
     }
 
     // =========================================================================================

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvEmitterRuntime.cs
@@ -575,6 +575,21 @@ public class WmvEmitterRuntime : MonoBehaviour
         m.SetFloat("_SrcBlend", (float)src);
         m.SetFloat("_DstBlend", (float)dst);
         m.SetFloat("_AlphaTest", alphaTest ? 1f : 0f);
+
+        // PARTICLES DRAW AFTER THE MODEL. The shader's own queue is Transparent (3000), which is
+        // the very first slot of the band the model's transparent batches are ranked into
+        // (Transparent + rank, WmvModelBuilder), so an emitter's quads went down BEFORE the
+        // alpha-blended geometry they float in front of and every sparkle inside the silhouette
+        // was dimmed by the body's alpha and pulled toward its colour. Both references draw the
+        // particle systems -- and the ribbons, which share this material path -- after the whole
+        // model. The legacy says why in so many words: "render our particles, we do this
+        // afterwards so that all the particles display OK without having things like shields
+        // overwriting the particles" (modelcanvas.cpp:694-702, root->drawParticles() after
+        // root->draw(); WoWModel::drawParticles draws the systems and then the ribbons). Wowhead's
+        // viewer issues its particle draw after the last batch draw of the model -- captured live
+        // on Algalon as the three batch draws and then the particle draw. The band is capped at
+        // Transparent + 899, so + 900 is the first queue no batch can reach.
+        m.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent + 900;
         ownedMaterials.Add(m);
         return m;
     }

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvFrameDecodePass.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvFrameDecodePass.cs
@@ -1,0 +1,128 @@
+// WmvFrameDecodePass.cs
+//
+// Decodes the finished frame from the authored domain into linear light, once, before
+// post-processing -- so that every hardware blend before it has run on AUTHORED values, the way
+// Wowhead's viewer, the legacy OpenGL viewport and the game blend, and so that Bloom and the
+// swapchain still see exactly what they saw before for any pixel that was not blended.
+//
+// WHY A PASS ENQUEUED FROM SCRIPT
+//   The repository versions only Assets/Scripts and Assets/Resources of the Unity project; the
+//   renderer asset is not in it, so a renderer feature registered on that asset would not be a
+//   change anyone could rebuild from source. URP lets a script enqueue a pass per camera instead
+//   (RenderPipelineManager.beginCameraRendering -> ScriptableRenderer.EnqueuePass), and in
+//   RenderGraph mode such a pass runs through RecordRenderGraph like any other. That keeps the
+//   whole change in the repository.
+//
+// WHAT IT DOES, PRECISELY
+//   At BeforeRenderingPostProcessing -- after the opaque, transparent and emitter passes, before
+//   UberPost (Bloom) -- copy the camera colour to a temporary of the same description and draw it
+//   back through Wmv/FrameDecode, which applies the exact sRGB EOTF to rgb and leaves alpha and
+//   values above 1 alone. It is the URP FullScreenPassRendererFeature's own RenderGraph shape,
+//   with the material fixed. requiresIntermediateTexture is set so the camera never renders
+//   straight into a back buffer this pass could not read.
+//
+//   It runs on EVERY camera that renders while the transform is on, including the offscreen
+//   probe cameras (-wmvLightCheck, -wmvQueueProof): their shaders now write authored values too,
+//   and their readbacks are only right if the same decode precedes the final blit into their
+//   sRGB targets.
+//
+// The switch is ConfigureDisplayTransform's: 'full' installs this pass and turns the shaders'
+// per-fragment encode off; 'fragment' keeps the old per-fragment encode with no pass, so the two
+// can be captured from one build and differenced.
+
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.RenderGraphModule;
+using UnityEngine.Rendering.RenderGraphModule.Util;
+using UnityEngine.Rendering.Universal;
+
+public sealed class WmvFrameDecodePass : ScriptableRenderPass
+{
+    static WmvFrameDecodePass installed;
+    static Material material;
+
+    /// <summary>Is the frame decode installed on every camera right now?</summary>
+    public static bool Active { get { return installed != null; } }
+
+    /// <summary>
+    /// Install or remove the pass. Idempotent. Returns false when the shader is missing, in which
+    /// case nothing is installed and the caller must not turn the fragment encode off.
+    /// </summary>
+    public static bool SetActive(bool on)
+    {
+        if (on)
+        {
+            if (installed != null)
+                return true;
+            if (material == null)
+            {
+                // The way the other two Resources shaders are found (WmvModelBuilder): the asset
+                // by name first, the shader registry second.
+                Shader s = Resources.Load<Shader>("WmvFrameDecode");
+                if (s == null)
+                    s = Shader.Find("Wmv/FrameDecode");
+                if (s == null)
+                    return false;
+                material = new Material(s);
+                material.hideFlags = HideFlags.HideAndDontSave;
+            }
+            installed = new WmvFrameDecodePass();
+            RenderPipelineManager.beginCameraRendering += OnBeginCamera;
+            return true;
+        }
+        if (installed != null)
+        {
+            RenderPipelineManager.beginCameraRendering -= OnBeginCamera;
+            installed = null;
+        }
+        return true;
+    }
+
+    WmvFrameDecodePass()
+    {
+        renderPassEvent = RenderPassEvent.BeforeRenderingPostProcessing;
+        requiresIntermediateTexture = true;
+        profilingSampler = new ProfilingSampler("WmvFrameDecode");
+    }
+
+    static void OnBeginCamera(ScriptableRenderContext context, Camera camera)
+    {
+        if (installed == null || camera == null)
+            return;
+        // Scene-view, preview and reflection cameras never show this content; the game camera
+        // and the offscreen probes do. A camera rendering into a DEPTH texture -- WmvShadowRig's
+        // shadow map and view-depth cameras -- has no colour to decode, and URP still records the
+        // post-processing event on it, so it is skipped by the pipeline's own test for that case
+        // (UniversalRenderer.IsOffscreenDepthTexture).
+        if (camera.cameraType != CameraType.Game)
+            return;
+        if (camera.targetTexture != null && camera.targetTexture.format == RenderTextureFormat.Depth)
+            return;
+        UniversalAdditionalCameraData data = camera.GetUniversalAdditionalCameraData();
+        if (data == null || data.scriptableRenderer == null)
+            return;
+        data.scriptableRenderer.EnqueuePass(installed);
+    }
+
+    public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+    {
+        if (material == null)
+            return;
+        UniversalResourceData resources = frameData.Get<UniversalResourceData>();
+        TextureHandle target = resources.activeColorTexture;
+        if (!target.IsValid())
+            return;
+
+        // The decode reads the whole frame and writes the whole frame, so it goes through a copy:
+        // a pass cannot sample the attachment it is rendering into.
+        TextureDesc desc = renderGraph.GetTextureDesc(target);
+        desc.name = "_WmvFrameDecodeSource";
+        desc.clearBuffer = false;
+        TextureHandle copy = renderGraph.CreateTexture(desc);
+
+        renderGraph.AddBlitPass(target, copy, Vector2.one, Vector2.zero,
+                                passName: "WmvFrameDecode: copy");
+        renderGraph.AddBlitPass(new RenderGraphUtils.BlitMaterialParameters(copy, target, material, 0),
+                                passName: "WmvFrameDecode: authored -> linear");
+    }
+}

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvLifecycleSelfTest.cs
@@ -185,9 +185,20 @@ public static class WmvLifecycleSelfTest
         Check(applied, "emitter: ApplySequence reports something to animate", log);
         Check(rt.Emitters.ParticleEmitterCount == 1 && rt.Emitters.RibbonEmitterCount == 1,
               "emitter: the sequence change did NOT duplicate the emitters", log);
-        Check(rt.Emitters.LiveParticleCount == 0 && rt.Emitters.RibbonSegmentCount == 0,
-              "emitter: the sequence change cleared the previous animation's particles and "
-              + "ribbon history (no smear from where the bone used to be)", log);
+        // THE TWO HALVES OF A SEQUENCE CHANGE PART COMPANY HERE, and the reason is in
+        // WmvEmitterRuntime.Rebind. A ribbon is a trail of segments left behind by a bone, so its
+        // history has to go or the first frame of the new animation draws an edge from wherever
+        // the bone stood in the old one -- a smear across the model that no bone ever traced. A
+        // particle owes the previous frame's bone nothing: it is a free body with its own
+        // position, velocity and remaining life, and in the game changing animation does not put
+        // a torch out. The legacy viewport holds one std::list<Particle> for the life of the model
+        // (particle.h:74) and WoWModel::animate never touches it (WoWModel.cpp:2210-2224).
+        Check(rt.Emitters.LiveParticleCount == live,
+              "emitter: the sequence change KEPT the live particles (" + live + " before, "
+              + rt.Emitters.LiveParticleCount + " after)", log);
+        Check(rt.Emitters.RibbonSegmentCount == 0,
+              "emitter: the sequence change cleared the ribbon history (no smear from where the "
+              + "bone used to be)", log);
 
         for (int i = 0; i < 120; i++)
             rt.Emitters.Advance(1f / 60f, i * 16f, i * 16f);

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvM2Animator.cs
@@ -99,6 +99,17 @@ public class WmvM2Animator : MonoBehaviour
     /// </summary>
     readonly Dictionary<int, AnimatedBone[]> convertedBySequence = new Dictionary<int, AnimatedBone[]>();
     Transform[] cachedFor;              // the skeleton the cache above belongs to
+
+    /// <summary>
+    /// The bones the file marks as billboarded, shallowest first.
+    ///
+    /// A billboard bone is not an ANIMATED bone -- most carry no track at all -- so it cannot ride
+    /// in `bones`, which Setup narrows to the bones the playing sequence actually moves. The flag
+    /// belongs to the bone rather than to the animation, so this list is rebuilt with the skeleton
+    /// and then left alone across sequence changes.
+    /// </summary>
+    Transform[] billboardBones = new Transform[0];
+    Camera billboardCamera;
     readonly Dictionary<int, int> globalCountBySequence = new Dictionary<int, int>();
     uint[] globalSequences = new uint[0];
     float lengthMs = 1f;
@@ -217,6 +228,7 @@ public class WmvM2Animator : MonoBehaviour
         {
             convertedBySequence.Clear();
             cachedFor = boneTransforms;
+            billboardBones = CollectBillboards(model, boneTransforms, log);
         }
 
         AnimatedBone[] already;
@@ -458,6 +470,94 @@ public class WmvM2Animator : MonoBehaviour
             if (b.Scale.HasData)
                 b.Transform.localScale = EvalVector(b.Scale, TrackTime(b.Scale.GlobalSequence, t));
         }
+
+        // LAST, so it is the animated pose that gets turned. A billboard bone may also be an
+        // animated one, and the flag overrides the track's rotation rather than composing with it.
+        ApplyBillboards();
+    }
+
+    /// <summary>
+    /// The bones carrying bone flag 0x08, ordered parents before children.
+    ///
+    /// The order matters because the billboard is written as a WORLD rotation: turning a parent
+    /// afterwards would carry its child round with it and undo the child's own facing. Depth
+    /// ordering costs one pass over the bone array and removes the question entirely.
+    ///
+    /// ONLY 0x08 -- the spherical billboard -- is collected. The cylindrical bits (0x10/0x20/0x40,
+    /// one per locked axis) are a different construction, and the legacy viewport implements
+    /// neither: Bone::calcMatrix tests MODELBONE_BILLBOARD (= 8) alone and carries the cylindrical
+    /// case only as a commented-out line (Bone.cpp:39-53). Guessing at them here would put
+    /// untested geometry on screen, so they keep the behaviour they have always had.
+    /// </summary>
+    static Transform[] CollectBillboards(M2ParsedModel model, Transform[] boneTransforms,
+                                         Action<string> log)
+    {
+        int n = Math.Min(model.Bones.Length, boneTransforms.Length);
+        var found = new List<int>();
+        for (int i = 0; i < n; i++)
+            if (model.Bones[i].Billboard && boneTransforms[i] != null)
+                found.Add(i);
+        if (found.Count == 0)
+            return new Transform[0];
+
+        var depth = new int[n];
+        for (int i = 0; i < n; i++)
+        {
+            int d = 0;
+            for (short p = model.Bones[i].Parent; p >= 0 && p < n && d <= n; p = model.Bones[p].Parent)
+                d++;
+            depth[i] = d;
+        }
+        found.Sort((a, b) => depth[a].CompareTo(depth[b]));
+
+        var result = new Transform[found.Count];
+        for (int i = 0; i < found.Count; i++)
+            result[i] = boneTransforms[found[i]];
+        if (log != null)
+            log(string.Format("anim: {0} of {1} bone(s) are billboarded (flag 0x08) and are turned "
+                              + "to face the camera every frame", found.Count, n));
+        return result;
+    }
+
+    /// <summary>
+    /// Turn every billboard bone to face the camera.
+    ///
+    /// WHAT THE FLAG IS FOR. A billboard bone carries a flat card -- a glow, a flare, a halo --
+    /// authored in one canonical plane, and the renderer is expected to spin that card to the
+    /// viewer every frame. Algalon the Observer is the plain case: 18 of his constellation joints
+    /// and both of his full-body haloes are single quads on bones flagged 0x08, each authored flat
+    /// in the model's YZ plane with EXACTLY zero thickness along X. Left unturned they are not
+    /// merely mis-angled, they are edge-on or backwards, and a card whose front face has turned
+    /// away is removed by back-face culling before it can be shaded: all twenty drew zero pixels.
+    ///
+    /// THE ROTATION. The card's authored plane maps to the bone's local XY with its front face
+    /// along local +Z, so facing the viewer means pointing local +Z back down the view direction.
+    /// That is Quaternion.LookRotation(-camera.forward, camera.up), and it is a screen-aligned
+    /// billboard -- built from the camera's own axes, not from the direction to the bone -- which
+    /// is what the legacy viewport does when it takes its two axes from the rows of the modelview
+    /// matrix (Bone.cpp:41-53, and particle.cpp:401-408 for the same construction on particles).
+    /// A useful check on the sign: at a camera square on to the model's face this expression is
+    /// the identity, so it reproduces exactly the orientation the artist authored.
+    ///
+    /// Setting the WORLD rotation rather than the local one is deliberate. The legacy writes its
+    /// billboard into the bone's LOCAL matrix and then multiplies by the parent's, so a billboard
+    /// bone hanging off a rotating parent comes out turned by that parent as well -- harmless on a
+    /// rig whose billboards hang off unrotated joints, wrong on one whose do not. Unity's
+    /// Transform.rotation is the world rotation and takes the parent out of it.
+    /// </summary>
+    void ApplyBillboards()
+    {
+        if (billboardBones.Length == 0)
+            return;
+        if (billboardCamera == null)
+            billboardCamera = Camera.main;
+        if (billboardCamera == null)
+            return;
+        Transform cam = billboardCamera.transform;
+        Quaternion facing = Quaternion.LookRotation(-cam.forward, cam.up);
+        for (int i = 0; i < billboardBones.Length; i++)
+            if (billboardBones[i] != null)
+                billboardBones[i].rotation = facing;
     }
 
     /// <summary>Put every animated bone back exactly where the bind pose expects it.</summary>

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvMain.cs
@@ -168,7 +168,7 @@ public class WmvMain : MonoBehaviour
             camGo.tag = "MainCamera";
         }
         cam.clearFlags = CameraClearFlags.SolidColor;
-        cam.backgroundColor = new Color(0.10f, 0.10f, 0.12f);
+        cam.backgroundColor = ViewportClear;    // re-set in the composited domain by ConfigureDisplayTransform
         cam.nearClipPlane = 0.01f;
         orbit = cam.gameObject.GetComponent<WmvOrbitCamera>() ?? cam.gameObject.AddComponent<WmvOrbitCamera>();
 
@@ -767,7 +767,7 @@ public class WmvMain : MonoBehaviour
                 if (same2 != mask[i]) maskDrift++;
             }
 
-            Color bg = src.backgroundColor;
+            Color bg = ViewportClear;   // as displayed; GrabFrame converts for the current domain
             float bgLum = 0.2126f * bg.r + 0.7152f * bg.g + 0.0722f * bg.b;
             // WHICH SKIN WAS MEASURED, spelled out. WMV picks a random skin per load unless
             // Session/RandomLooks is off, and a creature can carry skins that differ in brightness
@@ -872,7 +872,7 @@ public class WmvMain : MonoBehaviour
     /// </summary>
     Color32[] GrabFrame(Camera cam, RenderTexture rt, Color clear, int w, int h)
     {
-        cam.backgroundColor = clear;
+        cam.backgroundColor = ClearColour(clear);
         cam.targetTexture = rt;
         cam.Render();
         cam.targetTexture = null;
@@ -1356,20 +1356,78 @@ public class WmvMain : MonoBehaviour
     /// BLOOM STAYS. Glowing WoW content does bleed light, the effect is authored for, and it now
     /// operates on genuine linear values above 1 rather than on a range that was clamped flat.
     ///
+    /// WHERE THE FRAME IS DECODED. The authored working space needs one conversion to linear
+    /// somewhere before the swapchain. It used to be the last line of each fragment, and that was
+    /// exact for a lone fragment and wrong for every stack: the hardware blend then ran on linear
+    /// numbers while Wowhead's viewer, the legacy OpenGL viewport and the game all blend the
+    /// authored values. Two additive layers authored at 0.5 reach 255 in all three references and
+    /// 175 summed in linear; a lone additive particle fading at alpha a displays a in the
+    /// references and OETF(a) here. So the fragments now write authored values, the blend runs on
+    /// them, and WmvFrameDecodePass converts the finished composite once, before post-processing
+    /// (see that file). A lone fragment lands on exactly the same byte as before.
+    ///
+    /// The camera's clear colour has to be given in the same domain as the fragments: Unity
+    /// treats backgroundColor as sRGB and linearises it on clear, so to leave the AUTHORED value
+    /// in the buffer the colour is passed through its own OETF first (Color.gamma). The frame
+    /// decode then brings it back to the linear value the swapchain expects and the background
+    /// displays as (25,25,30), as it always has.
+    ///
     /// WMV_DISPLAY selects, for A/B only:
-    ///   full     (default) authored working space + no tone curve + no vignette
-    ///   notonemap          tone curve and vignette off, old sampling domain
-    ///   legacy             exactly what the renderer did before this change
+    ///   full      (default) authored working space, decoded once per FRAME, no tone curve,
+    ///                       no vignette
+    ///   fragment            authored working space decoded per FRAGMENT: the behaviour before
+    ///                       the frame decode, so the two can be differenced from one build
+    ///   notonemap           tone curve and vignette off, old sampling domain
+    ///   legacy              exactly what the renderer did before any of this
     /// </summary>
     static void ConfigureDisplayTransform()
     {
         string want = System.Environment.GetEnvironmentVariable("WMV_DISPLAY");
         if (string.IsNullOrEmpty(want)) want = "full";
         bool legacy = (want == "legacy");
-        bool authored = (want == "full");
+        bool authored = (want == "full" || want == "fragment");
+        bool frameDecode = (want == "full");
 
         WmvModelBuilder.AuthoredTextureDomain = authored;
         Shader.SetGlobalFloat("_WmvAuthoredDomain", authored ? 1f : 0f);
+
+        if (frameDecode && !WmvFrameDecodePass.SetActive(true))
+        {
+            // Without the shader nothing would ever decode the frame: fall back to the fragment
+            // encode rather than present authored values as linear.
+            Debug.LogWarning("WMV: display transform 'full' needs Wmv/FrameDecode, which is "
+                             + "missing -- decoding per fragment instead");
+            frameDecode = false;
+        }
+        if (!frameDecode)
+            WmvFrameDecodePass.SetActive(false);
+        Shader.SetGlobalFloat("_WmvShaderEncode", authored && !frameDecode ? 1f : 0f);
+        ClearInAuthoredDomain = frameDecode;
+
+        // THE BUFFER HAS TO HOLD AUTHORED VALUES WITHOUT BANDING. The pipeline asset asks for a
+        // 32-bit HDR buffer, which URP satisfies with B10G11R11: 6-bit mantissas in red and green,
+        // 5 in blue. That was fine for linear light, where the swapchain's encode spreads the
+        // top of the range out, but an authored value is already perceptual and the same format
+        // quantises [0.5, 1) to ~1/128 in red and green and ~1/64 in blue -- two and four 8-bit
+        // steps -- which bands in smooth bright gradients, blue worst. FP16 has a 10-bit mantissa
+        // and does not. The asset is not in the repository, so the request is made here.
+        if (frameDecode)
+        {
+            var rp = UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline
+                     as UnityEngine.Rendering.Universal.UniversalRenderPipelineAsset;
+            if (rp != null)
+            {
+                var had = rp.hdrColorBufferPrecision;
+                rp.hdrColorBufferPrecision =
+                    UnityEngine.Rendering.Universal.HDRColorBufferPrecision._64Bits;
+                Debug.Log(string.Format("WMV: HDR colour buffer precision {0} -> {1} (authored "
+                                        + "values need the mantissa)", had, rp.hdrColorBufferPrecision));
+            }
+        }
+
+        var mainCam = Camera.main;
+        if (mainCam != null)
+            mainCam.backgroundColor = ClearColour(ViewportClear);
 
         int touched = 0;
         var vols = UnityEngine.Object.FindObjectsByType<UnityEngine.Rendering.Volume>(
@@ -1398,10 +1456,26 @@ public class WmvMain : MonoBehaviour
             }
         }
         Debug.Log(string.Format(
-            "WMV: display transform '{0}' -- authored texture domain {1}, shader encode {2}, "
+            "WMV: display transform '{0}' -- authored texture domain {1}, decode {2}, "
             + "{3} volume parameter(s) set across {4} volume(s)",
             want, WmvModelBuilder.AuthoredTextureDomain ? "ON" : "off",
-            authored ? "ON" : "off", touched, vols != null ? vols.Length : 0));
+            frameDecode ? "once per FRAME (blends in the authored domain)"
+                        : (authored ? "per FRAGMENT (blends in linear)" : "none"),
+            touched, vols != null ? vols.Length : 0));
+    }
+
+    /// <summary>The viewport's background, as displayed: (25,25,30).</summary>
+    static readonly Color ViewportClear = new Color(0.10f, 0.10f, 0.12f);
+
+    /// <summary>True while WmvFrameDecodePass is decoding the frame, so a clear colour has to be
+    /// left in the buffer in the authored domain. See ConfigureDisplayTransform.</summary>
+    static bool ClearInAuthoredDomain;
+
+    /// <summary>A camera clear colour in whichever domain the frame is currently composited in.
+    /// Black and white are fixed points of the curve and come back unchanged.</summary>
+    static Color ClearColour(Color displayed)
+    {
+        return ClearInAuthoredDomain ? displayed.gamma : displayed;
     }
 
     void DumpPng(Color32[] px, int w, int h, string name)

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -1983,19 +1983,38 @@ public static class WmvModelBuilder
             // 1.0. A field set deliberately on nine batches out of ten, to values that only make
             // sense as a dimmer, is not dead data.
             //
-            // So the lobe is restored WEIGHTED BY UNIT 1'S OWN TEXTURE WEIGHT, which is what ps20
-            // and ps23 already do here (Lobe2Weighted) and on the same kind of evidence. Measured:
-            // on Algalon, both Celestial Serpents, the Celestial Fox Wyvern and Val'kier -- five
+            // So the lobe is restored WEIGHTED BY UNIT 1'S OWN TEXTURE WEIGHT. Measured: on
+            // Algalon, both Celestial Serpents, the Celestial Fox Wyvern and Val'kier -- five
             // models whose ps10 batches bind NO unit-1 weight, so the weight is 1 -- the weighted
             // and raw forms are identical to the pixel. On the knife the clipped fraction goes
             // 5.75 % raw to 1.90 %, against 0.77 % with no lobe at all, and the blade's engraving
             // stays legible instead of washing out.
             //
+            // THE WEIGHT IS A KNOWING DEVIATION, NOT A DECODE, AND IT IS STILL OPEN. This comment
+            // used to justify it as "what ps20 and ps23 already do here, on the same kind of
+            // evidence"; that is FALSE and is corrected here. ps20/ps23's weight is spelled out in
+            // the reference -- retail's own shader multiplies their lobe by cb0[22] explicitly --
+            // and for ps10 it is not. Every reference that names a weight names it for ps20, ps23
+            // and ps24 and NOT for this combiner. There are now three witnesses against the
+            // weighting and none for it:
+            //
+            //   the legacy GLSL transcription    specular = tex2.rgb   (ModelRenderPass.cpp:117)
+            //   retail's own DXBC                no cb0[22] multiply on the ps10 lobe
+            //   Wowhead's WebGL viewer           _specular = tex1.rgb, captured live from the
+            //                                    running page on this exact FileDataID
+            //
+            // What holds it in place is one model: raw, knife_1h_naxx25_d_01 blows out. Since the
+            // weight resolves to 1 wherever nothing binds it, the two forms differ ONLY on batches
+            // that author a unit-1 weight, so this term is doing nothing at all on Algalon and the
+            // other four models above -- it is hiding a fault that belongs to the knife. Reverting
+            // to Plan(0, 1, 1f, true, false, 4) is the correct end state; it needs the knife's
+            // blowout diagnosed first, and that has not been done.
+            //
             // ps8 IS STILL HELD BACK, and now for a reason that is about coverage rather than
             // correctness: its 1,277 batches include the character EYES geoset (3301), which
             // 52,180 of 120,978 CreatureDisplayInfo rows resolve to, and none of that has been
-            // looked at. The shape is identical -- Plan(0, 4, 1f, true, false, 4, true) -- and the
-            // weight evidence above is as strong for it. It is a validation job, not a decode one.
+            // looked at. The shape is identical -- Plan(0, 4, 1f, true, false, 4, true). It is a
+            // validation job, not a decode one.
             case 8:  return Plan(0, 4, 1f, true);    // Mod_Add   -- lobe held back, see above
             // Mod_Add_Alpha. THE ONE THAT DOES NOT FOLLOW THE PATTERN:
             //   specular = tex2.rgb * (1.0 - tex1.a)   (ModelRenderPass.cpp:128)

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -1906,7 +1906,18 @@ public static class WmvModelBuilder
             // Confirmed against retail: combiners_uber_2_2.bls case l(10) leaves the t1 sample in
             // the lobe register untouched and sets the diffuse to t0 -- no alpha, no mask, no
             // weight -- and its alpha arm is an empty `break`, i.e. unit 0's alpha stands.
-            case 10: return Plan(0, 1, 1f, false);   // Mod_AddNA -- lobe HELD BACK, see below
+            // Mod_AddNA. The diffuse is unit 0 alone; the "_AddNA" is the second unit added
+            // as a luminous lobe, with no alpha of its own:
+            //   ps10  mat_diffuse = mesh_color * tex1.rgb; discard_alpha = tex1.a;
+            //         can_discard = true; specular = tex2.rgb;
+            //   (Source/games/wow/ModelRenderPass.cpp:117)
+            // scaled by unit 1's own texture weight -- see the note above case 8 for why.
+            //
+            // WITHOUT THE LOBE THIS COMBINER LOSES A WHOLE TEXTURE. On the layered translucent
+            // materials it lives on -- Algalon the Observer, the Celestial mounts, Val'kier --
+            // unit 0 is the dim inner detail and unit 1 IS the luminous layer, so dropping it
+            // leaves a dark, nearly opaque figure where the game draws a glowing translucent one.
+            case 10: return Plan(0, 1, 1f, true, false, 4, true);   // Mod_AddNA
             // Mod_AddAlpha: ps13's lobe on a discarding pass.
             //   specular = tex2.rgb * tex2.a; discard_alpha = tex1.a  (ModelRenderPass.cpp:123)
             // No weight -- the reference multiplies the lobe by nothing.
@@ -1927,25 +1938,46 @@ public static class WmvModelBuilder
             // but 52,180 of 120,978 CreatureDisplayInfo rows (43.13 %) resolve to a model that
             // carries it, because humanoid NPCs reuse about 217 player-race bodies. It is the
             // character EYES geoset (3301 -- the iris, not the 1700-1799 eye-glow).
-            // ps8 AND ps10 ARE HELD BACK DELIBERATELY, and this is not a gap in the decode.
-            // Their lobe is `specular = tex2.rgb` -- the raw second texture, no alpha, no weight --
-            // confirmed in retail in all three of combiners_uber_2_2's switch blocks (case l(8) at
-            // asm 2_2/0.asm:186 and :309, case l(10) at :194 and :320). We implemented exactly
-            // that, and on knife_1h_naxx25_d_01 it produced a white blowout across the blade that
-            // the user's in-game screenshot of the same dagger does not have. It is not a phase of
-            // the unit-1 scroll either: swept across the animation the blade's p99 is 254 at every
-            // instant and 8-15 % of it clips.
+            // ps8 AND ps10 CARRY THE SAME LOBE -- `specular = tex2.rgb`, the raw second
+            // texture, no alpha -- confirmed in retail in all three of combiners_uber_2_2's
+            // switch blocks (case l(8) at asm 2_2/0.asm:186 and :309, case l(10) at :194 and
+            // :320). Both were held back after implementing exactly that produced a white blowout
+            // across the blade of knife_1h_naxx25_d_01.
             //
-            // THE CAUSE IS UPSTREAM AND IT IS NAMED. Retail multiplies the combiner output by the
-            // VERTEX COLOUR -- `mul r3.xyz, r5.xyzx, v1.xyzx`, asm 2_2/0.asm:477 -- and this
-            // renderer never uploads vertex colours at all (mesh.colors is never assigned). On the
-            // stacked additive batches these two combiners live on, vertex colour is exactly how
-            // the artist tones the layers down, so every such batch is already too bright here and
-            // a raw additive lobe on top is what made it visible.
+            // THE DIAGNOSIS THAT KEPT THEM BACK WAS WRONG, and its own witness disproves it. It
+            // blamed a missing multiply by retail's v1 -- the M2 material colour -- reasoning
+            // that the artist tones these stacked additive layers down with it. But
+            // knife_1h_naxx25_d_01 HAS NO COLOUR BLOCKS AT ALL: nColors is 0, and its ps10 batch
+            // (skin 490678 batch 3, submesh 1 layer 1) has colorIndex -1. The multiply would have
+            // been white there and could never have attenuated anything. That multiply does now
+            // exist -- WmvMaterialAnimator writes _Color on every pass, lit or unlit -- and it
+            // makes no difference to this model, which is exactly what its data predicts.
             //
-            // Restore these two AFTER the vertex-colour multiply exists, not before. Everything
-            // needed is in place: Lobe2 shape 4 is the raw lobe and the wiring is understood.
-            case 8:  return Plan(0, 4, 1f, true);    // Mod_Add   -- lobe HELD BACK, see above
+            // WHAT THE KNIFE ACTUALLY AUTHORS is a texture weight of 0.5 on UNIT 1 -- the very
+            // unit whose colour this lobe adds -- through textureWeightComboIndex 0 + unit 1 ->
+            // weight lookup[1] -> track 1. The reference transcriptions do not read it for these
+            // two combiners, and for a long time that looked like the end of the matter. The
+            // client's own authoring says otherwise: of the 219 ps10 batches that bind a CONSTANT
+            // unit-1 weight, only 21 are exactly 1.0 -- 90.4 % author something else, spread
+            // continuously from 0.15 to 0.9 -- and another 37 animate it with 8 more driven by a
+            // global sequence. ps8 is the same picture: 262 of its 293 constants (89.4 %) are not
+            // 1.0. A field set deliberately on nine batches out of ten, to values that only make
+            // sense as a dimmer, is not dead data.
+            //
+            // So the lobe is restored WEIGHTED BY UNIT 1'S OWN TEXTURE WEIGHT, which is what ps20
+            // and ps23 already do here (Lobe2Weighted) and on the same kind of evidence. Measured:
+            // on Algalon, both Celestial Serpents, the Celestial Fox Wyvern and Val'kier -- five
+            // models whose ps10 batches bind NO unit-1 weight, so the weight is 1 -- the weighted
+            // and raw forms are identical to the pixel. On the knife the clipped fraction goes
+            // 5.75 % raw to 1.90 %, against 0.77 % with no lobe at all, and the blade's engraving
+            // stays legible instead of washing out.
+            //
+            // ps8 IS STILL HELD BACK, and now for a reason that is about coverage rather than
+            // correctness: its 1,277 batches include the character EYES geoset (3301), which
+            // 52,180 of 120,978 CreatureDisplayInfo rows resolve to, and none of that has been
+            // looked at. The shape is identical -- Plan(0, 4, 1f, true, false, 4, true) -- and the
+            // weight evidence above is as strong for it. It is a validation job, not a decode one.
+            case 8:  return Plan(0, 4, 1f, true);    // Mod_Add   -- lobe held back, see above
             // Mod_Add_Alpha. THE ONE THAT DOES NOT FOLLOW THE PATTERN:
             //   specular = tex2.rgb * (1.0 - tex1.a)   (ModelRenderPass.cpp:128)
             // There is no tex2.a in it. Every other second-unit lobe in the table multiplies by

--- a/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/WmvModelBuilder.cs
@@ -66,14 +66,31 @@ public struct WmvMaterialAnimBinding
 }
 
 /// <summary>
-/// One drawn batch's place in the transparent draw order. The legacy viewport sorts its passes
-/// before drawing -- blend mode first, then geoset index, then the texture's "special" type
-/// (Source/games/wow/WoWModel.cpp:2011-2018) -- and this renderer drew them in skin order, which
-/// is a different order whenever a model mixes blend modes across submeshes.
+/// One drawn batch's place in the transparent draw order.
+///
+/// PRIORITY PLANE FIRST. M2Batch.priorityPlane is the field the format provides for exactly this
+/// question, and it is what the client uses: instrumenting Wowhead's WebGL viewer on Algalon the
+/// Observer (FileDataID 252165, the same file this renderer loads, batches confirmed identical)
+/// shows it issue the three transparent draws in ascending priorityPlane -- constellation (1),
+/// body (2), haloes (3) -- not in blend-mode order.
+///
+/// The legacy viewport does NOT read the field. It sorts blend mode first, then geoset index, then
+/// the texture's "special" type (Source/games/wow/WoWModel.cpp:2011-2018), and it parses
+/// priorityPlane only to print it. That order is kept below as the tiebreaker chain, because it is
+/// still the right answer everywhere the planes are equal -- which is nearly every model, since
+/// the overwhelming majority ship priorityPlane 0 on every batch and are therefore bit-identical
+/// under this key.
+///
+/// WHAT IT FIXES. All three of Algalon's transparent batches have depth writes off, so order alone
+/// decides the composite. Ranking blend mode first put his alpha-blended body BEFORE the additive
+/// constellation, so the constellation lines landed on top of the torso at full strength; the
+/// client lays them down first and then draws the semi-transparent body over them, so they read as
+/// being inside him and fade out where the body is most opaque.
 /// </summary>
 struct WmvDrawOrderKey
 {
     public int Material;     // index into the materials list
+    public int Prio;         // M2Batch.priorityPlane -- the format's own key, and the client's
     public int Blend;        // M2 blend mode, the legacy's primary key
     public int Submesh;      // the legacy's secondary key
     public int SpecialTex;   // the legacy's tertiary key: texture type, -1 for a plain file
@@ -1078,7 +1095,7 @@ public static class WmvModelBuilder
                              ? (int)model.Textures[textureSlot].Type : -1;
             drawOrder.Add(new WmvDrawOrderKey
             {
-                Material = materials.Count, Blend = (int)mode,
+                Material = materials.Count, Prio = batch.PriorityPlane, Blend = (int)mode,
                 Submesh = batch.SubmeshIndex, SpecialTex = specialTex, Built = drawOrder.Count,
             });
             // What animates this material. Resolved here, where the batch, its units and the
@@ -1117,6 +1134,7 @@ public static class WmvModelBuilder
             // same on every run and on every machine.
             ranked.Sort(delegate(WmvDrawOrderKey a, WmvDrawOrderKey b)
             {
+                if (a.Prio != b.Prio) return a.Prio.CompareTo(b.Prio);
                 if (a.Blend != b.Blend) return a.Blend.CompareTo(b.Blend);
                 if (a.Submesh != b.Submesh) return a.Submesh.CompareTo(b.Submesh);
                 if (a.SpecialTex != b.SpecialTex) return a.SpecialTex.CompareTo(b.SpecialTex);
@@ -1134,9 +1152,10 @@ public static class WmvModelBuilder
                 string order = "";
                 for (int r = 0; r < ranked.Count && r < 12; r++)
                     order += (r > 0 ? " " : "") + "submesh" + ranked[r].Submesh +
-                             "/blend" + ranked[r].Blend;
-                log(string.Format("draw order: {0} transparent batch(es) ranked by blend mode then " +
-                                  "submesh then texture type, queues {1}..{2} -- {3}{4}",
+                             "/prio" + ranked[r].Prio + "/blend" + ranked[r].Blend;
+                log(string.Format("draw order: {0} transparent batch(es) ranked by priority plane " +
+                                  "then blend mode then submesh then texture type, " +
+                                  "queues {1}..{2} -- {3}{4}",
                                   ranked.Count, transparentQueue,
                                   transparentQueue + Mathf.Min(ranked.Count - 1, 899), order,
                                   ranked.Count > 12 ? " ..." : ""));

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Model.cs
@@ -366,6 +366,10 @@ namespace Wmv.Wow
 
         public float Slowdown;
         public float SpriteRotation;
+        /// <summary>ModelParticleParams.tailLength: how long a TAIL particle's streak is, as a
+        /// multiple of its velocity -- the quad runs from the particle back along -velocity *
+        /// TailLength. Meaningless for a head-only emitter.</summary>
+        public float TailLength;
 
         public bool WorldSpace { get { return (Flags & 0x8) != 0; } }
         public bool DoNotTrail { get { return (Flags & 0x10) != 0; } }
@@ -375,6 +379,25 @@ namespace Wmv.Wow
         public bool RandomTexture { get { return (Flags & 0x10000) != 0; } }
         public bool Outward { get { return (Flags & 0x20000) != 0; } }
         public bool RandomStart { get { return (Flags & 0x200000) != 0; } }
+
+        /// <summary>
+        /// HEAD AND TAIL. Two bits the Cataclysm-and-later client reads that the legacy table above
+        /// never named: 0x20000 HEAD -- draw the particle as a camera-facing quad -- and 0x40000
+        /// TAIL -- draw it as a streak from where it is back along its velocity. An emitter can
+        /// set either or both. Across 1,236 emitters sampled from the client 91.7 % are head-only,
+        /// 6.1 % tail-only, 2.2 % both and none neither.
+        ///
+        /// 0x20000 is the same bit the legacy calls OUTWARD, and 0x400 the one it calls PINNED;
+        /// those readings come from the pre-Cataclysm table and are kept above untouched. These
+        /// three are the client's current meanings and are what its particle builder tests --
+        /// confirmed live against Wowhead's viewer, whose build loop does exactly
+        /// `head &amp;&amp; buildHead(); tail &amp;&amp; buildTail();` on this file.
+        /// </summary>
+        public bool HeadStyle { get { return (Flags & 0x20000) != 0; } }
+        public bool TailStyle { get { return (Flags & 0x40000) != 0; } }
+        /// <summary>Bit 0x400 as the tail rule reads it: the streak is min(age, TailLength) long,
+        /// so a newborn particle's tail grows out of it rather than appearing at full length.</summary>
+        public bool ClampTailToAge { get { return (Flags & 0x400) != 0; } }
 
         /// <summary>
         /// Bit 0x800000. Set on 82.9 % of the client's emitters, and it changes how a Gravity KEY

--- a/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
+++ b/Tools/UnityRendererProject/Assets/Scripts/Wow/M2Parser.cs
@@ -142,6 +142,7 @@ namespace Wmv.Wow
         const int OfsParamsAlpha = 16;     // keys: int16, fixed16
         const int OfsParamsSize = 32;      // keys: WowVec2
         const int OfsParamsScales = 100;         // see M2ParticleEmitterDef.ParticleScale
+        const int OfsParamsTailLength = 88;
         const int OfsParamsSlowdown = 112;
         const int OfsParamsRotation = 124;
 
@@ -1243,6 +1244,10 @@ namespace Wmv.Wow
                 c.Seek(p + OfsParamsSlowdown);
                 float slow = c.ReadSingle();
                 def.Slowdown = IsFinite(slow) ? slow : 0f;
+
+                c.Seek(p + OfsParamsTailLength);
+                float tail = c.ReadSingle();
+                def.TailLength = IsFinite(tail) && tail > 0f ? tail : 0f;
 
                 c.Seek(p + OfsParamsRotation);
                 float rot = c.ReadSingle();


### PR DESCRIPTION
## Summary

Makes layered, translucent M2 effect models render as the game renders them, using Algalon the Observer (FileDataID 252165) as the driving case and Wowhead's WebGL viewer — instrumented live, rendering the same file — as the measured reference. Every change is a general M2 rule; there is no model-specific code.

Ten commits, plus the merge of `feature/unity-contact-shadow-parity` (its own PR) so this branch's player carries the tuned contact shadows:

| commit | what |
|---|---|
| `03f974f0` | **`Combiners_Mod_AddNA` (ps10) gets its second texture back.** The lobe had been held back on a diagnosis its own witness disproved; without it the combiner lost a whole texture and layered materials rendered dark and nearly opaque. |
| `e08ace34` | **Particles survive an animation change.** `ResetState` was clearing the whole pool on every sequence change; the legacy holds one particle list for the life of the model. Ribbons still restart (a stale trail is a smear). |
| `48a6155d` | **Bone billboarding (flag 0x08).** Parsed, never applied. Algalon's 18 constellation flares and both full-body haloes are billboard cards authored with exactly 0.000 thickness; unturned they were back-face culled — all twenty drew zero pixels. 11.2 % of client M2s carry the flag. |
| `fef997dd` | Emitter self-test asserts the rule `e08ace34` implemented (it had been failing since). |
| `5fe343e0` | **Emission rate is particles per second.** The legacy divides by lifespan; Algalon plateaued at 45 where Wowhead draws 311 and the file's own `CapacityFor` sizes for 315. |
| `0c44dc11` | **Transparent batches sort by `priorityPlane` first.** The client's order; the legacy never read the field. Only models that author mixed planes move (6 % of the client); additive-only stacks are bit-identical. |
| `878e61f0` | Correct a comment: the ps10 lobe weight has no reference behind it (comment only). |
| `7bef8e38` | **Tail-style particles (flag 0x40000) draw as streaks along their velocity**, the client's rule as Wowhead implements it. Algalon's emitter is tail-only; as heads, 315 equal sprites hung in the air. Head-only emitters (91.7 %) are bit-identical. |
| `7b58b144` | **Particles and ribbons draw after the model**, as both references do; they were landing under the alpha-blended body. |
| `084653be` | **Blend in the authored domain, decode the frame once.** Fragments write authored values, the hardware blend runs on them, and one full-screen pass (`WmvFrameDecodePass`, enqueued from script) applies the exact sRGB EOTF before post-processing. Two additive 0.5 layers now reach 255 as in every reference, not 175. Opaque surfaces display the same bytes (≤ 2 code values, the FP16 buffer's rounding). HDR precision is raised to 64-bit from script because the pipeline asset is not in the repository. |

## Method

Wowhead's viewer was loaded in a real browser and its WebGL context wrapped: per-frame blend state and draw calls, the parsed batch table and emitter definition, the fragment shader source, and the particle vertex buffer every frame (driven deterministically at 60 Hz, particles tracked across frames to fit launch speed, drag and size-vs-age). The client file was read directly from CASC in parallel. Each fix cites the measurement that motivated it and the one that verifies it.

## Measured (Algalon, against Wowhead's frame over the same background)

| | specks | saturated | body blue p25/p50/p75/p95 |
|---|---|---|---|
| Wowhead | 109 | 91.7 % | 75 / 114 / 201 / 255 |
| before this branch | 64 | 60.9 % | 117 / 161 / 200 / 242 |
| after | 87 | 88.5 % | 82 / 120 / 199 / 254 |

## Reviewer notes

- Every commit has BEFORE/AFTER captures and bit-identical controls in its message; the full per-round change documents are in the session deliverables.
- `WMV_DISPLAY=fragment` reproduces the pre-`084653be` pipeline from the same build for A/B (bit-identical to the previous player on eight models).
- Not changed: the preview lighting rig and its constants, Bloom, tonemapping, the sphere map, any material.
- The contact-shadow work is separate and follows in #42; the branch also carries a merge of it (07463336, pushed after this PR merged) so a player built from the branch has the tuned shadows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
